### PR TITLE
slowcook(A-fast): docs: track A-fast dev feature lane in automation status

### DIFF
--- a/docs/automation-status.md
+++ b/docs/automation-status.md
@@ -34,6 +34,10 @@ These are automated via OpenClaw cron jobs (so the system works without manual C
   - code root: `/root/.openclaw/workspace/openclaw-mem-dev` (dev)
   - DB: `/root/.openclaw/memory/openclaw-mem-dev.sqlite`
   - receipts: `/root/.openclaw/memory/openclaw-mem-dev/{harvest_last.json,triage_last.json}`
+- DEV feature lane: `57d3e88c-4278-414a-8e33-c091baae7887` (`17,47 * * * *` Asia/Taipei)
+  - code root: `/root/.openclaw/workspace/openclaw-mem-dev` (dev)
+  - branch: `dev`
+  - lock: `openclaw-mem-dev-feature` + global heavy-python guard
 
 ### AI compression (derived artifact, dev)
 - Job: `58a7c87c-d1b2-4c9c-96fd-6ecccf623b85` (daily 00:35 Asia/Taipei)


### PR DESCRIPTION
## Summary
- Lane: `A-fast`
- Docs-only: `false`

## Changed files
- `QUICKSTART.md`
- `README.md`
- `docs/automation-status.md`
- `docs/upgrade-checklist.md`
- `openclaw_mem/cli.py`
- `tests/data/HEURISTIC_TESTCASES.jsonl`
- `tests/test_cli.py`
- `uv.lock`

## Validation
- `openclaw_mem_dev_helper.py validate --mode fast`

## Notes
- PR metadata updates are done via REST (`gh api`) to avoid GraphQL breakages (e.g., Projects (classic) deprecation).
