### PR TITLE
docs: align public baseline wording (since v1.0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ Expected output (minimal): `status` prints a JSON object with `count/min_ts/max_
 - Sidecar capture plugin: `docs/auto-capture.md`
 - Ecosystem fit / comparisons: `docs/ecosystem-fit.md`
 
-## What’s new (v1.0.4)
-- **Safer production posture** for the optional `openclaw-mem-engine`: embedding failures/limits won’t hard-break memory flows (fail-open with lexical fallback + explicit warnings).
+## What’s new (v1.0.4, since v1.0.1)
+- **More reliable mem-engine in real chats**: long prompts + embedding hiccups are less likely to break memory flows (fail-open + lexical fallback + warnings).
 - **Embedding clamp knobs** (`embedding.maxChars/headChars/maxBytes`) to control how long prompts are trimmed before embedding.
+- Release notes: https://github.com/phenomenoner/openclaw-mem/releases/tag/v1.0.4
 
 ## Status map (DONE / PARTIAL / ROADMAP)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,12 +62,14 @@ uv run python -m openclaw_mem --json search "gateway timeout" --limit 10
 uv run python -m openclaw_mem pack --query "gateway timeout" --limit 8 --trace --json
 ```
 
-## What’s new (v1.0.4)
+## What’s new (v1.0.4, since v1.0.1)
 
 - **More reliable Mem Engine**: long prompts + embedding hiccups are less likely to break memory flows (fail-open + lexical fallback + warnings).
 - **Configurable embedding clamping**: `embedding.maxChars`, `embedding.headChars`, `embedding.maxBytes`.
 
-See full release notes: <https://github.com/phenomenoner/openclaw-mem/releases>
+See release notes:
+- v1.0.4: <https://github.com/phenomenoner/openclaw-mem/releases/tag/v1.0.4>
+- all releases: <https://github.com/phenomenoner/openclaw-mem/releases>
 
 ## Links
 


### PR DESCRIPTION
$## Summary
Align public-facing “What’s new” baseline wording.

## Why
The last public release before v1.0.4 was **v1.0.1** (later tags were not public releases), so docs should compare against v1.0.1 to avoid confusing external readers.

## Changes
- README: “What’s new (v1.0.4, since v1.0.1)” + link to v1.0.4 release notes.
- Docs home: same baseline wording + direct link to v1.0.4 release notes.

## Verification
- `uv sync --locked --extra docs`
- `mkdocs build`}