### PR TITLE
release: v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- (nothing yet)
+### Changed
+- `openclaw-mem-engine` now supports configurable embedding clamp knobs (`embedding.maxChars`, `embedding.headChars`, `embedding.maxBytes`) and enforces them in both recall/store paths.
+- Memory recall/store now fail-open when embeddings are unavailable, provider errors, or input is over long:
+  - `memory_recall` still returns lexical (FTS) results when vector path is skipped.
+  - `memory_store` still stores the memory with a zero vector fallback so ingest never blocks on embedding failure.
+- `memory_recall` and `memory_store` now emit explicit warnings when recall/store quality is degraded due to embedding skip.
+- Expanded memory-engine tunables for recall/capture/receipts behavior and harden-config parsing in plugin schema/normalization (`autoRecall`, `autoCapture`, `receipts`).
+
+### Testing
+- `test_triage_json_contract_v0` now writes a temporary cron jobs fixture and passes `--cron-jobs-path`, preventing host-state coupling to `~/.openclaw/cron/jobs.json`.
 
 ## [1.0.3] - 2026-02-28
 

--- a/docs/notes/pm-brief-v1.0.4.md
+++ b/docs/notes/pm-brief-v1.0.4.md
@@ -1,0 +1,34 @@
+# PM Brief — openclaw-mem v1.0.4 prep
+
+## What changed
+- Bumped release version to **1.0.4** and aligned version declarations:
+  - `pyproject.toml`
+  - `openclaw_mem/__init__.py`
+  - `extensions/openclaw-mem/openclaw.plugin.json`
+- Fixed flaky contract test dependency on host cron state:
+  - `tests/test_json_contracts.py::test_triage_json_contract_v0`
+  - writes a temp `jobs.json` fixture (`{"jobs": []}`) in the test tempdir
+  - passes `--cron-jobs-path <fixture>` to CLI
+- Updated `CHANGELOG.md` [Unreleased] with v1.0.4 items:
+  - embedding clamp controls in `openclaw-mem-engine` (`maxChars` / `headChars` / `maxBytes`)
+  - recall/store fail-open behavior when embedding is skipped (provider missing/unavailable or input too long)
+  - warning emission on degraded recall/store quality
+  - expanded/clarified config knobs for autoRecall/autoCapture/receipts handling
+  - test hermeticity fix above
+
+## Why
+- Prevent release drift and unstable test behavior across dev boxes by removing implicit reads from `~/.openclaw/cron/jobs.json`.
+- Preserve recall availability even under embedding failures by keeping lexical fallback path active.
+- Give operators explicit control and guardrails over embedding input trimming so recall can be tuned without code changes.
+- Make degradation visible with warnings instead of silent quality loss.
+
+## Risks / rollback
+- **Risk:** clamp defaults may remove too much context for some prompts and lower recall quality.
+  - **Rollback:** revert the version bump commit, or set `embedding.maxChars`/`embedding.headChars`/`embedding.maxBytes` to safer values in plugin config.
+- **Risk:** fail-open behavior changes the shape of diagnostics (`missing/ fallback` reasons) and may surface more warnings.
+  - **Rollback:** narrow warnings/notifications or temporarily route downstream filtering to ignore warning-only messages.
+
+## What NOT to duplicate
+- Do **not** keep tests coupled to host filesystem state (`~/.openclaw/cron/jobs.json`, etc.)—always inject fixtures.
+- Do **not** touch `extensions/openclaw-mem-engine` plugin version (`openclaw.plugin.json`) unless explicitly planning an engine-specific semver change.
+- Do **not** duplicate embedding clamp/warning logic in multiple places; keep it centralized in the existing clamp utility + plugin config plumbing.

--- a/extensions/openclaw-mem/openclaw.plugin.json
+++ b/extensions/openclaw-mem/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "name": "OpenClaw Mem",
   "description": "Capture tool results into JSONL for openclaw-mem ingestion",
   "kind": "utility",
-  "version": "1.0.1",
+  "version": "1.0.4",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/openclaw_mem/__init__.py
+++ b/openclaw_mem/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "1.0.1"
+__version__ = "1.0.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openclaw-mem"
-version = "1.0.3"
+version = "1.0.4"
 description = "CLI-first memory store + search prototype for OpenClaw"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/tests/test_json_contracts.py
+++ b/tests/test_json_contracts.py
@@ -14,6 +14,8 @@ class TestJsonContracts(unittest.TestCase):
         self.db_path = Path(self.tmpdir.name) / "test.sqlite"
         self.source = Path(self.tmpdir.name) / "openclaw-mem-observations.jsonl"
         self.state_path = Path(self.tmpdir.name) / "triage-state.json"
+        self.cron_jobs_path = Path(self.tmpdir.name) / "jobs.json"
+        self.cron_jobs_path.write_text("{\"jobs\": []}", encoding="utf-8")
 
     def tearDown(self):
         self.tmpdir.cleanup()
@@ -92,6 +94,8 @@ class TestJsonContracts(unittest.TestCase):
             "heartbeat",
             "--state-path",
             str(self.state_path),
+            "--cron-jobs-path",
+            str(self.cron_jobs_path),
         )
 
         self.assertEqual(out["kind"], "openclaw-mem.triage.v0")

--- a/uv.lock
+++ b/uv.lock
@@ -351,7 +351,7 @@ wheels = [
 
 [[package]]
 name = "openclaw-mem"
-version = "1.0.3"
+version = "1.0.4"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What/Why

This PR prepared patch release **v1.0.4**.

Main goal: make the release/tests reproducible and prevent a JSON contract test from depending on whatever cron state happens to exist on the machine running the tests.

## Changes

- **Hermetic triage contract test**: `test_triage_json_contract_v0` now uses a temp cron-jobs fixture and passes `--cron-jobs-path`.
- **Version alignment + bump to 1.0.4** across:
  - `pyproject.toml`
  - `openclaw_mem/__init__.py`
  - `extensions/openclaw-mem/openclaw.plugin.json`
- **Lockfile refreshed** (`uv.lock`) to match locked CI expectations.

## How to verify

- `uv sync --locked`
- `uv sync --locked --extra docs`
- `uv run -m unittest discover -s tests -p "test_*.py"`
- `node --test extensions/openclaw-mem-engine/embeddingClamp.test.mjs`

## Notes

No tags/releases are created by this PR.