### PR TITLE
slowcook(A-fast): docs: make QUICKSTART uv run deterministic (--frozen)

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -21,7 +21,7 @@ uv sync --locked
 **Invocation note (truthful):** from a source checkout, run the CLI as:
 
 ```bash
-uv run --python 3.13 -- python -m openclaw_mem ...
+uv run --python 3.13 --frozen -- python -m openclaw_mem ...
 ```
 
 If you have a packaged install that provides the console script, you can use:
@@ -36,10 +36,10 @@ openclaw-mem ...
 
 ```bash
 # Creates/opens a DB and prints stats
-uv run --python 3.13 -- python -m openclaw_mem --json status
+uv run --python 3.13 --frozen -- python -m openclaw_mem --json status
 
 # Inspect active OpenClaw memory backend + fallback posture
-uv run --python 3.13 -- python -m openclaw_mem --json backend
+uv run --python 3.13 --frozen -- python -m openclaw_mem --json backend
 ```
 
 ---
@@ -66,7 +66,7 @@ cat > /tmp/sample.jsonl <<'JSONL'
 {"ts":"2026-02-05T10:02:00Z","kind":"tool","tool_name":"exec","summary":"ran git status","detail":{"exit_code":0}}
 JSONL
 
-uv run --python 3.13 -- python -m openclaw_mem ingest --file /tmp/sample.jsonl --json
+uv run --python 3.13 --frozen -- python -m openclaw_mem ingest --file /tmp/sample.jsonl --json
 ```
 
 ---
@@ -74,9 +74,9 @@ uv run --python 3.13 -- python -m openclaw_mem ingest --file /tmp/sample.jsonl -
 ## Step 4: Progressive recall (search → timeline → get)
 
 ```bash
-uv run --python 3.13 -- python -m openclaw_mem search "OpenClaw" --limit 10 --json
-uv run --python 3.13 -- python -m openclaw_mem timeline 2 --window 2 --json
-uv run --python 3.13 -- python -m openclaw_mem get 1 --json
+uv run --python 3.13 --frozen -- python -m openclaw_mem search "OpenClaw" --limit 10 --json
+uv run --python 3.13 --frozen -- python -m openclaw_mem timeline 2 --window 2 --json
+uv run --python 3.13 --frozen -- python -m openclaw_mem get 1 --json
 ```
 
 ---
@@ -84,11 +84,11 @@ uv run --python 3.13 -- python -m openclaw_mem get 1 --json
 ## Step 4.5: Dual-language memory (optional)
 
 ```bash
-uv run --python 3.13 -- python -m openclaw_mem store "<original non-English text>" \
+uv run --python 3.13 --frozen -- python -m openclaw_mem store "<original non-English text>" \
   --text-en "Preference: run integration tests before release" \
   --lang zh --category preference --importance 0.9 --json
 
-uv run --python 3.13 -- python -m openclaw_mem hybrid "<original query>" \
+uv run --python 3.13 --frozen -- python -m openclaw_mem hybrid "<original query>" \
   --query-en "pre-release process" \
   --limit 5 --json
 ```
@@ -150,7 +150,7 @@ tail -f ~/.openclaw/memory/openclaw-mem-observations.jsonl
 Ingest captured observations:
 
 ```bash
-uv run --python 3.13 -- python -m openclaw_mem ingest \
+uv run --python 3.13 --frozen -- python -m openclaw_mem ingest \
   --file ~/.openclaw/memory/openclaw-mem-observations.jsonl --json
 ```
 
@@ -159,8 +159,8 @@ uv run --python 3.13 -- python -m openclaw_mem ingest \
 ## Step 6: Deterministic triage (optional)
 
 ```bash
-uv run --python 3.13 -- python -m openclaw_mem triage --mode heartbeat --json
-uv run --python 3.13 -- python -m openclaw_mem triage --mode tasks --tasks-since-minutes 1440 --json
+uv run --python 3.13 --frozen -- python -m openclaw_mem triage --mode heartbeat --json
+uv run --python 3.13 --frozen -- python -m openclaw_mem triage --mode tasks --tasks-since-minutes 1440 --json
 ```
 
 Task matching rules in `--mode tasks` are deterministic:
@@ -173,7 +173,7 @@ Task matching rules in `--mode tasks` are deterministic:
 - Example run:
 
 ```bash
-uv run --python 3.13 -- python -m openclaw_mem triage --mode tasks --tasks-since-minutes 1440 --importance-min 0.7 --json
+uv run --python 3.13 --frozen -- python -m openclaw_mem triage --mode tasks --tasks-since-minutes 1440 --importance-min 0.7 --json
 ```
 
 ---
@@ -186,19 +186,19 @@ uv run --python 3.13 -- python -m openclaw_mem triage --mode tasks --tasks-since
 Enable per-command:
 
 ```bash
-OPENCLAW_MEM_IMPORTANCE_SCORER=heuristic-v1 uv run --python 3.13 -- python -m openclaw_mem harvest --file /tmp/incoming.jsonl --json --no-embed
+OPENCLAW_MEM_IMPORTANCE_SCORER=heuristic-v1 uv run --python 3.13 --frozen -- python -m openclaw_mem harvest --file /tmp/incoming.jsonl --json --no-embed
 ```
 
 Disable for a one-off run (kill-switch):
 
 ```bash
-OPENCLAW_MEM_IMPORTANCE_SCORER=off uv run --python 3.13 -- python -m openclaw_mem harvest --file /tmp/incoming.jsonl --json --no-embed
+OPENCLAW_MEM_IMPORTANCE_SCORER=off uv run --python 3.13 --frozen -- python -m openclaw_mem harvest --file /tmp/incoming.jsonl --json --no-embed
 ```
 
 Or override only this command:
 
 ```bash
-uv run --python 3.13 -- python -m openclaw_mem harvest --file /tmp/incoming.jsonl --json --no-embed --importance-scorer off
+uv run --python 3.13 --frozen -- python -m openclaw_mem harvest --file /tmp/incoming.jsonl --json --no-embed --importance-scorer off
 ```
 
 ## Step 8: Graphic Memory automation knobs (optional, dev)
@@ -212,20 +212,20 @@ Graphic Memory automation toggles are opt-in (default OFF):
 Inspect effective toggle state:
 
 ```bash
-uv run --python 3.13 -- python -m openclaw_mem graph auto-status --json
+uv run --python 3.13 --frozen -- python -m openclaw_mem graph auto-status --json
 ```
 
 Examples:
 
 ```bash
 # Preflight recall pack (bounded context bundle)
-OPENCLAW_MEM_GRAPH_AUTO_RECALL=1 uv run --python 3.13 -- python -m openclaw_mem graph preflight "slow-cook benchmark drift" --scope openclaw-mem --take 12 --budget-tokens 1200
+OPENCLAW_MEM_GRAPH_AUTO_RECALL=1 uv run --python 3.13 --frozen -- python -m openclaw_mem graph preflight "slow-cook benchmark drift" --scope openclaw-mem --take 12 --budget-tokens 1200
 
 # Capture recent repo commits as observations
-OPENCLAW_MEM_GRAPH_AUTO_CAPTURE=1 uv run --python 3.13 -- python -m openclaw_mem graph capture-git --repo /root/.openclaw/workspace/openclaw-mem-dev --since 24 --max-commits 50 --json
+OPENCLAW_MEM_GRAPH_AUTO_CAPTURE=1 uv run --python 3.13 --frozen -- python -m openclaw_mem graph capture-git --repo /root/.openclaw/workspace/openclaw-mem-dev --since 24 --max-commits 50 --json
 
 # Capture markdown heading sections (index-only)
-OPENCLAW_MEM_GRAPH_AUTO_CAPTURE_MD=1 uv run --python 3.13 -- python -m openclaw_mem graph capture-md --path /root/.openclaw/workspace/lyria-working-ledger --include .md --since-hours 24 --json
+OPENCLAW_MEM_GRAPH_AUTO_CAPTURE_MD=1 uv run --python 3.13 --frozen -- python -m openclaw_mem graph capture-md --path /root/.openclaw/workspace/lyria-working-ledger --include .md --since-hours 24 --json
 ```
 
 Spec: `docs/specs/graphic-memory-auto-capture-auto-recall.md`
@@ -243,5 +243,5 @@ Spec: `docs/specs/graphic-memory-auto-capture-auto-recall.md`
 ## Tests
 
 ```bash
-uv run --python 3.13 -- python -m unittest discover -s tests -p 'test_*.py'
+uv run --python 3.13 --frozen -- python -m unittest discover -s tests -p 'test_*.py'
 ```


### PR DESCRIPTION
## Summary
- Lane: `A-fast`
- Docs-only: `true`

## Changed files
- `QUICKSTART.md`

## Validation
- `openclaw_mem_dev_helper.py validate --mode fast`

## Notes
- PR metadata updates are done via REST (`gh api`) to avoid GraphQL breakages (e.g., Projects (classic) deprecation).
