### PR TITLE
feat: triage tasks mode + dedupe state (heartbeat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - (placeholder)
 
+## [0.5.6] - 2026-02-06
+
+### Added
+- `openclaw-mem triage --mode tasks`: deterministic scan for newly stored tasks (from `memory_store` / `openclaw-mem store --category task`).
+- `openclaw-mem triage` now uses a small state file to **dedupe alerts** (new-only) and avoid repeating the same heartbeat notifications.
+
+### Changed
+- `triage --mode heartbeat` now includes: observations scan + cron-errors scan + tasks scan.
+- Version bump to `0.5.6`.
+
 ## [0.5.5] - 2026-02-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - [**Quickstart Guide**](QUICKSTART.md) — Get started in 5 minutes
 - [**CHANGELOG**](CHANGELOG.md) — See what's new
 - [**Auto-Capture Setup**](docs/auto-capture.md) — Enable plugin
-- [**Tests**](tests/) — 31 tests (unit + integration)
+- [**Tests**](tests/) — 32 tests (unit + integration)
 
 ## 🙏 Credits & Inspiration
 
@@ -21,13 +21,13 @@ Thank you [@thedotmack](https://github.com/thedotmack) 🎉
 ✅ **M0 (minimal usable) complete!** A CLI-first SQLite + FTS5 prototype with full test coverage is ready. See "M0 Prototype" below for usage. The adoption plan and architecture design live in [`docs/claude-mem-adoption-plan.md`](docs/claude-mem-adoption-plan.md).
 
 **What works:**
-- CLI commands: `status`, `ingest`, `search`, `timeline`, `get`, `summarize`, `export`, `embed`, `vsearch`, `hybrid`, `store`, `harvest`, `index`, `semantic`, `triage`
+- CLI commands: `status`, `ingest`, `search`, `timeline`, `get`, `summarize`, `export`, `embed`, `vsearch`, `hybrid`, `store`, `harvest`, `index`, `semantic`, `triage` (modes: `heartbeat`, `cron-errors`, `tasks`)
 - Plugin: auto-capture via `tool_result_persist` + agent tools `memory_store` / `memory_recall`
 - FTS5 full-text search + progressive disclosure (3-layer search)
 - Vector search (cosine similarity) + hybrid search via RRF fusion
 - AI-native: `--json` output, non-interactive, example-rich help
 - Atomic file operations + SQLite WAL mode guidance
-- 31 tests (unit + integration, 100% coverage) + GitHub Actions CI
+- 32 tests (unit + integration, 100% coverage) + GitHub Actions CI
 
 **What's next:**
 - ✅ Phase 1: Auto-capture via `tool_result_persist` hook (plugin ready)

--- a/extensions/openclaw-mem/openclaw.plugin.json
+++ b/extensions/openclaw-mem/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "name": "OpenClaw Mem",
   "description": "Capture tool results into JSONL for openclaw-mem ingestion",
   "kind": "utility",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/openclaw_mem/__init__.py
+++ b/openclaw_mem/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "0.5.5"
+__version__ = "0.5.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openclaw-mem"
-version = "0.5.5"
+version = "0.5.6"
 description = "CLI-first memory store + search prototype for OpenClaw"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "openclaw-mem"
-version = "0.5.5"
+version = "0.5.6"
 source = { virtual = "." }


### PR DESCRIPTION
Adds deterministic task reminders + alert dedupe for the Isolated Heartbeat integration.

## What’s included
- `openclaw-mem triage --mode tasks`: finds newly stored tasks created via `memory_store` or `openclaw-mem store --category task`.
- `openclaw-mem triage` now uses a small state file (default: `~/.openclaw/memory/openclaw-mem/triage-state.json`) to avoid repeating the same alerts every 10 minutes.
- `triage --mode heartbeat` includes: observations scan + cron-errors scan + tasks scan.
- Version bump to `0.5.6` + docs/tests updates.

## Notes
- Fully deterministic: local SQLite + local cron store file.
- Exit code: 10 means “needs attention”.