### PR TITLE
slowcook(A-fast): docs: add quickstart autograde toggle snippet

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -158,6 +158,28 @@ uv run python -m openclaw_mem triage --mode tasks --tasks-since-minutes 1440 --i
 
 ---
 
+
+## Step 7: Autograde toggle (optional)
+
+`openclaw-mem` can auto-score importance during ingest/harvest with `heuristic-v1`.
+
+Enable per-command:
+
+```bash
+OPENCLAW_MEM_IMPORTANCE_SCORER=heuristic-v1 uv run python -m openclaw_mem harvest --file /tmp/incoming.jsonl --json --no-embed
+```
+
+Disable for a one-off run (kill-switch):
+
+```bash
+OPENCLAW_MEM_IMPORTANCE_SCORER=off uv run python -m openclaw_mem harvest --file /tmp/incoming.jsonl --json --no-embed
+```
+
+Or override only this command:
+
+```bash
+uv run python -m openclaw_mem harvest --file /tmp/incoming.jsonl --json --no-embed --importance-scorer off
+```
 ## Next steps
 
 - Full docs: `README.md`


### PR DESCRIPTION
## Summary
- Lane: `A-fast`
- Docs-only: `true`

## Changed files
- `QUICKSTART.md`

## Validation
- `openclaw_mem_dev_helper.py validate --mode fast`

## Notes
- PR metadata updates are done via REST (`gh api`) to avoid GraphQL breakages (e.g., Projects (classic) deprecation).
