### PR TITLE
feat(plugin): redact sensitive patterns before persisting

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -49,6 +49,7 @@ Add to `~/.openclaw/openclaw.json` (or `/etc/openclaw/openclaw.json` for system-
         "config": {
           "outputPath": "~/.openclaw/memory/openclaw-mem-observations.jsonl",
           "captureMessage": false,
+          "redactSensitive": true,
           
           // Recommended safety default: avoid persisting high-sensitivity tools.
           // This plugin captures *tool results* (not raw user inbound messages).

--- a/extensions/openclaw-mem/openclaw.plugin.json
+++ b/extensions/openclaw-mem/openclaw.plugin.json
@@ -25,6 +25,11 @@
         "default": false,
         "description": "Capture full tool message (truncated). Warning: can be large."
       },
+      "redactSensitive": {
+        "type": "boolean",
+        "default": true,
+        "description": "Redact common secret patterns from summaries/messages before persisting. Recommended true."
+      },
       "maxMessageLength": {
         "type": "number",
         "default": 1000,


### PR DESCRIPTION
This PR adds best-effort redaction (sk-*, Bearer tokens, Telegram bot token-like strings) before persisting summaries/messages to JSONL.\n\nMotivation: reduce risk of secrets leakage when using openclaw-mem auto-capture in production.\n\nNotes:\n- Default: redactSensitive=true (configurable)\n- No behavior change unless a captured snippet contains a matched pattern.\n\nRequesting Codex review: see comment below.