### PR TITLE
docs: AI agent quickstart (AGENTS.md) + demo links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+# AGENTS.md — openclaw-mem (for coding agents)
+
+This repo is a small, deterministic-ish **memory layer demo/prototype**.
+
+## Golden path (5 minutes)
+
+```bash
+# from repo root
+./scripts/inside_out_demo.sh
+```
+
+What it does:
+- stores a handful of **synthetic** preferences/decisions into a fresh SQLite DB
+- runs `openclaw-mem pack` to produce a compact, cited bundle
+
+## Common commands
+
+### Install / run
+
+```bash
+uv sync
+uv run openclaw-mem --help
+```
+
+### Tests
+
+```bash
+uv run -- python -m unittest discover -s tests -p "test_*.py" -q
+```
+
+### Store synthetic memories into a local DB
+
+```bash
+DB=/tmp/mem-demo.sqlite
+rm -f "$DB"
+uv run openclaw-mem store --db "$DB" --workspace /tmp/mem-ws --category preference --importance 0.8 \
+  "Prefers using Asia/Taipei (UTC+8) timezone for time displays."
+```
+
+### Pack (safe fallback)
+
+- With API key + embeddings present: hybrid retrieval (FTS + vector)
+- Without API key: **FTS-only fail-open** (still produces a bundle)
+
+```bash
+uv run openclaw-mem pack --db "$DB" --query "timezone privacy demo style" --trace
+```
+
+## Repo landmarks
+
+- CLI entrypoint: `openclaw_mem/cli.py`
+- Task marker contract (summary prefix detection): `_summary_has_task_marker()`
+- Inside-Out demo docs: `docs/showcase/inside-out-demo.md`
+- Demo script: `scripts/inside_out_demo.sh`
+
+## Environment variables
+
+- `OPENAI_API_KEY` (optional; enables vector search / embeddings)
+- `OPENCLAW_MEM_OPENAI_BASE_URL` (optional)
+- `OPENCLAW_MEM_EMBED_MODEL` (optional)
+
+## Guardrails
+
+- Keep demos **synthetic** (no secrets / no personal notes).
+- Prefer changes that are:
+  - deterministic
+  - test-covered
+  - fail-open (don’t crash a demo due to missing credentials)

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -44,6 +44,19 @@ uv run --python 3.13 -- python -m openclaw_mem --json backend
 
 ---
 
+## Step 2.1: 5-minute synthetic demo (Inside-Out Memory)
+
+This demo is **synthetic** (no private/user data) and is designed to run even
+without `OPENAI_API_KEY` (FTS-only fail-open).
+
+```bash
+./scripts/inside_out_demo.sh
+```
+
+See: `docs/showcase/inside-out-demo.md`.
+
+---
+
 ## Step 3: Ingest sample data
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ uv run python -m openclaw_mem --db "$DB" --json search "Docs" --limit 5
 Expected output (minimal): `status` prints a JSON object with `count/min_ts/max_ts`, and `ingest` prints `{inserted, ids}`.
 
 ## Quick links
+- **5-minute synthetic demo (Inside-Out Memory)**: `docs/showcase/inside-out-demo.md` (run: `./scripts/inside_out_demo.sh`)
+- **For AI coding agents**: `AGENTS.md`
 - Engine: `docs/mem-engine.md` (what it is + how to enable + knobs)
 - Sidecar capture plugin: `docs/auto-capture.md`
 - Ecosystem fit / comparisons: `docs/ecosystem-fit.md`


### PR DESCRIPTION
Adds an AI-coding-agent oriented quickstart:
- AGENTS.md (golden path, common commands, guardrails)
- README quick links: synthetic Inside-Out demo + AGENTS.md
- QUICKSTART step: run ./scripts/inside_out_demo.sh

Tests:
- uv run -- python -m unittest discover -s tests -p "test_*.py" -q