### PR TITLE
slowcook(A-fast): docs(cli): clarify task marker docstring examples

### DIFF
--- a/openclaw_mem/cli.py
+++ b/openclaw_mem/cli.py
@@ -2911,8 +2911,8 @@ def _summary_has_task_marker(summary: str) -> bool:
 
     Accepted forms:
     - plain marker: `TODO ...`
-    - bracketed marker: `[TODO] ...`, `(TODO) ...`, `【TODO】 ...`, `〔TODO〕 ...`, `{TODO} ...`, `「TODO」 ...`, `『TODO』 ...`, or `《TODO》 ...`
-    - compact no-space bracketed marker: `[TODO]buy milk`, `【TODO】buy milk`, `{TODO}buy milk`, `「TODO」buy milk`, `『TODO』buy milk`, `《TODO》buy milk`
+    - bracketed marker: `[TODO] ...`, `(TASK) ...`, `【REMINDER】 ...`, `〔TODO〕 ...`, `{TODO} ...`, `「TODO」 ...`, `『TODO』 ...`, or `《TODO》 ...`
+    - compact no-space bracketed marker: `[TODO]buy milk`, `(TASK)review PR`, `【REMINDER】pay rent`, `【TODO】buy milk`, `{TODO}buy milk`
 
     Optional leading markdown wrappers are tolerated before markers:
     - blockquotes: `>` (repeatable; whitespace optional before nested wrappers/marker)


### PR DESCRIPTION
## Summary
- Lane: `A-fast`
- Docs-only: `false`

## Changed files
- `openclaw_mem/cli.py`

## Validation
- `openclaw_mem_dev_helper.py validate --mode fast`

## Notes
- PR metadata updates are done via REST (`gh api`) to avoid GraphQL breakages (e.g., Projects (classic) deprecation).
