### PR TITLE
slowcook(A-fast): docs(cli): include ◦ bullet in task-marker docstrings

### DIFF
--- a/openclaw_mem/cli.py
+++ b/openclaw_mem/cli.py
@@ -2916,7 +2916,7 @@ def _summary_has_task_marker(summary: str) -> bool:
 
     Optional leading markdown wrappers are tolerated before markers:
     - blockquotes: `>` (repeatable; whitespace optional before nested wrappers/marker)
-    - list bullets: `-`, `*`, `+`, `•`, `‣`, `∙`, `·` (whitespace optional before nested wrappers/marker)
+    - list bullets: `-`, `*`, `+`, `•`, `‣`, `∙`, `·`, `◦` (whitespace optional before nested wrappers/marker)
     - markdown checkboxes: `[ ]` / `[x]` / `[✓]` / `[✔]` / `[☐]` / `[☑]` (whitespace optional before nested wrappers/marker)
     - ordered-list prefixes: `1.` / `1)` / `(1)` / `a.` / `a)` / `(a)` / `iv.` / `iv)` / `(iv)` (whitespace optional before nested wrappers/marker)
 
@@ -3156,7 +3156,7 @@ def _triage_tasks(conn: sqlite3.Connection, *, since_ts: str, importance_min: fl
       (case-insensitive; width-normalized via NFKC; supports plain or
       bracketed forms like `[TODO]`/`(TASK)`/`【TODO】`/`〔TODO〕`/`「TODO」`/`『TODO』` (including compact no-space forms like `[TODO]buy milk`/`【TODO】buy milk`/`「TODO」buy milk`/`『TODO』buy milk`), plus optional leading
       markdown wrappers like `>` blockquotes, list/checklist prefixes
-      (`-`/`*`/`+`/`•`/`‣`/`∙`/`·`, `[ ]`/`[x]`/`[✓]`/`[✔]`/`[☐]`/`[☑]`), and ordered-list prefixes like
+      (`-`/`*`/`+`/`•`/`‣`/`∙`/`·`/`◦`, `[ ]`/`[x]`/`[✓]`/`[✔]`/`[☐]`/`[☑]`), and ordered-list prefixes like
       `1.`/`1)`/`(1)`/`a.`/`a)`/`(a)`/`iv.`/`iv)`/`(iv)`; whitespace is optional
       between wrappers and the next wrapper/marker;
       accepts ':', whitespace, '-', '－', '–', '—', '−', or marker-only)


### PR DESCRIPTION
## Summary
- Lane: `A-fast`
- Docs-only: `false`

## Changed files
- `openclaw_mem/cli.py`

## Validation
- `openclaw_mem_dev_helper.py validate --mode fast`

## Notes
- PR metadata updates are done via REST (`gh api`) to avoid GraphQL breakages (e.g., Projects (classic) deprecation).
