### PR TITLE
slowcook: task-marker contract — rejected forms + tests

### DIFF
--- a/openclaw_mem/cli.py
+++ b/openclaw_mem/cli.py
@@ -2926,6 +2926,12 @@ def _summary_has_task_marker(summary: str) -> bool:
     - '-' / '.' / '。' / '－' / '–' / '—' / '−'
     - end-of-string
 
+    Rejected forms (examples):
+    - inline markers not at the beginning: `We should TODO: fix this later`
+    - words that merely start with a marker: `TODOLIST ...`, `taskforce ...`
+    - punctuation-only suffix: `TODO! ...` (must be followed by a separator/space/end)
+    - mismatched wrappers: `[TODO) ...`
+
     Example formats:
     - TODO: rotate runbook
     - task- check alerts

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -153,6 +153,14 @@ class TestCliM0(unittest.TestCase):
         self.assertFalse(_summary_has_task_marker("(iiv) TODO clean old notes"))
         self.assertTrue(_summary_has_task_marker("* (1)TODO clean old notes"))
 
+    def test_summary_has_task_marker_rejects_inline_markers_and_mismatched_wrappers(self):
+        self.assertFalse(_summary_has_task_marker("We should TODO: fix this later"))
+        self.assertFalse(_summary_has_task_marker("Meeting notes - TODO: fix this later"))
+        self.assertFalse(_summary_has_task_marker("I think [TODO] fix this later"))
+        self.assertFalse(_summary_has_task_marker("TODO! fix this later"))
+        self.assertFalse(_summary_has_task_marker("[TODO) fix this later"))
+        self.assertFalse(_summary_has_task_marker("TODOs: plural shouldn't match"))
+
     def test_parser_merges_global_and_command_json_flags(self):
         before_args = build_parser().parse_args(["--json", "status"])
         after_args = build_parser().parse_args(["status", "--json"])


### PR DESCRIPTION
Adds explicit rejected-form examples to _summary_has_task_marker() docstring and unit tests for inline markers / mismatched wrappers / punctuation suffix.

- No behavior change intended.
- Tests: python -m unittest discover -s tests -p "test_*.py"