### PR TITLE
slowcook: Inside-Out Memory 5-min demo (synthetic) + keyless pack

### DIFF
--- a/docs/showcase/inside-out-architecture.mmd
+++ b/docs/showcase/inside-out-architecture.mmd
@@ -1,0 +1,26 @@
+flowchart LR
+  subgraph User
+    U[Human]
+  end
+
+  subgraph Agent
+    A[OpenClaw main session
+(prompt + tools)]
+  end
+
+  subgraph MemoryLayer[openclaw-mem]
+    W[store
+(category/importance/text)]
+    S[(SQLite store)]
+    R[pack/query
+(cited bundle + optional trace)]
+  end
+
+  U -->|chat| A
+  A -->|memory_store| W
+  W --> S
+  A -->|recall request
+(query)| R
+  R --> S
+  R -->|bundle_text + citations| A
+  A -->|answer + receipts| U

--- a/docs/showcase/inside-out-demo.md
+++ b/docs/showcase/inside-out-demo.md
@@ -1,0 +1,48 @@
+# Inside-Out Memory — 5-minute reproducible demo (synthetic)
+
+This demo is **synthetic** (no private/user data). It showcases the *contract* for a “durable self” memory layer:
+
+- A small set of **core preferences / decisions / commitments** is stored once.
+- On demand, we can **pack** the relevant memories into a compact, cited bundle.
+- An agent can then answer consistently (timezone, privacy constraints, style), without bloating its chat context.
+
+## Prereqs
+- `uv`
+- In this repo: `uv sync` (or just let `uv run ...` build on demand)
+
+## Run
+
+```bash
+# From repo root
+./scripts/inside_out_demo.sh
+```
+
+You should see a packed bundle (plus an optional trace) for a keyword-style query (works even with no API key / no embeddings):
+> `timezone privacy demo style`
+
+## What to look for
+- **Timezone preference** is recalled (UTC+8 / Asia-Taipei in this synthetic example).
+- **Privacy constraint** is recalled (demo uses synthetic data; do not leak private notes).
+- **Style preference** is recalled (index-first / bounded reveal).
+
+## Architecture diagram
+- Mermaid: `docs/showcase/inside-out-architecture.mmd`
+
+## Before/After (illustrative transcript)
+
+### Before (no memory)
+User: “Write a demo plan for my agent system.”
+
+Agent (typical): gives a generic plan, may ignore timezone + privacy constraints.
+
+### After (with packed memories)
+User: “Write a demo plan for my agent system.”
+
+Agent (memory-aware):
+- uses the preferred timezone for time references
+- explicitly keeps the demo synthetic / privacy-safe
+- structures output index-first and cites the recalled constraints
+
+## Notes
+- This demo is intentionally small: it’s a **vertical slice** + an executable regression.
+- It’s OK if not every feature is finished yet — the demo defines the contract and exposes gaps.

--- a/openclaw_mem/cli.py
+++ b/openclaw_mem/cli.py
@@ -2116,50 +2116,61 @@ def _hybrid_retrieve(
         # Keep a wider candidate pool before final rerank.
         candidate_limit = max(candidate_limit, rerank_topn * 3)
 
-    api_key = _get_api_key()
-    if not api_key:
-        raise RuntimeError("OPENAI_API_KEY not set and no key found in ~/.openclaw/openclaw.json")
-
-    client = OpenAIEmbeddingsClient(
-        api_key=api_key,
-        base_url=getattr(args, "base_url", defaults.openai_base_url()),
-    )
-    try:
-        embed_inputs = [query] + ([query_en] if query_en else [])
-        embed_vecs = client.embed(embed_inputs, model=model)
-        query_vec = embed_vecs[0]
-        query_en_vec = embed_vecs[1] if query_en else None
-    except Exception as e:
-        raise RuntimeError(str(e)) from e
+    # Vector lane is optional: if no API key (or no stored embeddings), we
+    # fall back to FTS-only retrieval.
+    vec_ids: List[int] = []
+    vec_en_ids: List[int] = []
 
     vec_rows = conn.execute(
         "SELECT observation_id, vector, norm FROM observation_embeddings WHERE model = ?",
         (model,),
     ).fetchall()
 
-    vec_ranked = rank_cosine(
-        query_vec=query_vec,
-        items=((int(r[0]), r[1], float(r[2])) for r in vec_rows),
-        limit=candidate_limit,
-    )
-    vec_ids = [rid for rid, _ in vec_ranked]
-
-    vec_en_ids: List[int] = []
-    if query_en_vec is not None:
+    vec_en_rows = []
+    if query_en:
         vec_en_rows = conn.execute(
             "SELECT observation_id, vector, norm FROM observation_embeddings_en WHERE model = ?",
             (model,),
         ).fetchall()
 
-        # Backward-compatible fallback when dedicated EN table is not populated.
-        search_rows = vec_en_rows if vec_en_rows else vec_rows
+    need_vec = bool(vec_rows)
+    need_vec_en = bool(query_en and (vec_en_rows or vec_rows))
 
-        vec_en_ranked = rank_cosine(
-            query_vec=query_en_vec,
-            items=((int(r[0]), r[1], float(r[2])) for r in search_rows),
-            limit=candidate_limit,
+    api_key = _get_api_key()
+    if api_key and (need_vec or need_vec_en):
+        client = OpenAIEmbeddingsClient(
+            api_key=api_key,
+            base_url=getattr(args, "base_url", defaults.openai_base_url()),
         )
-        vec_en_ids = [rid for rid, _ in vec_en_ranked]
+        try:
+            embed_inputs = [query] + ([query_en] if query_en else [])
+            embed_vecs = client.embed(embed_inputs, model=model)
+            query_vec = embed_vecs[0]
+            query_en_vec = embed_vecs[1] if query_en else None
+        except Exception as e:
+            raise RuntimeError(str(e)) from e
+
+        if need_vec:
+            vec_ranked = rank_cosine(
+                query_vec=query_vec,
+                items=((int(r[0]), r[1], float(r[2])) for r in vec_rows),
+                limit=candidate_limit,
+            )
+            vec_ids = [rid for rid, _ in vec_ranked]
+
+        if query_en_vec is not None and need_vec_en:
+            # Backward-compatible fallback when dedicated EN table is not populated.
+            search_rows = vec_en_rows if vec_en_rows else vec_rows
+
+            vec_en_ranked = rank_cosine(
+                query_vec=query_en_vec,
+                items=((int(r[0]), r[1], float(r[2])) for r in search_rows),
+                limit=candidate_limit,
+            )
+            vec_en_ids = [rid for rid, _ in vec_en_ranked]
+    else:
+        if not api_key and (need_vec or need_vec_en):
+            print("Warning: No API key, skipping vector retrieval", file=sys.stderr)
 
     fts_rows = []
     try:
@@ -2173,16 +2184,61 @@ def _hybrid_retrieve(
             """,
             (query, candidate_limit),
         ).fetchall()
-    except sqlite3.OperationalError as e:
-        # FTS syntax can fail for edge-case query strings (e.g. hyphens/operators).
-        if "no such column: matches" in str(e):
+    except sqlite3.OperationalError:
+        # FTS syntax can fail for edge-case query strings (hyphens/operators/punctuation).
+        # Prefer fail-open behavior:
+        # 1) retry once with a best-effort sanitized query
+        # 2) if it still fails, skip the FTS lane (instead of crashing)
+        sanitized = re.sub(r"[^\w\s]", " ", query, flags=re.UNICODE)
+        sanitized = " ".join(sanitized.split())
+        retry_query = sanitized if sanitized else query
+
+        if retry_query != query:
+            try:
+                fts_rows = conn.execute(
+                    """
+                    SELECT rowid
+                    FROM observations_fts
+                    WHERE observations_fts MATCH ?
+                    ORDER BY bm25(observations_fts) ASC
+                    LIMIT ?;
+                    """,
+                    (retry_query, candidate_limit),
+                ).fetchall()
+            except sqlite3.OperationalError:
+                print(
+                    f"[openclaw-mem] FTS query parse failed; skipping FTS lane (query={query!r}).",
+                    file=sys.stderr,
+                )
+        else:
             print(
                 f"[openclaw-mem] FTS query parse failed; skipping FTS lane (query={query!r}).",
                 file=sys.stderr,
             )
-        else:
-            raise
     fts_ids = [int(r["rowid"]) for r in fts_rows]
+
+    # If the query is a multi-token natural-language string, FTS5 MATCH defaults
+    # to an implicit AND, which can easily yield zero hits. As a best-effort
+    # fallback (especially when vector search is unavailable), retry with an OR
+    # query to recover some signal.
+    if not fts_ids:
+        tokens = [t for t in re.sub(r"[^\w\s]", " ", query, flags=re.UNICODE).split() if t]
+        if len(tokens) > 1:
+            or_query = " OR ".join(tokens)
+            try:
+                fts_rows = conn.execute(
+                    """
+                    SELECT rowid
+                    FROM observations_fts
+                    WHERE observations_fts MATCH ?
+                    ORDER BY bm25(observations_fts) ASC
+                    LIMIT ?;
+                    """,
+                    (or_query, candidate_limit),
+                ).fetchall()
+                fts_ids = [int(r["rowid"]) for r in fts_rows]
+            except sqlite3.OperationalError:
+                pass
 
     ranked_lists = [fts_ids, vec_ids]
     if vec_en_ids:

--- a/scripts/inside_out_demo.sh
+++ b/scripts/inside_out_demo.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Inside-Out Memory demo (synthetic)
+# Usage:
+#   ./scripts/inside_out_demo.sh [/path/to/demo.sqlite]
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+DB_PATH=${1:-/tmp/openclaw-mem-inside-out-demo.sqlite}
+DEMO_WS=${DEMO_WS:-$(mktemp -d /tmp/openclaw-mem-demo-ws.XXXXXX)}
+mkdir -p "$DEMO_WS/memory"
+
+cd "$ROOT_DIR"
+
+rm -f "$DB_PATH"
+
+echo "[demo] Using DB: $DB_PATH"
+echo "[demo] Using workspace: $DEMO_WS (markdown memory stays here)"
+
+echo "[demo] Storing synthetic memories..."
+uv run openclaw-mem store --db "$DB_PATH" --workspace "$DEMO_WS" --category preference --importance 0.85 \
+  "Prefers using Asia/Taipei (UTC+8) timezone for time displays and references."
+
+uv run openclaw-mem store --db "$DB_PATH" --workspace "$DEMO_WS" --category preference --importance 0.95 \
+  "Demo content must use synthetic data; do not leak private notes, credentials, or personal details."
+
+uv run openclaw-mem store --db "$DB_PATH" --workspace "$DEMO_WS" --category preference --importance 0.80 \
+  "Writing style: index-first / bounded reveal; lead with the decision then 2–3 receipts."
+
+uv run openclaw-mem store --db "$DB_PATH" --workspace "$DEMO_WS" --category decision --importance 0.75 \
+  "Showcase theme: openclaw-mem (memory/self) as the main protagonist."
+
+uv run openclaw-mem store --db "$DB_PATH" --workspace "$DEMO_WS" --category decision --importance 0.70 \
+  "Killer demo goal: before/after transcript + architecture diagram + reproducible runbook."
+
+
+echo
+echo "[demo] Packing memories for query (with trace)..."
+uv run openclaw-mem pack --db "$DB_PATH" \
+  --query "timezone privacy demo style" \
+  --limit 12 --budget-tokens 900 --trace | cat
+
+echo
+echo "[demo] Done. Next: open docs/showcase/inside-out-demo.md"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ import sys
 import unittest
 from contextlib import redirect_stdout
 
-from openclaw_mem.cli import _connect, _summary_has_task_marker, build_parser, cmd_ingest, cmd_search, cmd_get, cmd_timeline, cmd_triage, cmd_store, cmd_hybrid, cmd_status, cmd_profile, cmd_backend, cmd_graph_index, cmd_graph_pack, cmd_graph_preflight, cmd_graph_auto_status, cmd_graph_capture_git, cmd_graph_capture_md, cmd_graph_export
+from openclaw_mem.cli import _connect, _insert_observation, _summary_has_task_marker, build_parser, cmd_ingest, cmd_search, cmd_get, cmd_timeline, cmd_triage, cmd_store, cmd_hybrid, cmd_pack, cmd_status, cmd_profile, cmd_backend, cmd_graph_index, cmd_graph_pack, cmd_graph_preflight, cmd_graph_auto_status, cmd_graph_capture_git, cmd_graph_capture_md, cmd_graph_export
 
 
 class TestCliM0(unittest.TestCase):
@@ -25,6 +25,39 @@ class TestCliM0(unittest.TestCase):
         out = json.loads(buf.getvalue())
         self.assertIn("embeddings_en", out)
         self.assertEqual(out["embeddings_en"]["count"], 0)
+        conn.close()
+
+    def test_pack_falls_back_to_fts_when_no_api_key(self):
+        conn = _connect(":memory:")
+        _insert_observation(
+            conn,
+            {
+                "kind": "preference",
+                "summary": "Prefers using Asia/Taipei (UTC+8) timezone for time displays.",
+                "tool_name": "memory_store",
+                "detail": {"importance": {"score": 0.8, "label": "must_remember"}},
+            },
+        )
+
+        args = type(
+            "Args",
+            (),
+            {
+                "query": "timezone",
+                "query_en": None,
+                "limit": 12,
+                "budget_tokens": 400,
+                "trace": False,
+                "json": True,
+            },
+        )()
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cmd_pack(conn, args)
+        payload = json.loads(buf.getvalue())
+        texts = [it.get("summary") for it in payload.get("items", [])]
+        self.assertTrue(any("UTC+8" in (t or "") for t in texts))
         conn.close()
 
     def test_summary_has_task_marker_accepts_full_width_colon_and_unicode_dashes(self):


### PR DESCRIPTION
Adds a reproducible, synthetic Inside-Out Memory showcase:
- docs/showcase/inside-out-demo.md
- docs/showcase/inside-out-architecture.mmd
- scripts/inside_out_demo.sh

Also makes pack/hybrid fail-open when no OPENAI_API_KEY:
- vector lane becomes optional (FTS-only fallback)
- FTS parse errors retry with sanitized query; otherwise skip lane
- if FTS yields 0 hits, retry with OR query as best-effort

Tests:
- python -m unittest discover -s tests -p "test_*.py"