### PR TITLE
slowcook(A-fast): docs: clarify autograde precedence

### DIFF
--- a/docs/importance-grading.md
+++ b/docs/importance-grading.md
@@ -97,6 +97,8 @@ You can optionally have `ingest` / `harvest` run `heuristic-v1` and write `detai
 - Enable via env var:
   - `OPENCLAW_MEM_IMPORTANCE_SCORER=heuristic-v1`
 - Or override per-run:
+
+  - CLI override takes precedence over env var for the same run (for one-off dry-run behavior, use `--importance-scorer off`).
   - `--importance-scorer {heuristic-v1|off}`
 
 Notes:


### PR DESCRIPTION
## Summary
- Lane: `A-fast`
- Docs-only: `true`

## Changed files
- `docs/importance-grading.md`

## Validation
- `openclaw_mem_dev_helper.py validate --mode fast`

## Notes
- PR metadata updates are done via REST (`gh api`) to avoid GraphQL breakages (e.g., Projects (classic) deprecation).
