### PR TITLE
slowcook(A-deep): triage: add --no-dedupe mode (debug)

### DIFF
--- a/openclaw_mem/cli.py
+++ b/openclaw_mem/cli.py
@@ -3255,6 +3255,8 @@ def cmd_triage(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
     since_minutes = max(0, since_minutes)
     limit = max(1, min(200, limit))
 
+    dedupe = bool(getattr(args, "dedupe", True))
+
     kw_raw = getattr(args, "keywords", None)
     if kw_raw:
         keywords = [k.strip().lower() for k in str(kw_raw).split(",") if k.strip()]
@@ -3279,7 +3281,7 @@ def cmd_triage(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
     importance_min = float(getattr(args, "importance_min", 0.7))
 
     state_path = Path(os.path.expanduser(getattr(args, "state_path", None) or "~/.openclaw/memory/openclaw-mem/triage-state.json"))
-    state = _load_triage_state(state_path)
+    state = _load_triage_state(state_path) if dedupe else {}
 
     last_obs_id = int(((state.get("observations") or {}).get("last_alerted_id") or 0))
     last_task_id = int(((state.get("tasks") or {}).get("last_alerted_id") or 0))
@@ -3307,10 +3309,15 @@ def cmd_triage(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
     if mode in {"heartbeat", "tasks"}:
         tasks_all = _triage_tasks(conn, since_ts=tasks_since_utc, importance_min=importance_min, limit=limit)
 
-    # Dedupe: only alert on *new* items
-    obs_new = [m for m in obs_all if int(m.get("id") or 0) > last_obs_id]
-    tasks_new = [m for m in tasks_all if int(m.get("id") or 0) > last_task_id]
-    cron_new = [m for m in cron_all if int(m.get("lastRunAtMs") or 0) > last_cron_ms]
+    if dedupe:
+        # Dedupe: only alert on *new* items
+        obs_new = [m for m in obs_all if int(m.get("id") or 0) > last_obs_id]
+        tasks_new = [m for m in tasks_all if int(m.get("id") or 0) > last_task_id]
+        cron_new = [m for m in cron_all if int(m.get("lastRunAtMs") or 0) > last_cron_ms]
+    else:
+        obs_new = list(obs_all)
+        tasks_new = list(tasks_all)
+        cron_new = list(cron_all)
 
     needs_attention = (len(obs_new) > 0) or (len(cron_new) > 0) or (len(tasks_new) > 0)
 
@@ -3320,6 +3327,7 @@ def cmd_triage(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
         "version": {"openclaw_mem": __version__, "schema": "v0"},
         "ok": True,
         "mode": mode,
+        "dedupe": dedupe,
         "since_minutes": since_minutes,
         "since_utc": since_utc,
         "keywords": keywords,
@@ -3346,7 +3354,7 @@ def cmd_triage(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
         },
     }
 
-    if needs_attention:
+    if needs_attention and dedupe:
         # Update state maxima
         if obs_new:
             last_obs_id = max(last_obs_id, max(int(m.get("id") or 0) for m in obs_new))
@@ -5985,6 +5993,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--state-path",
         dest="state_path",
         help="State file for dedupe (default: ~/.openclaw/memory/openclaw-mem/triage-state.json)",
+    )
+    sp.add_argument(
+        "--no-dedupe",
+        dest="dedupe",
+        action="store_false",
+        default=True,
+        help="Disable state dedupe; return all matches (manual debugging)",
     )
     sp.set_defaults(func=cmd_triage)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1011,6 +1011,76 @@ class TestCliM0(unittest.TestCase):
 
         conn.close()
 
+    def test_triage_tasks_mode_no_dedupe_does_not_write_state(self):
+        import tempfile
+        from datetime import datetime, timezone
+
+        conn = _connect(":memory:")
+
+        now = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+        sample = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "ts": now,
+                        "kind": "task",
+                        "tool_name": "memory_store",
+                        "summary": "TODO: buy coffee this afternoon",
+                        "detail": {"importance": 0.9},
+                    }
+                )
+            ]
+        )
+
+        old_stdin = sys.stdin
+        try:
+            sys.stdin = io.StringIO(sample)
+            args = type("Args", (), {"file": None, "json": True})()
+            with redirect_stdout(io.StringIO()):
+                cmd_ingest(conn, args)
+        finally:
+            sys.stdin = old_stdin
+
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", delete=False) as st:
+            state_path = st.name
+
+        args = type("Args", (), {
+            "mode": "tasks",
+            "since_minutes": 60,
+            "limit": 10,
+            "keywords": None,
+            "cron_jobs_path": None,
+            "tasks_since_minutes": 1440,
+            "importance_min": 0.7,
+            "state_path": state_path,
+            "dedupe": False,
+            "json": True,
+        })()
+
+        buf1 = io.StringIO()
+        with redirect_stdout(buf1):
+            with self.assertRaises(SystemExit) as cm1:
+                cmd_triage(conn, args)
+        self.assertEqual(cm1.exception.code, 10)
+        out1 = json.loads(buf1.getvalue())
+        self.assertEqual(out1["dedupe"], False)
+        self.assertEqual(out1["tasks"]["found_total"], 1)
+        self.assertEqual(out1["tasks"]["found_new"], 1)
+
+        # no-dedupe should not write state
+        with open(state_path, "r", encoding="utf-8") as fp:
+            self.assertEqual(fp.read().strip(), "")
+
+        buf2 = io.StringIO()
+        with redirect_stdout(buf2):
+            with self.assertRaises(SystemExit) as cm2:
+                cmd_triage(conn, args)
+        self.assertEqual(cm2.exception.code, 10)
+        out2 = json.loads(buf2.getvalue())
+        self.assertEqual(out2["tasks"]["found_new"], 1)
+
+        conn.close()
+
     def test_triage_tasks_accepts_task_marker_without_colon(self):
         import tempfile
         from datetime import datetime, timezone


### PR DESCRIPTION
## Summary
- Lane: `A-deep`
- Docs-only: `false`

## Changed files
- `openclaw_mem/cli.py`
- `tests/test_cli.py`

## Validation
- `openclaw_mem_dev_helper.py validate --mode deep`

## Notes
- PR metadata updates are done via REST (`gh api`) to avoid GraphQL breakages (e.g., Projects (classic) deprecation).
