### PR TITLE
Chore: label-gated auto-merge + PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+- What changed?
+- Why?
+
+## Reality check
+
+Paste commands that verify the change (or link to docs). Keep it minimal.
+
+## Risk
+
+- [ ] docs-only
+- [ ] low-risk code change
+- [ ] behavior change (call out user impact)
+
+## Codex
+
+- [ ] I checked Codex’s review comments and addressed or explicitly rejected them.
+
+## Auto-merge (optional)
+
+If this PR is safe to land without waiting for a human review, add the **`automerge`** label.

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,22 @@
+name: automerge
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, labeled, synchronize]
+
+jobs:
+  enable:
+    if: >-
+      github.event.pull_request.draft == false &&
+      contains(join(github.event.pull_request.labels.*.name, ','), 'automerge')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Enable auto-merge (squash)
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash


### PR DESCRIPTION
Adds a lightweight PR template (Reality check + risk + Codex checkbox) and a label-gated auto-merge workflow.

- Auto-merge is only enabled when the PR has the **automerge** label (and is not a draft).
- Merge method: squash.

This keeps the slow-cook, low-intervention flow while still requiring CI to pass.