### PR TITLE
release-train: reconcile dev into main after README/CHANGELOG conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an initial deterministic query-plane foundation module (`openclaw_mem.graph`) with rebuildable SQLite schema + refresh contract (`topology -> graph_nodes/graph_edges`) and refresh metadata receipts (`schema_version`, digest, counts, source path).
 - Added `openclaw-mem graph query ...` CLI subcommands for deterministic topology reads (`upstream`, `downstream`, `lineage`, `writers`, `filter`) with structured receipt payload `openclaw-mem.graph.query.v0`.
 - Added `openclaw-mem graph query drift --live-json <path> --db <path>` to compare stable topology nodes against runtime-state snapshots (missing/runtime-only/non-ok buckets) without mutating topology truth.
+- Added `openclaw-mem graph query provenance` for deterministic provenance-cardinality reads (with optional node/edge-type filters) so operators can inspect lineage source concentration without mutating graph truth.
+- `graph query provenance` now also returns per-provenance `edge_types` breakdowns (`edge_type` + count) to expose lineage concentration without requiring extra follow-up queries.
+- `graph query provenance` now trims blank/whitespace provenance keys before grouping and supports `--min-edge-count` for bounded high-signal concentration views.
+- Plain-text `graph query provenance` output now includes per-provenance `edge_types=<type:count,...>` summaries so non-JSON operator checks retain concentration detail.
+- `graph query receipts` now supports optional exact filters (`--source-path`, `--topology-digest`) and returns `total_count` alongside paged `count`, so operators can inspect receipt history slices without losing overall cardinality.
 - Expanded episodic auto-mode flow to full conversation coverage:
   - `extensions/openclaw-mem` emits bounded episodic spool JSONL for `tool.call`, `tool.result`, and `ops.alert` under feature flag `config.episodes.enabled`.
   - added extractor lane `openclaw-mem episodes extract-sessions` to tail OpenClaw session JSONL and emit `conversation.user` / `conversation.assistant` with offset-state tracking.
@@ -48,6 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - bounded receipt/log markers: `openclaw-mem-engine:docsColdLane.ingest`, `openclaw-mem-engine:docsColdLane.search`, plus optional `coldLane` block in recall lifecycle receipts.
 
 ### Docs
+- Added README quick-proof timeline example (`timeline 2 --window 2`) so the local proof demonstrates the full search → timeline → get recall loop.
+- Updated `docs/specs/graphic-memory-query-plane-v0.md` Stage-2 CLI examples to reflect shipped `graph query drift --live-json <path> --db <path>` command shape.
+- Updated `docs/roadmap.md` section 1.7a to PARTIAL status with shipped query-plane slice (`graph query ...`, `graph query drift --live-json <path> --db <path>`) while keeping deeper provenance integration as roadmap work.
 
 - Reframed `README.md` as a slimmer product/entry page focused on value, audience, adoption paths, and a quick local proof.
 - Added `docs/about.md` and `docs/install-modes.md` so the docs site has a product-facing story plus one install/setup decision page.
@@ -66,12 +74,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `tests/test_optimize_review.py` coverage for parser wiring, structured report shape, signal generation, repeated miss detection (`memory_recall` no-result patterns), and read-only behavior of `optimize review`.
 - Added guardrail regression coverage for invalid/non-finite TODO dedupe and stale-TTL inputs in `extensions/openclaw-mem-engine/todoGuardrails.test.mjs`.
 - Added task-marker regression coverage for ASCII angle wrappers (`<TODO>...`) in parser and triage flows, plus heuristic fixture parity (`tc31`).
+- Added triage tasks regression coverage for emoji checkbox wrappers (`[✅] TODO ...`) to keep task-marker parity with parser-level acceptance rules.
 - Added episodic ingest regression tests (`tests/test_episodes_ingest.py`) for offset state handling, invalid JSON lines, bounded payload behavior, and deterministic query ordering after ingest.
 - Added conversation extractor regression tests (`tests/test_episodes_extract_sessions.py`) for scope-tag parsing, PII redaction, payload truncation, and redacted/null payload policy.
 - Added plugin contract checks (`tests/test_plugin_episodic_spool.py`) for episodic spool schema + event-type emission markers.
 - `test_triage_json_contract_v0` now writes a temporary cron jobs fixture and passes `--cron-jobs-path`, preventing host-state coupling to `~/.openclaw/cron/jobs.json`.
 - Added docs-cold-lane contract tests (`test_mem_engine_docs_cold_lane.py`) for config schema defaults, trust/provenance markers, and runtime marker wiring.
 - Added `tests/test_graph_refresh.py` coverage for deterministic topology refresh, schema/meta initialization, JSON topology loading, and unknown-node edge rejection.
+- Added regression coverage for `graph query provenance` in both query-layer and CLI JSON contract tests (`tests/test_graph_query.py`, `tests/test_graph_query_cli.py`).
+- Added provenance guardrail tests for whitespace provenance exclusion and `min_edge_count` filtering in query-layer and CLI paths.
+- Added CLI plain-text coverage for provenance output `edge_types` summaries (`tests/test_graph_query_cli.py`).
 
 ### Benchmarks
 - Added a fixed docs-memory query set for repeatable benchmark runs (`benchmarks/docs_memory_query_set.v1.jsonl`).

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -179,7 +179,7 @@ uv run --python 3.13 --frozen -- python -m openclaw_mem triage --mode tasks --ta
 uv run --python 3.13 --frozen -- python -m openclaw_mem optimize review --json --limit 500
 ```
 
-This command is zero-write by design in v0.1: it only reports candidates (staleness, duplication, bloat, weakly-connected memories) and suggestions.
+This command is zero-write by design in v0.1: it only reports candidates (staleness, duplication, bloat, weakly-connected memories, repeated no-result `memory_recall` misses) and suggestions.
 
 ## Step 7: Autograde toggle (optional)
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ python3 ./scripts/make_sample_jsonl.py --out /tmp/openclaw-mem-sample.jsonl
 uv run --python 3.13 --frozen -- python -m openclaw_mem --db "$DB" --json status
 uv run --python 3.13 --frozen -- python -m openclaw_mem --db "$DB" --json ingest --file /tmp/openclaw-mem-sample.jsonl
 uv run --python 3.13 --frozen -- python -m openclaw_mem --db "$DB" --json search "OpenClaw" --limit 5
+
+uv run --python 3.13 --frozen -- python -m openclaw_mem --db "$DB" --json timeline 2 --window 2
 ```
 
 If that works, the product story is real: you already have a local memory ledger plus a recall path you can inspect.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -77,7 +77,7 @@ Acceptance criteria:
 
 ### 1.7a) Graphic Memory query plane (operator-facing graph interface)
 
-Status: **ROADMAP**.
+Status: **PARTIAL** (query-plane foundation + deterministic query CLI shipped; deeper provenance integration pending).
 
 - Problem: operators need a practical query layer over stable topology + runtime drift + provenance, but today those relationships are scattered across YAML, cron state, and receipts.
 - Decision: keep repo-backed topology as the source of truth; add a **derived query plane** under `openclaw-mem`.
@@ -85,6 +85,10 @@ Status: **ROADMAP**.
   - source of truth = structured files (YAML / markdown / receipts)
   - derived cache = SQLite graph tables
   - first shippable slice = YAML-only query helper for one-hop operator questions
+- Shipped slice (Unreleased):
+  - deterministic query-plane foundation module + SQLite refresh contract
+  - `graph query` commands for `upstream` / `downstream` / `lineage` / `writers` / `filter`
+  - `graph query drift --live-json <path> --db <path>` for stable-topology vs runtime-state checks
 - Initial operator questions:
   - what depends on this node?
   - what does this node feed/write?
@@ -149,7 +153,7 @@ Status: **PARTIAL** (v0.1 recommendation observer shipped; apply path still road
 Shipped v0.1 slice:
 - `openclaw-mem optimize review` (zero-write observer/reporter)
 - bounded source-of-truth scan (`observations`, default limit 1000)
-- low-risk signals: staleness, duplication, bloat, weakly-connected candidates
+- low-risk signals: staleness, duplication, bloat, weakly-connected candidates, repeated no-result `memory_recall` miss patterns
 - outputs structured report `openclaw-mem.optimize.review.v0` with recommendations (no mutation)
 
 Artifacts:

--- a/docs/specs/graphic-memory-query-plane-v0.md
+++ b/docs/specs/graphic-memory-query-plane-v0.md
@@ -99,7 +99,7 @@ tests/
 ### Stage-2 derived SQLite CLI
 - `openclaw-mem graph refresh --topology <path> --db <path>`
 - `openclaw-mem graph query upstream --node <id> --db <path>`
-- `openclaw-mem graph drift --topology <path> --db <path> --live-cron-json <path>`
+- `openclaw-mem graph query drift --live-json <path> --db <path>`
 - `openclaw-mem graph health --db <path> --stale-hours 24`
 
 ### Stage-3 provenance / receipts

--- a/docs/specs/self-optimizing-memory-loop-v0.md
+++ b/docs/specs/self-optimizing-memory-loop-v0.md
@@ -149,6 +149,7 @@ tests/
   - duplication
   - bloat
   - weakly-connected candidates
+  - repeated no-result `memory_recall` miss patterns
 - structured report: `openclaw-mem.optimize.review.v0`
 - no auto-apply
 - zero writes to memory rows (observe + propose only)

--- a/docs/upgrade-checklist.md
+++ b/docs/upgrade-checklist.md
@@ -133,12 +133,6 @@ Task extraction is deterministic and picks rows when either:
   - Example formats: `TODO`, `TODO: rotate runbook`, `{TODO}: rotate runbook`, `【TODO】 rotate runbook`, `「TODO」 rotate runbook`, `『TODO』 rotate runbook`, `《TODO》 rotate runbook`, `«TODO» rotate runbook`, `〈TODO〉 rotate runbook`, `〖TODO〗 rotate runbook`, `〘TODO〙 rotate runbook`, `‹TODO› rotate runbook`, `<TODO> rotate runbook`, `＜TODO＞rotate runbook`, `task- check alerts`, `(TASK): review PR`, `- [ ] TODO file patch`, `> TODO follow up with vendor`, `>>[x]TODO: compact wrappers`, `TODO; rotate runbook`, `TASK；follow up on release checklist`.
   - Example run:
 
-```bash
-uv run python -m openclaw_mem triage --mode tasks --tasks-since-minutes 1440 --importance-min 0.7 --json
-```
-
-  - Example run:
-
     ```bash
     uv run --python 3.13 --frozen -- python -m openclaw_mem triage --mode tasks --tasks-since-minutes 1440 --importance-min 0.7 --json
     ```

--- a/extensions/openclaw-mem-engine/.gitignore
+++ b/extensions/openclaw-mem-engine/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .npm/
 *.log
+tmp*.mjs

--- a/openclaw_mem/cli.py
+++ b/openclaw_mem/cli.py
@@ -52,6 +52,17 @@ from openclaw_mem.docs_memory import (
 )
 from openclaw_mem.vector import l2_norm, pack_f32, rank_cosine, rank_rrf
 from openclaw_mem.optimization import build_memory_health_review, render_memory_health_review
+from openclaw_mem.graph.drift import query_drift
+from openclaw_mem.graph.query import (
+    query_downstream,
+    query_filter_nodes,
+    query_lineage,
+    query_provenance,
+    query_refresh_receipts,
+    query_upstream,
+    query_writers,
+)
+from openclaw_mem.scope import normalize_scope_token as _normalize_scope_token
 
 def _resolve_home_dir() -> str:
     """Best-effort OpenClaw-style home resolution.
@@ -191,19 +202,6 @@ EPISODIC_TOOL_OUTPUT_PATTERNS: Tuple[re.Pattern[str], ...] = (
 def _utcnow_ts_ms() -> int:
     return int(time.time() * 1000)
 
-
-def _normalize_scope_token(raw: Any) -> Optional[str]:
-    if raw is None:
-        return None
-    token = str(raw).strip().lower()
-    if not token:
-        return None
-    token = re.sub(r"[\s]+", "-", token)
-    token = re.sub(r"[^a-z0-9._:/-]+", "-", token)
-    token = re.sub(r"-+", "-", token)
-    token = re.sub(r"^[-./:_]+", "", token)
-    token = re.sub(r"[-./:_]+$", "", token)
-    return token or None
 
 
 def _normalize_episodic_scope(raw: Any) -> str:
@@ -1424,6 +1422,7 @@ def cmd_optimize_review(conn: sqlite3.Connection, args: argparse.Namespace) -> N
         bloat_summary_chars=int(getattr(args, "bloat_summary_chars", 240)),
         bloat_detail_bytes=int(getattr(args, "bloat_detail_bytes", 4096)),
         orphan_min_tokens=int(getattr(args, "orphan_min_tokens", 2)),
+        miss_min_count=int(getattr(args, "miss_min_count", 2)),
         top=int(getattr(args, "top", 10)),
         scope=getattr(args, "scope", None),
     )
@@ -4071,7 +4070,7 @@ def _summary_has_task_marker(summary: str) -> bool:
 
     Optional leading markdown wrappers are tolerated before markers:
     - blockquotes: `>` (repeatable; whitespace optional before nested wrappers/marker)
-    - list bullets: `-`, `*`, `+`, `•`, `▪`, `‣`, `∙`, `·`, `◦`, `・`, `–`, `—`, `−` (whitespace optional before nested wrappers/marker)
+    - list bullets: `-`, `*`, `+`, `•`, `▪`, `‣`, `∙`, `·`, `●`, `○`, `◦`, `・`, `–`, `—`, `−` (whitespace optional before nested wrappers/marker)
     - markdown checkboxes: `[ ]` / `[x]` / `[✓]` / `[✔]` / `[☐]` / `[☑]` / `[☒]` (whitespace optional before nested wrappers/marker)
     - ordered-list prefixes: `1.` / `1)` / `1-` / `（1）` / `(1)` / `a.` / `a)` / `(a)` / `iv.` / `iv)` / `(iv)` (whitespace optional before nested wrappers/marker)
 
@@ -4101,7 +4100,7 @@ def _summary_has_task_marker(summary: str) -> bool:
 
     markers = ("TODO", "TASK", "REMINDER")
     separators = {":", "：", ";", "；", "-", ".", "。", "－", "–", "—", "−"}
-    bullet_prefixes = {"-", "*", "+", "•", "▪", "‣", "∙", "·", "◦", "・", "–", "—", "−"}
+    bullet_prefixes = {"-", "*", "+", "•", "▪", "‣", "∙", "·", "●", "○", "◦", "・", "–", "—", "−"}
     checkbox_markers = {" ", "x", "X", "✓", "✔", "☐", "☑", "☒", "✅"}
     ordered_prefix_sep = {".", ")", "-", "－", "–", "—", "−"}
 
@@ -4318,7 +4317,7 @@ def _triage_tasks(conn: sqlite3.Connection, *, since_ts: str, importance_min: fl
       (case-insensitive; width-normalized via NFKC; supports plain or
       bracketed forms like `[TODO]`/`(TASK)`/`【TODO】`/`〔TODO〕`/`「TODO」`/`『TODO』`/`〖TODO〗`/`〘TODO〙`/`<TODO>`/`＜TODO＞` (including compact no-space forms like `[TODO]buy milk`/`【TODO】buy milk`/`〔TODO〕buy milk`/`「TODO」buy milk`/`『TODO』buy milk`/`〖TODO〗buy milk`/`〘TODO〙buy milk`/`<TODO>buy milk`/`＜TODO＞buy milk`), plus optional leading
       markdown wrappers like `>` blockquotes, list/checklist prefixes
-      (`-`/`*`/`+`/`•`/`▪`/`‣`/`∙`/`·`/`◦`/`・`/`–`/`—`/`−`, `[ ]`/`[x]`/`[✓]`/`[✔]`/`[☐]`/`[☑]`/`[☒]`), and ordered-list prefixes like
+      (`-`/`*`/`+`/`•`/`▪`/`‣`/`∙`/`·`/`●`/`○`/`◦`/`・`/`–`/`—`/`−`, `[ ]`/`[x]`/`[✓]`/`[✔]`/`[☐]`/`[☑]`/`[☒]`), and ordered-list prefixes like
       `1.`/`1)`/`1-`/`（1）`/`(1)`/`a.`/`a)`/`(a)`/`iv.`/`iv)`/`(iv)`; whitespace is optional
       between wrappers and the next wrapper/marker;
       accepts ':', whitespace, ';', '；', '-', '－', '–', '—', '−', or marker-only)
@@ -5138,7 +5137,7 @@ def _extract_writeback_updates(row: sqlite3.Row) -> Optional[Dict[str, Any]]:
     if label:
         updates["importance_label"] = label
 
-    scope = str(detail_obj.get("scope") or row["kind"] or "").strip()
+    scope = _normalize_scope_token(detail_obj.get("scope") or row["kind"])
     if scope:
         updates["scope"] = scope
 
@@ -6858,6 +6857,143 @@ def cmd_graph_export(conn: sqlite3.Connection, args: argparse.Namespace) -> None
     _emit(payload, bool(args.json))
 
 
+def cmd_graph_query(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    _ = conn
+    query_cmd = str(getattr(args, "graph_query_cmd", "") or "").strip().lower()
+    db_path = str(getattr(args, "db", "") or "").strip()
+
+    if not db_path:
+        _emit({"error": "missing --db"}, True)
+        sys.exit(2)
+
+    try:
+        if query_cmd == "upstream":
+            result = query_upstream(db_path=db_path, node_id=getattr(args, "node_id", None))
+        elif query_cmd == "downstream":
+            result = query_downstream(db_path=db_path, node_id=getattr(args, "node_id", None))
+        elif query_cmd == "lineage":
+            result = query_lineage(db_path=db_path, node_id=getattr(args, "node_id", None))
+        elif query_cmd == "writers":
+            result = query_writers(db_path=db_path, artifact_id=getattr(args, "artifact_id", None))
+        elif query_cmd == "filter":
+            result = query_filter_nodes(
+                db_path=db_path,
+                tag=getattr(args, "tag", None),
+                not_tag=getattr(args, "not_tag", None),
+                node_type=getattr(args, "node_type", None),
+            )
+        elif query_cmd == "receipts":
+            result = query_refresh_receipts(
+                db_path=db_path,
+                limit=getattr(args, "limit", 10),
+                source_path=getattr(args, "source_path", None),
+                topology_digest=getattr(args, "topology_digest", None),
+            )
+        elif query_cmd == "provenance":
+            result = query_provenance(
+                db_path=db_path,
+                node_id=getattr(args, "node_id", None),
+                edge_type=getattr(args, "edge_type", None),
+                limit=getattr(args, "limit", 20),
+                min_edge_count=getattr(args, "min_edge_count", 1),
+            )
+        elif query_cmd == "drift":
+            result = query_drift(
+                db_path=db_path,
+                live_json_path=getattr(args, "live_json", None),
+                limit=getattr(args, "limit", 50),
+            )
+        else:
+            raise ValueError(f"unsupported graph query command: {query_cmd}")
+    except ValueError as e:
+        _emit({"error": str(e)}, True)
+        sys.exit(2)
+    except sqlite3.OperationalError as e:
+        _emit({"error": str(e)}, True)
+        sys.exit(1)
+
+    payload = {
+        "kind": "openclaw-mem.graph.query.v0",
+        "ts": _utcnow_iso(),
+        "query_cmd": query_cmd,
+        "result": result,
+    }
+
+    if bool(args.json):
+        _emit(payload, True)
+        return
+
+    if query_cmd == "filter":
+        print(f"count={int(result.get('count', 0))}")
+        for node in list(result.get("nodes") or []):
+            print(f"{node.get('id')} type={node.get('type')} tags={','.join(node.get('tags') or [])}")
+        return
+
+    if query_cmd == "receipts":
+        receipts = list(result.get("receipts") or [])
+        print(
+            f"count={int(result.get('count', 0))} "
+            f"total_count={int(result.get('total_count', 0))}"
+        )
+        for receipt in receipts:
+            print(
+                f"id={receipt.get('id')} refreshed_at={receipt.get('refreshed_at')} "
+                f"nodes={receipt.get('node_count')} edges={receipt.get('edge_count')} "
+                f"source={receipt.get('source_path')}"
+            )
+        return
+
+    if query_cmd == "provenance":
+        print(
+            f"count={int(result.get('count', 0))} "
+            f"total_distinct={int(result.get('total_distinct', 0))}"
+        )
+        for item in list(result.get("items") or []):
+            edge_types = list(item.get("edge_types") or [])
+            if edge_types:
+                edge_types_summary = ",".join(
+                    f"{str(edge.get('edge_type'))}:{int(edge.get('edge_count', 0))}"
+                    for edge in edge_types
+                )
+            else:
+                edge_types_summary = ""
+            line = f"{item.get('provenance')} edges={item.get('edge_count')}"
+            if edge_types_summary:
+                line += f" edge_types={edge_types_summary}"
+            print(line)
+        return
+
+    if query_cmd == "drift":
+        print(
+            f"topology_nodes={int(result.get('topology_node_count', 0))} "
+            f"runtime_nodes={int(result.get('runtime_node_count', 0))}"
+        )
+        missing = result.get("missing_in_runtime") or {}
+        runtime_only = result.get("runtime_only") or {}
+        non_ok = result.get("non_ok_nodes") or {}
+        print(f"missing_in_runtime={int(missing.get('count', 0))}")
+        print(f"runtime_only={int(runtime_only.get('count', 0))}")
+        print(f"non_ok_nodes={int(non_ok.get('count', 0))}")
+        for item in list(non_ok.get("items") or []):
+            print(f"non_ok:{item.get('node_id')} status={item.get('status')}")
+        return
+
+    edges = list(result.get("edges") or [])
+    if query_cmd == "lineage":
+        upstream = list(result.get("upstream") or [])
+        downstream = list(result.get("downstream") or [])
+        print(f"upstream_count={len(upstream)} downstream_count={len(downstream)}")
+        for edge in upstream:
+            print(f"UP {edge.get('src')} --{edge.get('type')}--> {edge.get('dst')}")
+        for edge in downstream:
+            print(f"DOWN {edge.get('src')} --{edge.get('type')}--> {edge.get('dst')}")
+        return
+
+    print(f"count={int(result.get('count', 0))}")
+    for edge in edges:
+        print(f"{edge.get('src')} --{edge.get('type')}--> {edge.get('dst')}")
+
+
 def cmd_episodes_append(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
     try:
         event_type = _normalize_episodic_type(getattr(args, "type", None))
@@ -8303,6 +8439,7 @@ def build_parser() -> argparse.ArgumentParser:
     o.add_argument("--bloat-summary-chars", dest="bloat_summary_chars", type=int, default=240, help="Summary length threshold for bloat candidates (default: 240)")
     o.add_argument("--bloat-detail-bytes", dest="bloat_detail_bytes", type=int, default=4096, help="detail_json size threshold for bloat candidates in bytes (default: 4096)")
     o.add_argument("--orphan-min-tokens", dest="orphan_min_tokens", type=int, default=2, help="Minimum token count for weakly connected candidates (default: 2)")
+    o.add_argument("--miss-min-count", dest="miss_min_count", type=int, default=2, help="Min repeated no-result memory_recall events per query/scope group (default: 2)")
     o.add_argument("--scope", default=None, help="Filter review to a normalized detail.scope token")
     o.add_argument("--top", type=int, default=10, help="Max candidate rows/groups per signal in output (default: 10)")
     o.set_defaults(func=cmd_optimize_review)
@@ -8558,6 +8695,49 @@ def build_parser() -> argparse.ArgumentParser:
 
     g = gsub.add_parser("auto-status", help="Show effective Graphic Memory automation env toggles")
     g.set_defaults(func=cmd_graph_auto_status)
+
+    g = gsub.add_parser("query", help="Deterministic graph topology queries (upstream/downstream/lineage/writers/filter/receipts/provenance/drift)")
+    qsub = g.add_subparsers(dest="graph_query_cmd", required=True)
+
+    q = qsub.add_parser("upstream", help="List incoming edges into node_id")
+    q.add_argument("node_id", help="Target node id")
+    q.set_defaults(func=cmd_graph_query)
+
+    q = qsub.add_parser("downstream", help="List outgoing edges from node_id")
+    q.add_argument("node_id", help="Source node id")
+    q.set_defaults(func=cmd_graph_query)
+
+    q = qsub.add_parser("lineage", help="List both upstream and downstream edges for node_id")
+    q.add_argument("node_id", help="Target node id")
+    q.set_defaults(func=cmd_graph_query)
+
+    q = qsub.add_parser("writers", help="List writes edges that target artifact_id")
+    q.add_argument("artifact_id", help="Artifact node id")
+    q.set_defaults(func=cmd_graph_query)
+
+    q = qsub.add_parser("filter", help="Filter nodes by tags/type")
+    q.add_argument("--tag", help="Require tag")
+    q.add_argument("--not-tag", dest="not_tag", help="Exclude tag")
+    q.add_argument("--node-type", dest="node_type", help="Require node type")
+    q.set_defaults(func=cmd_graph_query)
+
+    q = qsub.add_parser("receipts", help="List recent deterministic refresh receipts")
+    q.add_argument("--limit", type=int, default=10, help="Max receipts to return (default: 10)")
+    q.add_argument("--source-path", dest="source_path", help="Optional exact source_path filter")
+    q.add_argument("--topology-digest", dest="topology_digest", help="Optional exact topology_digest filter")
+    q.set_defaults(func=cmd_graph_query)
+
+    q = qsub.add_parser("provenance", help="List provenance references with edge counts")
+    q.add_argument("--node-id", dest="node_id", help="Optional node id filter (matches src or dst)")
+    q.add_argument("--edge-type", dest="edge_type", help="Optional edge type filter")
+    q.add_argument("--min-edge-count", dest="min_edge_count", type=int, default=1, help="Only include provenance groups with at least this many edges (default: 1)")
+    q.add_argument("--limit", type=int, default=20, help="Max provenance rows to return (default: 20)")
+    q.set_defaults(func=cmd_graph_query)
+
+    q = qsub.add_parser("drift", help="Compare topology graph nodes against runtime state JSON")
+    q.add_argument("--live-json", dest="live_json", required=True, help="Runtime state JSON path (nodes/status_by_node)")
+    q.add_argument("--limit", type=int, default=50, help="Max node ids to include per drift bucket (default: 50)")
+    q.set_defaults(func=cmd_graph_query)
 
     g = gsub.add_parser("capture-git", help="Capture recent git commits as observations (idempotent)")
     g.add_argument("--repo", action="append", required=True, help="Git repository path (repeatable)")

--- a/openclaw_mem/graph/__init__.py
+++ b/openclaw_mem/graph/__init__.py
@@ -1,7 +1,10 @@
+from .drift import query_drift
 from .query import (
     query_downstream,
     query_filter_nodes,
     query_lineage,
+    query_provenance,
+    query_refresh_receipts,
     query_upstream,
     query_writers,
 )
@@ -11,9 +14,12 @@ from .schema import GRAPH_SCHEMA_VERSION, ensure_graph_schema
 __all__ = [
     "GRAPH_SCHEMA_VERSION",
     "ensure_graph_schema",
+    "query_drift",
     "query_downstream",
     "query_filter_nodes",
     "query_lineage",
+    "query_provenance",
+    "query_refresh_receipts",
     "query_upstream",
     "query_writers",
     "refresh_topology",

--- a/openclaw_mem/graph/drift.py
+++ b/openclaw_mem/graph/drift.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from .schema import connect_graph_db_for_query
+
+
+_NON_OK_STATUSES = {"stale", "error", "missing"}
+_MAX_DRIFT_LIMIT = 200
+
+
+def _normalize_status(raw: Any) -> str:
+    token = str(raw or "").strip().lower()
+    return token or "unknown"
+
+
+def _parse_limit(raw: int, *, max_limit: int) -> int:
+    limit_int = int(raw)
+    if limit_int <= 0:
+        raise ValueError("limit must be > 0")
+    if limit_int > max_limit:
+        raise ValueError(f"limit must be <= {max_limit}")
+    return limit_int
+
+
+def _bounded_ids(items: List[str], *, limit: int) -> Tuple[List[str], bool]:
+    if limit <= 0:
+        raise ValueError("limit must be > 0")
+    if len(items) <= limit:
+        return items, False
+    return items[:limit], True
+
+
+def _load_runtime_rows(payload: Any) -> List[Dict[str, Any]]:
+    if isinstance(payload, list):
+        rows = payload
+    elif isinstance(payload, dict):
+        if isinstance(payload.get("nodes"), list):
+            rows = payload.get("nodes") or []
+        elif isinstance(payload.get("status_by_node"), dict):
+            rows = [
+                {"id": str(node_id), "status": status}
+                for node_id, status in (payload.get("status_by_node") or {}).items()
+            ]
+        else:
+            raise ValueError("runtime JSON object must include list key 'nodes' or object key 'status_by_node'")
+    else:
+        raise ValueError("runtime JSON root must be a list or object")
+
+    out: List[Dict[str, Any]] = []
+    for idx, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise ValueError(f"runtime rows[{idx}] must be an object")
+        node_id = str(row.get("id") or row.get("node_id") or row.get("node") or "").strip()
+        if not node_id:
+            raise ValueError(f"runtime rows[{idx}] missing id/node_id")
+        status = _normalize_status(row.get("status"))
+        out.append({"node_id": node_id, "status": status})
+
+    return out
+
+
+def _load_runtime_state(path: Path) -> Tuple[Dict[str, str], List[str]]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid runtime JSON: {path}: {exc.msg}") from exc
+
+    rows = _load_runtime_rows(payload)
+    runtime_by_node: Dict[str, str] = {}
+    duplicate_ids: List[str] = []
+    for row in rows:
+        node_id = row["node_id"]
+        if node_id in runtime_by_node:
+            duplicate_ids.append(node_id)
+        runtime_by_node[node_id] = row["status"]
+    return runtime_by_node, sorted(set(duplicate_ids))
+
+
+def query_drift(*, db_path: str | Path, live_json_path: str | Path, limit: int = 50) -> Dict[str, Any]:
+    limit_int = _parse_limit(limit, max_limit=_MAX_DRIFT_LIMIT)
+
+    live_path = Path(str(live_json_path or "").strip())
+    if not str(live_path):
+        raise ValueError("live_json_path is required")
+    if not live_path.is_file():
+        raise ValueError(f"live runtime JSON not found: {live_path}")
+
+    conn = connect_graph_db_for_query(db_path)
+    try:
+        rows = conn.execute("SELECT node_id FROM graph_nodes ORDER BY node_id").fetchall()
+    finally:
+        conn.close()
+
+    topology_ids = sorted(str(row[0]) for row in rows)
+    topology_set = set(topology_ids)
+
+    runtime_by_node, duplicate_ids = _load_runtime_state(live_path)
+    runtime_ids = sorted(runtime_by_node.keys())
+    runtime_set = set(runtime_ids)
+
+    missing = sorted(topology_set - runtime_set)
+    runtime_only = sorted(runtime_set - topology_set)
+
+    non_ok = sorted(
+        node_id
+        for node_id in sorted(topology_set & runtime_set)
+        if runtime_by_node.get(node_id) in _NON_OK_STATUSES
+    )
+
+    missing_slice, missing_truncated = _bounded_ids(missing, limit=limit_int)
+    runtime_only_slice, runtime_only_truncated = _bounded_ids(runtime_only, limit=limit_int)
+    non_ok_slice, non_ok_truncated = _bounded_ids(non_ok, limit=limit_int)
+
+    status_counts: Dict[str, int] = {}
+    for node_id in runtime_ids:
+        status = runtime_by_node.get(node_id, "unknown")
+        status_counts[status] = status_counts.get(status, 0) + 1
+
+    non_ok_details = [
+        {"node_id": node_id, "status": runtime_by_node.get(node_id, "unknown")}
+        for node_id in non_ok_slice
+    ]
+
+    return {
+        "ok": True,
+        "query": "drift",
+        "live_json_path": str(live_path),
+        "topology_node_count": len(topology_ids),
+        "runtime_node_count": len(runtime_ids),
+        "status_counts": dict(sorted(status_counts.items())),
+        "missing_in_runtime": {
+            "count": len(missing),
+            "node_ids": missing_slice,
+            "truncated": missing_truncated,
+        },
+        "runtime_only": {
+            "count": len(runtime_only),
+            "node_ids": runtime_only_slice,
+            "truncated": runtime_only_truncated,
+        },
+        "non_ok_nodes": {
+            "count": len(non_ok),
+            "items": non_ok_details,
+            "truncated": non_ok_truncated,
+            "statuses": sorted(_NON_OK_STATUSES),
+        },
+        "duplicate_runtime_ids": {
+            "count": len(duplicate_ids),
+            "node_ids": duplicate_ids,
+        },
+    }

--- a/openclaw_mem/graph/query.py
+++ b/openclaw_mem/graph/query.py
@@ -5,6 +5,11 @@ import sqlite3
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from .schema import connect_graph_db_for_query
+
+
+_MAX_RECEIPTS_LIMIT = 200
+
 
 def _json_load_object(raw: Any) -> Dict[str, Any]:
     if isinstance(raw, str) and raw.strip():
@@ -31,6 +36,15 @@ def _json_load_tags(raw: Any) -> List[str]:
                     out.append(token)
             return sorted(set(out))
     return []
+
+
+def _parse_limit(raw: int, *, max_limit: int) -> int:
+    limit_int = int(raw)
+    if limit_int <= 0:
+        raise ValueError("limit must be > 0")
+    if limit_int > max_limit:
+        raise ValueError(f"limit must be <= {max_limit}")
+    return limit_int
 
 
 def _load_node_map(conn: sqlite3.Connection) -> Dict[str, Dict[str, Any]]:
@@ -95,7 +109,7 @@ def _query_edges(
     where_sql: str,
     where_args: Tuple[Any, ...],
 ) -> List[Dict[str, Any]]:
-    conn = sqlite3.connect(str(Path(db_path)))
+    conn = connect_graph_db_for_query(db_path)
     try:
         node_map = _load_node_map(conn)
         edges = _edge_rows(conn, where_sql=where_sql, where_args=where_args)
@@ -161,7 +175,7 @@ def query_filter_nodes(
     exclude_tag = (not_tag or "").strip()
     only_type = (node_type or "").strip()
 
-    conn = sqlite3.connect(str(Path(db_path)))
+    conn = connect_graph_db_for_query(db_path)
     try:
         node_map = _load_node_map(conn)
     finally:
@@ -208,4 +222,168 @@ def query_lineage(*, db_path: str | Path, node_id: str) -> Dict[str, Any]:
         "downstream_count": len(downstream),
         "upstream": upstream,
         "downstream": downstream,
+    }
+
+
+def query_provenance(
+    *,
+    db_path: str | Path,
+    node_id: Optional[str] = None,
+    edge_type: Optional[str] = None,
+    limit: int = 20,
+    min_edge_count: int = 1,
+) -> Dict[str, Any]:
+    limit_int = _parse_limit(limit, max_limit=_MAX_RECEIPTS_LIMIT)
+    min_edges = int(min_edge_count)
+    if min_edges <= 0:
+        raise ValueError("min_edge_count must be > 0")
+
+    node = (node_id or "").strip()
+    edge_kind = (edge_type or "").strip()
+
+    where_parts = ["TRIM(provenance) != ''"]
+    where_args: List[Any] = []
+    if node:
+        where_parts.append("(src_id = ? OR dst_id = ?)")
+        where_args.extend([node, node])
+    if edge_kind:
+        where_parts.append("edge_type = ?")
+        where_args.append(edge_kind)
+
+    where_sql = " AND ".join(where_parts)
+    where_args_tuple = tuple(where_args)
+
+    conn = connect_graph_db_for_query(db_path)
+    try:
+        total_row = conn.execute(
+            "SELECT COUNT(*) FROM ("
+            f"SELECT provenance FROM graph_edges WHERE {where_sql} "
+            "GROUP BY provenance HAVING COUNT(*) >= ?"
+            ")",
+            where_args_tuple + (min_edges,),
+        ).fetchone()
+
+        rows = conn.execute(
+            f"SELECT provenance, COUNT(*) AS edge_count FROM graph_edges WHERE {where_sql} "
+            "GROUP BY provenance HAVING COUNT(*) >= ? "
+            "ORDER BY edge_count DESC, provenance ASC LIMIT ?",
+            where_args_tuple + (min_edges, limit_int),
+        ).fetchall()
+
+        selected_provenances = [str(row[0]) for row in rows]
+        detail_rows: List[Tuple[Any, Any, Any]] = []
+        if selected_provenances:
+            placeholders = ", ".join(["?"] * len(selected_provenances))
+            detail_rows = conn.execute(
+                f"SELECT provenance, edge_type, COUNT(*) AS edge_count FROM graph_edges WHERE {where_sql} "
+                f"AND provenance IN ({placeholders}) "
+                "GROUP BY provenance, edge_type "
+                "ORDER BY provenance ASC, edge_count DESC, edge_type ASC",
+                where_args_tuple + tuple(selected_provenances),
+            ).fetchall()
+    finally:
+        conn.close()
+
+    edge_types_by_provenance: Dict[str, List[Dict[str, Any]]] = {}
+    for row in detail_rows:
+        provenance = str(row[0])
+        edge_types_by_provenance.setdefault(provenance, []).append(
+            {
+                "edge_type": str(row[1]),
+                "edge_count": int(row[2]),
+            }
+        )
+
+    items: List[Dict[str, Any]] = []
+    for row in rows:
+        provenance = str(row[0])
+        items.append(
+            {
+                "provenance": provenance,
+                "edge_count": int(row[1]),
+                "edge_types": edge_types_by_provenance.get(provenance, []),
+            }
+        )
+
+    total_distinct = int(total_row[0]) if total_row and total_row[0] is not None else 0
+
+    return {
+        "ok": True,
+        "query": "provenance",
+        "filters": {
+            "node_id": node or None,
+            "edge_type": edge_kind or None,
+            "min_edge_count": min_edges,
+        },
+        "count": len(items),
+        "total_distinct": total_distinct,
+        "items": items,
+    }
+
+
+def query_refresh_receipts(
+    *,
+    db_path: str | Path,
+    limit: int = 10,
+    source_path: Optional[str] = None,
+    topology_digest: Optional[str] = None,
+) -> Dict[str, Any]:
+    limit_int = _parse_limit(limit, max_limit=_MAX_RECEIPTS_LIMIT)
+    source = (source_path or "").strip()
+    digest = (topology_digest or "").strip()
+
+    where_parts: List[str] = []
+    where_args: List[Any] = []
+    if source:
+        where_parts.append("source_path = ?")
+        where_args.append(source)
+    if digest:
+        where_parts.append("topology_digest = ?")
+        where_args.append(digest)
+
+    where_sql = ""
+    if where_parts:
+        where_sql = " WHERE " + " AND ".join(where_parts)
+
+    conn = connect_graph_db_for_query(db_path)
+    try:
+        total_row = conn.execute(
+            "SELECT COUNT(*) FROM graph_refresh_receipts" + where_sql,
+            tuple(where_args),
+        ).fetchone()
+        rows = conn.execute(
+            "SELECT id, refreshed_at, source_path, topology_digest, node_count, edge_count "
+            "FROM graph_refresh_receipts"
+            + where_sql
+            + " ORDER BY id DESC LIMIT ?",
+            tuple(where_args) + (limit_int,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    receipts: List[Dict[str, Any]] = []
+    for row in rows:
+        receipts.append(
+            {
+                "id": int(row[0]),
+                "refreshed_at": str(row[1]),
+                "source_path": str(row[2]),
+                "topology_digest": str(row[3]),
+                "node_count": int(row[4]),
+                "edge_count": int(row[5]),
+            }
+        )
+
+    total_count = int(total_row[0]) if total_row and total_row[0] is not None else 0
+
+    return {
+        "ok": True,
+        "query": "receipts",
+        "filters": {
+            "source_path": source or None,
+            "topology_digest": digest or None,
+        },
+        "count": len(receipts),
+        "total_count": total_count,
+        "receipts": receipts,
     }

--- a/openclaw_mem/graph/refresh.py
+++ b/openclaw_mem/graph/refresh.py
@@ -212,6 +212,11 @@ def refresh_topology(topology: Dict[str, Any], *, db_path: str | Path, source_pa
                     "edge_count": str(len(edges)),
                 },
             )
+            conn.execute(
+                "INSERT INTO graph_refresh_receipts(refreshed_at, source_path, topology_digest, node_count, edge_count) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (refreshed_at, source_path or "", digest, len(nodes), len(edges)),
+            )
     finally:
         conn.close()
 

--- a/openclaw_mem/graph/schema.py
+++ b/openclaw_mem/graph/schema.py
@@ -1,8 +1,72 @@
 from __future__ import annotations
 
 import sqlite3
+from pathlib import Path
+from typing import Iterable
 
 GRAPH_SCHEMA_VERSION = 1
+
+
+_REQUIRED_GRAPH_TABLES = (
+    "graph_nodes",
+    "graph_edges",
+    "graph_meta",
+    "graph_refresh_receipts",
+)
+
+
+def connect_graph_db_for_query(
+    db_path: str | Path,
+    *,
+    required_tables: Iterable[str] = _REQUIRED_GRAPH_TABLES,
+) -> sqlite3.Connection:
+    db_file = Path(str(db_path or "")).resolve()
+    if not str(db_path or "").strip():
+        raise ValueError("db_path is required")
+    if not db_file.is_file():
+        raise ValueError(f"graph db not found: {db_file}")
+
+    try:
+        conn = sqlite3.connect(str(db_file))
+    except sqlite3.Error as exc:
+        raise ValueError(f"failed to open graph db: {db_file}: {exc}") from exc
+
+    try:
+        rows = conn.execute("SELECT name FROM sqlite_master WHERE type = ?", ("table",)).fetchall()
+    except sqlite3.Error as exc:
+        conn.close()
+        raise ValueError(f"failed to inspect graph db schema: {db_file}: {exc}") from exc
+
+    existing_tables = {str(row[0]) for row in rows}
+    missing_tables = [name for name in required_tables if name not in existing_tables]
+    if missing_tables:
+        conn.close()
+        raise ValueError(
+            "graph schema missing required tables: " + ", ".join(missing_tables)
+        )
+
+    try:
+        schema_row = conn.execute(
+            "SELECT value FROM graph_meta WHERE key = ?",
+            ("schema_version",),
+        ).fetchone()
+    except sqlite3.Error as exc:
+        conn.close()
+        raise ValueError(f"failed to read graph schema version: {db_file}: {exc}") from exc
+
+    if schema_row is None or schema_row[0] is None:
+        conn.close()
+        raise ValueError("graph schema missing required meta key: schema_version")
+
+    schema_version = str(schema_row[0]).strip()
+    if schema_version != str(GRAPH_SCHEMA_VERSION):
+        conn.close()
+        raise ValueError(
+            "graph schema version mismatch: "
+            f"expected {GRAPH_SCHEMA_VERSION}, got {schema_version or 'missing'}"
+        )
+
+    return conn
 
 
 _SCHEMA_SQL = """
@@ -33,6 +97,18 @@ CREATE TABLE IF NOT EXISTS graph_meta (
   key TEXT PRIMARY KEY,
   value TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS graph_refresh_receipts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  refreshed_at TEXT NOT NULL,
+  source_path TEXT NOT NULL,
+  topology_digest TEXT NOT NULL,
+  node_count INTEGER NOT NULL,
+  edge_count INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_graph_refresh_receipts_refreshed_at
+ON graph_refresh_receipts(refreshed_at DESC);
 """
 
 

--- a/openclaw_mem/optimization.py
+++ b/openclaw_mem/optimization.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Set
 
 from openclaw_mem import __version__
 from openclaw_mem.importance import is_parseable_importance, label_from_score, parse_importance_score
+from openclaw_mem.scope import normalize_scope_token as _normalize_scope_token
 
 
 _STOPWORDS: Set[str] = {
@@ -40,19 +41,6 @@ _STOPWORDS: Set[str] = {
 _WORD_TOKEN_RE = re.compile(r"[a-z0-9_]{3,}")
 _CJK_TOKEN_RE = re.compile(r"[\u4e00-\u9fff]{2,}")
 
-
-def _normalize_scope_token(raw: Any) -> Optional[str]:
-    if raw is None:
-        return None
-    token = str(raw).strip().lower()
-    if not token:
-        return None
-    token = re.sub(r"[\s]+", "-", token)
-    token = re.sub(r"[^a-z0-9._:/-]+", "-", token)
-    token = re.sub(r"-+", "-", token)
-    token = re.sub(r"^[-./:_]+", "", token)
-    token = re.sub(r"[-./:_]+$", "", token)
-    return token or None
 
 
 def _parse_iso_utc(ts: Any) -> Optional[datetime]:
@@ -124,6 +112,98 @@ def _preview(text: str, limit: int = 120) -> str:
     if len(t) <= limit:
         return t
     return t[: max(16, limit - 1)].rstrip() + "…"
+
+
+def _to_nonnegative_int(raw: Any) -> Optional[int]:
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, int):
+        return raw if raw >= 0 else None
+    if isinstance(raw, float) and raw.is_integer():
+        iv = int(raw)
+        return iv if iv >= 0 else None
+    if isinstance(raw, str):
+        s = raw.strip()
+        if not s:
+            return None
+        if re.fullmatch(r"\d+", s):
+            return int(s)
+    return None
+
+
+def _sum_nonnegative_int_values(raw: Any) -> Optional[int]:
+    if not isinstance(raw, dict):
+        return None
+    total = 0
+    seen = 0
+    for v in raw.values():
+        iv = _to_nonnegative_int(v)
+        if iv is None:
+            continue
+        total += iv
+        seen += 1
+    if seen == 0:
+        return None
+    return total
+
+
+def _extract_recall_result_count(detail_obj: Dict[str, Any]) -> Optional[int]:
+    for key in ("result_count", "results_count"):
+        iv = _to_nonnegative_int(detail_obj.get(key))
+        if iv is not None:
+            return iv
+
+    direct_results = detail_obj.get("results")
+    if isinstance(direct_results, list):
+        return len(direct_results)
+    iv = _to_nonnegative_int(direct_results)
+    if iv is not None:
+        return iv
+
+    details_obj = detail_obj.get("details")
+    if isinstance(details_obj, dict):
+        nested_results = details_obj.get("results")
+        if isinstance(nested_results, list):
+            return len(nested_results)
+        iv = _to_nonnegative_int(nested_results)
+        if iv is not None:
+            return iv
+
+    receipt = detail_obj.get("receipt")
+    if isinstance(receipt, dict):
+        lifecycle = receipt.get("lifecycle")
+        if isinstance(lifecycle, dict):
+            for key in ("selected_total", "selectedTotal", "result_count", "results_count"):
+                iv = _to_nonnegative_int(lifecycle.get(key))
+                if iv is not None:
+                    return iv
+
+            selected_counts = lifecycle.get("selected_counts")
+            iv = _sum_nonnegative_int_values(selected_counts)
+            if iv is not None:
+                return iv
+
+            selected_counts = lifecycle.get("selectedCounts")
+            iv = _sum_nonnegative_int_values(selected_counts)
+            if iv is not None:
+                return iv
+
+    return None
+
+
+def _extract_recall_query(detail_obj: Dict[str, Any]) -> Optional[str]:
+    candidates: List[Any] = [
+        detail_obj.get("query"),
+        (detail_obj.get("args") or {}).get("query") if isinstance(detail_obj.get("args"), dict) else None,
+        (detail_obj.get("input") or {}).get("query") if isinstance(detail_obj.get("input"), dict) else None,
+        (detail_obj.get("request") or {}).get("query") if isinstance(detail_obj.get("request"), dict) else None,
+    ]
+
+    for c in candidates:
+        q = _normalize_summary(c)
+        if len(q) >= 3:
+            return q
+    return None
 
 
 def _build_recommendations(report: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -200,6 +280,27 @@ def _build_recommendations(report: Dict[str, Any]) -> List[Dict[str, Any]]:
             }
         )
 
+    misses = report["signals"].get("repeated_misses", {})
+    if misses.get("groups", 0) > 0:
+        recs.append(
+            {
+                "type": "widen_scope_candidate",
+                "priority": "medium",
+                "confidence": 0.67,
+                "why": (
+                    f"{misses['groups']} repeated no-result memory_recall query patterns detected"
+                ),
+                "evidence": {
+                    "groups": misses["groups"],
+                    "miss_events": misses["miss_events"],
+                    "sample_queries": [it["query"] for it in misses["items"][:3]],
+                    "sample_ids": [it["latest_id"] for it in misses["items"][:5]],
+                },
+                "suggested_action": "Review scope/query constraints and capture missing canonical memory for high-repeat misses.",
+                "safe_for_auto_apply": False,
+            }
+        )
+
     return recs
 
 
@@ -212,6 +313,7 @@ def build_memory_health_review(
     bloat_summary_chars: int = 240,
     bloat_detail_bytes: int = 4096,
     orphan_min_tokens: int = 2,
+    miss_min_count: int = 2,
     top: int = 10,
     scope: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -221,6 +323,7 @@ def build_memory_health_review(
     bloat_summary_chars = max(80, int(bloat_summary_chars))
     bloat_detail_bytes = max(256, int(bloat_detail_bytes))
     orphan_min_tokens = max(1, int(orphan_min_tokens))
+    miss_min_count = max(2, int(miss_min_count))
     top = max(1, int(top))
     scope_norm = _normalize_scope_token(scope)
 
@@ -267,6 +370,10 @@ def build_memory_health_review(
         summary = _normalize_summary(r["summary_en"] or r["summary"] or "")
         detail_raw = r["detail_json"] or ""
         detail_obj = _parse_detail(detail_raw)
+        tool_name = str(r["tool_name"] or "")
+        tool_name_norm = tool_name.strip().lower()
+        recall_query = _extract_recall_query(detail_obj) if tool_name_norm == "memory_recall" else None
+        recall_result_count = _extract_recall_result_count(detail_obj) if tool_name_norm == "memory_recall" else None
         dt = _parse_iso_utc(r["ts"])
         age_days = None
         if dt is not None:
@@ -277,6 +384,7 @@ def build_memory_health_review(
             "ts": r["ts"],
             "kind": r["kind"],
             "tool_name": r["tool_name"],
+            "tool_name_norm": tool_name_norm,
             "summary": summary,
             "summary_preview": _preview(summary),
             "fingerprint": _fingerprint_summary(summary),
@@ -287,6 +395,8 @@ def build_memory_health_review(
             "summary_chars": len(summary),
             "scope": _normalize_scope_token(detail_obj.get("scope")),
             "importance": _importance_label(detail_obj),
+            "recall_query": recall_query,
+            "recall_result_count": recall_result_count,
         }
         item["token_count"] = len(item["tokens"])
         prepared.append(item)
@@ -397,6 +507,37 @@ def build_memory_health_review(
 
     weak_items.sort(key=lambda x: (x["token_count"], x["id"]), reverse=True)
 
+    # Repeated memory_recall misses (same normalized query + scope, no results)
+    miss_map: Dict[tuple[str, str], List[Dict[str, Any]]] = {}
+    for it in prepared:
+        if it["tool_name_norm"] != "memory_recall":
+            continue
+        if not it["recall_query"]:
+            continue
+        if it["recall_result_count"] is None or it["recall_result_count"] > 0:
+            continue
+        scope_key = it["scope"] or "__global__"
+        miss_map.setdefault((scope_key, it["recall_query"]), []).append(it)
+
+    repeated_miss_items: List[Dict[str, Any]] = []
+    repeated_miss_events = 0
+    for (scope_key, query), group in miss_map.items():
+        if len(group) < miss_min_count:
+            continue
+        ordered = sorted(group, key=lambda x: x["id"])
+        repeated_miss_events += len(ordered)
+        repeated_miss_items.append(
+            {
+                "scope": None if scope_key == "__global__" else scope_key,
+                "query": query,
+                "count": len(ordered),
+                "ids": [g["id"] for g in ordered],
+                "latest_id": ordered[-1]["id"],
+                "latest_ts": ordered[-1]["ts"],
+            }
+        )
+    repeated_miss_items.sort(key=lambda x: (x["count"], x["latest_id"], x["query"]), reverse=True)
+
     rows_scanned = len(prepared)
     coverage_pct = round((rows_scanned / total_rows) * 100, 1) if total_rows > 0 else 100.0
     warnings: List[Dict[str, Any]] = []
@@ -452,6 +593,13 @@ def build_memory_health_review(
                 "rare_token_max_freq": max_common_freq,
                 "items": weak_items[:top],
             },
+            "repeated_misses": {
+                "groups": len(repeated_miss_items),
+                "miss_events": repeated_miss_events,
+                "min_count": miss_min_count,
+                "tool_name": "memory_recall",
+                "items": repeated_miss_items[:top],
+            },
         },
         "policy": {
             "mode": "recommendation-first",
@@ -474,6 +622,7 @@ def render_memory_health_review(report: Dict[str, Any]) -> str:
     dup = sig.get("duplication", {})
     bloat = sig.get("bloat", {})
     weak = sig.get("weakly_connected", {})
+    misses = sig.get("repeated_misses", {})
 
     lines = [
         "openclaw-mem optimize review (recommendation-only)",
@@ -487,7 +636,8 @@ def render_memory_health_review(report: Dict[str, Any]) -> str:
             f"stale={stale.get('count', 0)} | "
             f"duplicates={dup.get('groups', 0)} groups ({dup.get('duplicate_rows', 0)} extra rows) | "
             f"bloat={bloat.get('count', 0)} | "
-            f"weakly_connected={weak.get('count', 0)}"
+            f"weakly_connected={weak.get('count', 0)} | "
+            f"repeated_misses={misses.get('groups', 0)} groups ({misses.get('miss_events', 0)} events)"
         ),
     ]
 

--- a/openclaw_mem/scope.py
+++ b/openclaw_mem/scope.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Any, Optional
+
+
+def normalize_scope_token(raw: Any) -> Optional[str]:
+    if raw is None:
+        return None
+    token = unicodedata.normalize("NFKC", str(raw)).strip().lower()
+    if not token:
+        return None
+    token = re.sub(r"[\s]+", "-", token)
+    token = re.sub(r"[^a-z0-9._:/-]+", "-", token)
+    token = re.sub(r"-+", "-", token)
+    token = re.sub(r"^[-./:_]+", "", token)
+    token = re.sub(r"[-./:_]+$", "", token)
+    return token or None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,6 +129,8 @@ class TestCliM0(unittest.TestCase):
         self.assertTrue(_summary_has_task_marker("‣ TODO buy milk"))
         self.assertTrue(_summary_has_task_marker("▪ TODO buy milk"))
         self.assertTrue(_summary_has_task_marker("◦ TODO buy milk"))
+        self.assertTrue(_summary_has_task_marker("● TODO buy milk"))
+        self.assertTrue(_summary_has_task_marker("○ TODO buy milk"))
         self.assertTrue(_summary_has_task_marker("∙ [ ] TASK: clean desk"))
         self.assertTrue(_summary_has_task_marker("· [x] [REMINDER] renew domain"))
         self.assertTrue(_summary_has_task_marker("- [✓] TODO buy milk"))
@@ -163,6 +165,8 @@ class TestCliM0(unittest.TestCase):
         self.assertTrue(_summary_has_task_marker("▪[x]TODO clean pipeline"))
         self.assertTrue(_summary_has_task_marker("·[ ]TASK sync branch"))
         self.assertTrue(_summary_has_task_marker("◦[x]TODO compact pipeline"))
+        self.assertTrue(_summary_has_task_marker("●[x]TODO compact pipeline"))
+        self.assertTrue(_summary_has_task_marker("○[x]TODO compact pipeline"))
         self.assertTrue(_summary_has_task_marker("- (I)[ ] TODO reorder docs"))
         self.assertTrue(_summary_has_task_marker(">>‣TODO audit logs"))
         self.assertTrue(_summary_has_task_marker("—TODO audit logs"))
@@ -218,6 +222,7 @@ class TestCliM0(unittest.TestCase):
         self.assertTrue(_summary_has_task_marker("[☒]TODO clean old notes"))
         self.assertTrue(_summary_has_task_marker("[✅]TODO clean old notes"))
         self.assertTrue(_summary_has_task_marker("(TASK)clean old notes"))
+        self.assertTrue(_summary_has_task_marker("〔REMINDER〕clean old notes"))
         self.assertTrue(_summary_has_task_marker("1.TODO clean old notes"))
         self.assertTrue(_summary_has_task_marker("1)TODO clean old notes"))
         self.assertTrue(_summary_has_task_marker("(1)TODO clean old notes"))
@@ -291,6 +296,12 @@ class TestCliM0(unittest.TestCase):
         self.assertEqual(a.cmd, "graph")
         self.assertEqual(a.graph_cmd, "export")
         self.assertEqual(a.query, "hello")
+
+        a = build_parser().parse_args(["graph", "query", "upstream", "artifact.daily-mission"])
+        self.assertEqual(a.cmd, "graph")
+        self.assertEqual(a.graph_cmd, "query")
+        self.assertEqual(a.graph_query_cmd, "upstream")
+        self.assertEqual(a.node_id, "artifact.daily-mission")
 
 
     def test_writeback_lancedb_parser_accepts_flags(self):
@@ -1630,6 +1641,67 @@ class TestCliM0(unittest.TestCase):
         out = json.loads(buf.getvalue())
         self.assertEqual(out["tasks"]["found_new"], 1)
         self.assertEqual(out["tasks"]["matches"][0]["summary"], "- [ ] TODO: rotate on-call notes")
+
+        conn.close()
+
+    def test_triage_tasks_accepts_emoji_checkbox_prefixed_task_marker(self):
+        import tempfile
+        from datetime import datetime, timezone
+
+        conn = _connect(":memory:")
+
+        now = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+        sample = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "ts": now,
+                        "kind": "note",
+                        "tool_name": "memory_store",
+                        "summary": "- [✅] TODO: rotate on-call notes",
+                        "detail": {"importance": 0.9},
+                    }
+                )
+            ]
+        )
+
+        old_stdin = sys.stdin
+        try:
+            sys.stdin = io.StringIO(sample)
+            args = type("Args", (), {"file": None, "json": True})()
+            with redirect_stdout(io.StringIO()):
+                cmd_ingest(conn, args)
+        finally:
+            sys.stdin = old_stdin
+
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", delete=False) as st:
+            state_path = st.name
+
+        args = type(
+            "Args",
+            (),
+            {
+                "mode": "tasks",
+                "since_minutes": 60,
+                "limit": 10,
+                "keywords": None,
+                "cron_jobs_path": None,
+                "tasks_since_minutes": 1440,
+                "importance_min": 0.7,
+                "state_path": state_path,
+                "json": True,
+            },
+        )()
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            with self.assertRaises(SystemExit) as cm:
+                cmd_triage(conn, args)
+
+        self.assertEqual(cm.exception.code, 10)
+        out = json.loads(buf.getvalue())
+        self.assertEqual(out["tasks"]["found_new"], 1)
+        self.assertEqual(out["tasks"]["matches"][0]["summary"], "- [✅] TODO: rotate on-call notes")
 
         conn.close()
 

--- a/tests/test_graph_drift.py
+++ b/tests/test_graph_drift.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+from openclaw_mem.graph.drift import query_drift
+from openclaw_mem.graph.refresh import refresh_topology
+
+
+class TestGraphDrift(unittest.TestCase):
+    def test_query_drift_detects_missing_runtime_only_and_non_ok(self) -> None:
+        topology = {
+            "nodes": [
+                {"id": "cron.job.alpha", "type": "cron_job"},
+                {"id": "cron.job.beta", "type": "cron_job"},
+                {"id": "artifact.daily-mission", "type": "artifact"},
+            ],
+            "edges": [],
+        }
+
+        runtime = {
+            "nodes": [
+                {"id": "cron.job.alpha", "status": "ok"},
+                {"id": "cron.job.beta", "status": "stale"},
+                {"id": "cron.job.beta", "status": "error"},
+                {"id": "cron.job.gamma", "status": "ok"},
+            ]
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "graph.db"
+            runtime_path = Path(td) / "runtime.json"
+            refresh_topology(topology, db_path=db_path)
+            runtime_path.write_text(json.dumps(runtime), encoding="utf-8")
+
+            out = query_drift(db_path=db_path, live_json_path=runtime_path)
+
+            self.assertTrue(out["ok"])
+            self.assertEqual(out["query"], "drift")
+            self.assertEqual(out["topology_node_count"], 3)
+            self.assertEqual(out["runtime_node_count"], 3)
+
+            self.assertEqual(out["missing_in_runtime"]["count"], 1)
+            self.assertEqual(out["missing_in_runtime"]["node_ids"], ["artifact.daily-mission"])
+
+            self.assertEqual(out["runtime_only"]["count"], 1)
+            self.assertEqual(out["runtime_only"]["node_ids"], ["cron.job.gamma"])
+
+            self.assertEqual(out["non_ok_nodes"]["count"], 1)
+            self.assertEqual(out["non_ok_nodes"]["items"][0]["node_id"], "cron.job.beta")
+            self.assertEqual(out["non_ok_nodes"]["items"][0]["status"], "error")
+
+            self.assertEqual(out["duplicate_runtime_ids"]["count"], 1)
+            self.assertEqual(out["duplicate_runtime_ids"]["node_ids"], ["cron.job.beta"])
+            self.assertEqual(out["status_counts"], {"error": 1, "ok": 2})
+
+    def test_query_drift_supports_status_map_and_limit(self) -> None:
+        topology = {
+            "nodes": [
+                {"id": "n1", "type": "node"},
+                {"id": "n2", "type": "node"},
+                {"id": "n3", "type": "node"},
+            ],
+            "edges": [],
+        }
+
+        runtime = {
+            "status_by_node": {
+                "n1": "ok",
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "graph.db"
+            runtime_path = Path(td) / "runtime.json"
+            refresh_topology(topology, db_path=db_path)
+            runtime_path.write_text(json.dumps(runtime), encoding="utf-8")
+
+            out = query_drift(db_path=db_path, live_json_path=runtime_path, limit=1)
+            self.assertEqual(out["missing_in_runtime"]["count"], 2)
+            self.assertEqual(len(out["missing_in_runtime"]["node_ids"]), 1)
+            self.assertTrue(out["missing_in_runtime"]["truncated"])
+
+    def test_query_drift_requires_graph_schema(self) -> None:
+        runtime = {"nodes": [{"id": "n1", "status": "ok"}]}
+
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "graph.db"
+            runtime_path = Path(td) / "runtime.json"
+            runtime_path.write_text(json.dumps(runtime), encoding="utf-8")
+
+            with self.assertRaises(ValueError) as ctx_missing:
+                query_drift(db_path=db_path, live_json_path=runtime_path)
+            self.assertIn("graph db not found", str(ctx_missing.exception))
+
+            sqlite3.connect(str(db_path)).close()
+            with self.assertRaises(ValueError) as ctx_schema:
+                query_drift(db_path=db_path, live_json_path=runtime_path)
+            self.assertIn("graph schema missing required tables", str(ctx_schema.exception))
+
+    def test_query_drift_rejects_limit_above_cap(self) -> None:
+        topology = {
+            "nodes": [
+                {"id": "n1", "type": "node"},
+            ],
+            "edges": [],
+        }
+        runtime = {"nodes": [{"id": "n1", "status": "ok"}]}
+
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "graph.db"
+            runtime_path = Path(td) / "runtime.json"
+            refresh_topology(topology, db_path=db_path)
+            runtime_path.write_text(json.dumps(runtime), encoding="utf-8")
+
+            with self.assertRaises(ValueError) as ctx:
+                query_drift(db_path=db_path, live_json_path=runtime_path, limit=201)
+            self.assertIn("limit must be <= 200", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_graph_query.py
+++ b/tests/test_graph_query.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 import tempfile
 import unittest
 from pathlib import Path
@@ -8,6 +9,8 @@ from openclaw_mem.graph.query import (
     query_downstream,
     query_filter_nodes,
     query_lineage,
+    query_provenance,
+    query_refresh_receipts,
     query_upstream,
     query_writers,
 )
@@ -100,6 +103,349 @@ class TestGraphQuery(unittest.TestCase):
             self.assertEqual(lineage["downstream_count"], 0)
             self.assertEqual(lineage["upstream"][0]["provenance"], "docs/topology.yaml#L31")
             self.assertEqual(lineage["upstream"][0]["metadata"], {"lane": "A-deep"})
+
+    def test_query_provenance_groups_and_filters_edges(self) -> None:
+        topology = {
+            "nodes": [
+                {"id": "cron.job.alpha", "type": "cron_job"},
+                {"id": "cron.job.beta", "type": "cron_job"},
+                {"id": "artifact.daily-mission", "type": "artifact"},
+                {"id": "artifact.alert", "type": "artifact"},
+            ],
+            "edges": [
+                {
+                    "src": "cron.job.alpha",
+                    "dst": "artifact.daily-mission",
+                    "type": "writes",
+                    "provenance": "docs/topology.yaml#L10",
+                },
+                {
+                    "src": "cron.job.beta",
+                    "dst": "artifact.daily-mission",
+                    "type": "writes",
+                    "provenance": "docs/topology.yaml#L10",
+                },
+                {
+                    "src": "cron.job.beta",
+                    "dst": "artifact.alert",
+                    "type": "alerts_to",
+                    "provenance": "docs/topology.yaml#L14",
+                },
+                {
+                    "src": "cron.job.alpha",
+                    "dst": "artifact.alert",
+                    "type": "alerts_to",
+                    "provenance": "",
+                },
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "graph.db"
+            refresh_topology(topology, db_path=db_path)
+
+            out = query_provenance(db_path=db_path, limit=10)
+            self.assertTrue(out["ok"])
+            self.assertEqual(out["query"], "provenance")
+            self.assertEqual(out["total_distinct"], 2)
+            self.assertEqual(out["count"], 2)
+            self.assertEqual(out["items"][0]["provenance"], "docs/topology.yaml#L10")
+            self.assertEqual(out["items"][0]["edge_count"], 2)
+            self.assertEqual(
+                out["items"][0]["edge_types"],
+                [{"edge_type": "writes", "edge_count": 2}],
+            )
+
+            filtered = query_provenance(
+                db_path=db_path,
+                node_id="artifact.daily-mission",
+                edge_type="writes",
+                limit=10,
+            )
+            self.assertEqual(filtered["total_distinct"], 1)
+            self.assertEqual(filtered["count"], 1)
+            self.assertEqual(filtered["items"][0]["edge_count"], 2)
+            self.assertEqual(
+                filtered["items"][0]["edge_types"],
+                [{"edge_type": "writes", "edge_count": 2}],
+            )
+
+    def test_query_provenance_ignores_whitespace_and_supports_min_edge_count(self) -> None:
+        topology = {
+            "nodes": [
+                {"id": "cron.job.alpha", "type": "cron_job"},
+                {"id": "cron.job.beta", "type": "cron_job"},
+                {"id": "cron.job.gamma", "type": "cron_job"},
+                {"id": "artifact.daily-mission", "type": "artifact"},
+            ],
+            "edges": [
+                {
+                    "src": "cron.job.alpha",
+                    "dst": "artifact.daily-mission",
+                    "type": "writes",
+                    "provenance": "docs/topology.yaml#L10",
+                },
+                {
+                    "src": "cron.job.beta",
+                    "dst": "artifact.daily-mission",
+                    "type": "alerts_to",
+                    "provenance": "docs/topology.yaml#L20",
+                },
+                {
+                    "src": "cron.job.gamma",
+                    "dst": "artifact.daily-mission",
+                    "type": "feeds",
+                    "provenance": "docs/topology.yaml#L20",
+                },
+                {
+                    "src": "cron.job.alpha",
+                    "dst": "artifact.daily-mission",
+                    "type": "blocks",
+                    "provenance": "   ",
+                },
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "graph.db"
+            refresh_topology(topology, db_path=db_path)
+
+            out = query_provenance(db_path=db_path, min_edge_count=2, limit=10)
+            self.assertTrue(out["ok"])
+            self.assertEqual(out["total_distinct"], 1)
+            self.assertEqual(out["count"], 1)
+            self.assertEqual(out["filters"]["min_edge_count"], 2)
+            self.assertEqual(out["items"][0]["provenance"], "docs/topology.yaml#L20")
+            self.assertEqual(out["items"][0]["edge_count"], 2)
+            self.assertEqual(
+                out["items"][0]["edge_types"],
+                [
+                    {"edge_type": "alerts_to", "edge_count": 1},
+                    {"edge_type": "feeds", "edge_count": 1},
+                ],
+            )
+
+            broad = query_provenance(db_path=db_path, min_edge_count=1, limit=10)
+            self.assertEqual(broad["total_distinct"], 2)
+            self.assertEqual(broad["count"], 2)
+            self.assertEqual(
+                [item["provenance"] for item in broad["items"]],
+                ["docs/topology.yaml#L20", "docs/topology.yaml#L10"],
+            )
+
+    def test_query_provenance_rejects_invalid_min_edge_count(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "graph.db"
+            refresh_topology({"nodes": [], "edges": []}, db_path=db_path)
+
+            with self.assertRaises(ValueError) as ctx:
+                query_provenance(db_path=db_path, min_edge_count=0)
+            self.assertIn("min_edge_count must be > 0", str(ctx.exception))
+
+    def test_query_refresh_receipts_returns_recent_runs(self) -> None:
+        topology = {
+            "nodes": [
+                {"id": "cron.job.alpha", "type": "cron_job", "tags": ["background"]},
+                {"id": "artifact.receipt", "type": "artifact"},
+            ],
+            "edges": [
+                {
+                    "src": "cron.job.alpha",
+                    "dst": "artifact.receipt",
+                    "type": "writes",
+                    "provenance": "docs/topology.yaml#L31",
+                },
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "graph.db"
+            refresh_topology(topology, db_path=db_path, source_path="docs/topology-a.yaml")
+            refresh_topology(topology, db_path=db_path, source_path="docs/topology-b.yaml")
+
+            out = query_refresh_receipts(db_path=db_path, limit=1)
+            self.assertTrue(out["ok"])
+            self.assertEqual(out["query"], "receipts")
+            self.assertEqual(out["count"], 1)
+            self.assertEqual(out["total_count"], 2)
+            self.assertEqual(len(out["receipts"]), 1)
+            self.assertEqual(out["receipts"][0]["source_path"], "docs/topology-b.yaml")
+            self.assertEqual(out["receipts"][0]["node_count"], 2)
+            self.assertEqual(out["receipts"][0]["edge_count"], 1)
+
+    def test_query_refresh_receipts_supports_source_and_digest_filters(self) -> None:
+        topology_a = {
+            "nodes": [
+                {"id": "cron.job.alpha", "type": "cron_job"},
+                {"id": "artifact.receipt", "type": "artifact"},
+            ],
+            "edges": [
+                {
+                    "src": "cron.job.alpha",
+                    "dst": "artifact.receipt",
+                    "type": "writes",
+                    "provenance": "docs/topology-a.yaml#L10",
+                },
+            ],
+        }
+        topology_b = {
+            "nodes": [
+                {"id": "cron.job.beta", "type": "cron_job"},
+                {"id": "artifact.receipt", "type": "artifact"},
+            ],
+            "edges": [
+                {
+                    "src": "cron.job.beta",
+                    "dst": "artifact.receipt",
+                    "type": "alerts_to",
+                    "provenance": "docs/topology-b.yaml#L20",
+                },
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "graph.db"
+            out_a = refresh_topology(topology_a, db_path=db_path, source_path="docs/topology-a.yaml")
+            out_b = refresh_topology(topology_b, db_path=db_path, source_path="docs/topology-b.yaml")
+            refresh_topology(topology_a, db_path=db_path, source_path="docs/topology-a-v2.yaml")
+
+            filtered_source = query_refresh_receipts(
+                db_path=db_path,
+                source_path="docs/topology-a.yaml",
+                limit=10,
+            )
+            self.assertTrue(filtered_source["ok"])
+            self.assertEqual(filtered_source["count"], 1)
+            self.assertEqual(filtered_source["total_count"], 1)
+            self.assertEqual(filtered_source["filters"]["source_path"], "docs/topology-a.yaml")
+            self.assertEqual(filtered_source["receipts"][0]["topology_digest"], out_a["topology_digest"])
+
+            filtered_digest = query_refresh_receipts(
+                db_path=db_path,
+                topology_digest=out_b["topology_digest"],
+                limit=10,
+            )
+            self.assertEqual(filtered_digest["count"], 1)
+            self.assertEqual(filtered_digest["total_count"], 1)
+            self.assertEqual(filtered_digest["filters"]["topology_digest"], out_b["topology_digest"])
+            self.assertEqual(filtered_digest["receipts"][0]["source_path"], "docs/topology-b.yaml")
+
+    def test_queries_require_existing_graph_db(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "missing.db"
+
+            with self.assertRaises(ValueError) as ctx:
+                query_upstream(db_path=db_path, node_id="artifact.daily-mission")
+            self.assertIn("graph db not found", str(ctx.exception))
+
+    def test_queries_reject_db_without_graph_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "graph.db"
+            sqlite3.connect(str(db_path)).close()
+
+            with self.assertRaises(ValueError) as ctx:
+                query_refresh_receipts(db_path=db_path, limit=1)
+            self.assertIn("graph schema missing required tables", str(ctx.exception))
+
+    def test_queries_reject_db_with_missing_schema_version_meta(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "graph.db"
+            refresh_topology({"nodes": [], "edges": []}, db_path=db_path)
+
+            conn = sqlite3.connect(str(db_path))
+            try:
+                with conn:
+                    conn.execute("DELETE FROM graph_meta WHERE key = ?", ("schema_version",))
+            finally:
+                conn.close()
+
+            with self.assertRaises(ValueError) as ctx:
+                query_refresh_receipts(db_path=db_path, limit=1)
+            self.assertIn("graph schema missing required meta key: schema_version", str(ctx.exception))
+
+    def test_queries_reject_db_with_mismatched_schema_version_meta(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "graph.db"
+            refresh_topology({"nodes": [], "edges": []}, db_path=db_path)
+
+            conn = sqlite3.connect(str(db_path))
+            try:
+                with conn:
+                    conn.execute(
+                        "INSERT INTO graph_meta(key, value) VALUES (?, ?) "
+                        "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+                        ("schema_version", "999"),
+                    )
+            finally:
+                conn.close()
+
+            with self.assertRaises(ValueError) as ctx:
+                query_refresh_receipts(db_path=db_path, limit=1)
+            self.assertIn("graph schema version mismatch", str(ctx.exception))
+
+    def test_query_provenance_rejects_limit_above_cap(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "graph.db"
+            refresh_topology({"nodes": [], "edges": []}, db_path=db_path)
+
+            with self.assertRaises(ValueError) as ctx:
+                query_provenance(db_path=db_path, limit=201)
+            self.assertIn("limit must be <= 200", str(ctx.exception))
+
+    def test_query_refresh_receipts_rejects_limit_above_cap(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "graph.db"
+            refresh_topology({"nodes": [], "edges": []}, db_path=db_path)
+
+            with self.assertRaises(ValueError) as ctx:
+                query_refresh_receipts(db_path=db_path, limit=201)
+            self.assertIn("limit must be <= 200", str(ctx.exception))
+
+    def test_queries_tolerate_malformed_persisted_json(self) -> None:
+        topology = {
+            "nodes": [
+                {"id": "cron.job.alpha", "type": "cron_job", "tags": ["background"]},
+                {"id": "artifact.receipt", "type": "artifact"},
+            ],
+            "edges": [
+                {
+                    "src": "cron.job.alpha",
+                    "dst": "artifact.receipt",
+                    "type": "writes",
+                    "provenance": "docs/topology.yaml#L40",
+                    "metadata": {"lane": "A-deep"},
+                },
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "graph.db"
+            refresh_topology(topology, db_path=db_path)
+
+            conn = sqlite3.connect(str(db_path))
+            try:
+                with conn:
+                    conn.execute(
+                        "UPDATE graph_nodes SET tags_json = ?, metadata_json = ? WHERE node_id = ?",
+                        ('{"bad":"shape"}', '["not-an-object"]', "cron.job.alpha"),
+                    )
+                    conn.execute(
+                        "UPDATE graph_edges SET metadata_json = ? WHERE src_id = ? AND dst_id = ? AND edge_type = ?",
+                        ('["not-an-object"]', "cron.job.alpha", "artifact.receipt", "writes"),
+                    )
+            finally:
+                conn.close()
+
+            filtered = query_filter_nodes(db_path=db_path, node_type="cron_job")
+            self.assertTrue(filtered["ok"])
+            self.assertEqual(filtered["count"], 1)
+            self.assertEqual(filtered["nodes"][0]["tags"], [])
+            self.assertEqual(filtered["nodes"][0]["metadata"], {})
+
+            lineage = query_lineage(db_path=db_path, node_id="artifact.receipt")
+            self.assertTrue(lineage["ok"])
+            self.assertEqual(lineage["upstream_count"], 1)
+            self.assertEqual(lineage["upstream"][0]["metadata"], {})
 
 
 if __name__ == "__main__":

--- a/tests/test_graph_query_cli.py
+++ b/tests/test_graph_query_cli.py
@@ -1,0 +1,355 @@
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from openclaw_mem.cli import _connect, cmd_graph_query
+from openclaw_mem.graph.refresh import refresh_topology
+
+
+class TestGraphQueryCli(unittest.TestCase):
+    def test_cmd_graph_query_upstream_json_payload(self) -> None:
+        topology = {
+            "nodes": [
+                {"id": "project.finlife", "type": "project"},
+                {"id": "cron.job.alpha", "type": "cron_job", "tags": ["background"]},
+                {"id": "cron.job.beta", "type": "cron_job", "tags": ["background", "human_facing"]},
+                {"id": "artifact.daily-mission", "type": "artifact", "tags": ["deliverable"]},
+            ],
+            "edges": [
+                {"src": "project.finlife", "dst": "cron.job.alpha", "type": "depends_on", "provenance": "docs/topology.yaml#L10"},
+                {"src": "cron.job.alpha", "dst": "artifact.daily-mission", "type": "writes", "provenance": "docs/topology.yaml#L20"},
+                {"src": "cron.job.beta", "dst": "artifact.daily-mission", "type": "alerts_to", "provenance": "docs/topology.yaml#L21"},
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "mem.sqlite"
+            conn = _connect(str(db_path))
+            refresh_topology(topology, db_path=db_path)
+
+            args = type(
+                "Args",
+                (),
+                {
+                    "graph_query_cmd": "upstream",
+                    "db": str(db_path),
+                    "node_id": "artifact.daily-mission",
+                    "json": True,
+                },
+            )()
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                cmd_graph_query(conn, args)
+
+            out = json.loads(buf.getvalue())
+            self.assertEqual(out["kind"], "openclaw-mem.graph.query.v0")
+            self.assertEqual(out["query_cmd"], "upstream")
+            self.assertEqual(out["result"]["count"], 2)
+            self.assertEqual(out["result"]["edges"][0]["src"], "cron.job.alpha")
+            self.assertEqual(out["result"]["edges"][1]["src"], "cron.job.beta")
+            conn.close()
+
+    def test_cmd_graph_query_filter_json_payload(self) -> None:
+        topology = {
+            "nodes": [
+                {"id": "cron.job.alpha", "type": "cron_job", "tags": ["background"]},
+                {"id": "cron.job.beta", "type": "cron_job", "tags": ["background", "human_facing"]},
+                {"id": "artifact.receipt", "type": "artifact"},
+            ],
+            "edges": [],
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "mem.sqlite"
+            conn = _connect(str(db_path))
+            refresh_topology(topology, db_path=db_path)
+
+            args = type(
+                "Args",
+                (),
+                {
+                    "graph_query_cmd": "filter",
+                    "db": str(db_path),
+                    "tag": "background",
+                    "not_tag": "human_facing",
+                    "node_type": "cron_job",
+                    "json": True,
+                },
+            )()
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                cmd_graph_query(conn, args)
+
+            out = json.loads(buf.getvalue())
+            self.assertEqual(out["query_cmd"], "filter")
+            self.assertEqual(out["result"]["count"], 1)
+            self.assertEqual(out["result"]["nodes"][0]["id"], "cron.job.alpha")
+            conn.close()
+
+    def test_cmd_graph_query_receipts_json_payload(self) -> None:
+        topology = {
+            "nodes": [
+                {"id": "cron.job.alpha", "type": "cron_job"},
+                {"id": "artifact.receipt", "type": "artifact"},
+            ],
+            "edges": [
+                {
+                    "src": "cron.job.alpha",
+                    "dst": "artifact.receipt",
+                    "type": "writes",
+                    "provenance": "docs/topology.yaml#L42",
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "mem.sqlite"
+            conn = _connect(str(db_path))
+            refresh_topology(topology, db_path=db_path, source_path="docs/topology.yaml")
+
+            args = type(
+                "Args",
+                (),
+                {
+                    "graph_query_cmd": "receipts",
+                    "db": str(db_path),
+                    "limit": 5,
+                    "json": True,
+                },
+            )()
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                cmd_graph_query(conn, args)
+
+            out = json.loads(buf.getvalue())
+            self.assertEqual(out["query_cmd"], "receipts")
+            self.assertEqual(out["result"]["count"], 1)
+            self.assertEqual(out["result"]["receipts"][0]["source_path"], "docs/topology.yaml")
+            conn.close()
+
+    def test_cmd_graph_query_receipts_supports_source_filter(self) -> None:
+        topology_a = {
+            "nodes": [
+                {"id": "cron.job.alpha", "type": "cron_job"},
+                {"id": "artifact.receipt", "type": "artifact"},
+            ],
+            "edges": [
+                {
+                    "src": "cron.job.alpha",
+                    "dst": "artifact.receipt",
+                    "type": "writes",
+                    "provenance": "docs/topology-a.yaml#L42",
+                }
+            ],
+        }
+        topology_b = {
+            "nodes": [
+                {"id": "cron.job.beta", "type": "cron_job"},
+                {"id": "artifact.receipt", "type": "artifact"},
+            ],
+            "edges": [
+                {
+                    "src": "cron.job.beta",
+                    "dst": "artifact.receipt",
+                    "type": "alerts_to",
+                    "provenance": "docs/topology-b.yaml#L48",
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "mem.sqlite"
+            conn = _connect(str(db_path))
+            refresh_topology(topology_a, db_path=db_path, source_path="docs/topology-a.yaml")
+            refresh_topology(topology_b, db_path=db_path, source_path="docs/topology-b.yaml")
+
+            args = type(
+                "Args",
+                (),
+                {
+                    "graph_query_cmd": "receipts",
+                    "db": str(db_path),
+                    "limit": 10,
+                    "source_path": "docs/topology-a.yaml",
+                    "topology_digest": None,
+                    "json": True,
+                },
+            )()
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                cmd_graph_query(conn, args)
+
+            out = json.loads(buf.getvalue())
+            self.assertEqual(out["query_cmd"], "receipts")
+            self.assertEqual(out["result"]["count"], 1)
+            self.assertEqual(out["result"]["total_count"], 1)
+            self.assertEqual(out["result"]["receipts"][0]["source_path"], "docs/topology-a.yaml")
+            conn.close()
+
+    def test_cmd_graph_query_provenance_json_payload(self) -> None:
+        topology = {
+            "nodes": [
+                {"id": "cron.job.alpha", "type": "cron_job"},
+                {"id": "cron.job.beta", "type": "cron_job"},
+                {"id": "artifact.receipt", "type": "artifact"},
+            ],
+            "edges": [
+                {
+                    "src": "cron.job.alpha",
+                    "dst": "artifact.receipt",
+                    "type": "writes",
+                    "provenance": "docs/topology.yaml#L42",
+                },
+                {
+                    "src": "cron.job.beta",
+                    "dst": "artifact.receipt",
+                    "type": "writes",
+                    "provenance": "docs/topology.yaml#L42",
+                },
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "mem.sqlite"
+            conn = _connect(str(db_path))
+            refresh_topology(topology, db_path=db_path)
+
+            args = type(
+                "Args",
+                (),
+                {
+                    "graph_query_cmd": "provenance",
+                    "db": str(db_path),
+                    "node_id": "artifact.receipt",
+                    "edge_type": "writes",
+                    "min_edge_count": 2,
+                    "limit": 10,
+                    "json": True,
+                },
+            )()
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                cmd_graph_query(conn, args)
+
+            out = json.loads(buf.getvalue())
+            self.assertEqual(out["query_cmd"], "provenance")
+            self.assertEqual(out["result"]["total_distinct"], 1)
+            self.assertEqual(out["result"]["count"], 1)
+            self.assertEqual(out["result"]["filters"]["min_edge_count"], 2)
+            self.assertEqual(out["result"]["items"][0]["edge_count"], 2)
+            self.assertEqual(
+                out["result"]["items"][0]["edge_types"],
+                [{"edge_type": "writes", "edge_count": 2}],
+            )
+            conn.close()
+
+    def test_cmd_graph_query_provenance_plaintext_includes_edge_types(self) -> None:
+        topology = {
+            "nodes": [
+                {"id": "cron.job.alpha", "type": "cron_job"},
+                {"id": "cron.job.beta", "type": "cron_job"},
+                {"id": "artifact.receipt", "type": "artifact"},
+            ],
+            "edges": [
+                {
+                    "src": "cron.job.alpha",
+                    "dst": "artifact.receipt",
+                    "type": "writes",
+                    "provenance": "docs/topology.yaml#L42",
+                },
+                {
+                    "src": "cron.job.beta",
+                    "dst": "artifact.receipt",
+                    "type": "alerts_to",
+                    "provenance": "docs/topology.yaml#L42",
+                },
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "mem.sqlite"
+            conn = _connect(str(db_path))
+            refresh_topology(topology, db_path=db_path)
+
+            args = type(
+                "Args",
+                (),
+                {
+                    "graph_query_cmd": "provenance",
+                    "db": str(db_path),
+                    "node_id": None,
+                    "edge_type": None,
+                    "min_edge_count": 1,
+                    "limit": 10,
+                    "json": False,
+                },
+            )()
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                cmd_graph_query(conn, args)
+
+            text = buf.getvalue()
+            self.assertIn("count=1 total_distinct=1", text)
+            self.assertIn("docs/topology.yaml#L42 edges=2", text)
+            self.assertIn("edge_types=alerts_to:1,writes:1", text)
+            conn.close()
+
+    def test_cmd_graph_query_drift_json_payload(self) -> None:
+        topology = {
+            "nodes": [
+                {"id": "cron.job.alpha", "type": "cron_job"},
+                {"id": "cron.job.beta", "type": "cron_job"},
+            ],
+            "edges": [],
+        }
+        runtime = {
+            "nodes": [
+                {"id": "cron.job.alpha", "status": "ok"},
+                {"id": "cron.job.beta", "status": "stale"},
+                {"id": "cron.job.gamma", "status": "ok"},
+            ]
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "mem.sqlite"
+            runtime_path = Path(td) / "runtime.json"
+            runtime_path.write_text(json.dumps(runtime), encoding="utf-8")
+
+            conn = _connect(str(db_path))
+            refresh_topology(topology, db_path=db_path)
+
+            args = type(
+                "Args",
+                (),
+                {
+                    "graph_query_cmd": "drift",
+                    "db": str(db_path),
+                    "live_json": str(runtime_path),
+                    "limit": 20,
+                    "json": True,
+                },
+            )()
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                cmd_graph_query(conn, args)
+
+            out = json.loads(buf.getvalue())
+            self.assertEqual(out["query_cmd"], "drift")
+            self.assertEqual(out["result"]["missing_in_runtime"]["count"], 0)
+            self.assertEqual(out["result"]["runtime_only"]["count"], 1)
+            self.assertEqual(out["result"]["non_ok_nodes"]["count"], 1)
+            conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_graph_refresh.py
+++ b/tests/test_graph_refresh.py
@@ -45,6 +45,10 @@ class TestGraphRefresh(unittest.TestCase):
                 digest = conn.execute(
                     "SELECT value FROM graph_meta WHERE key='topology_digest'"
                 ).fetchone()[0]
+                receipt_count = conn.execute("SELECT COUNT(*) FROM graph_refresh_receipts").fetchone()[0]
+                latest_receipt = conn.execute(
+                    "SELECT topology_digest, node_count, edge_count FROM graph_refresh_receipts ORDER BY id DESC LIMIT 1"
+                ).fetchone()
             finally:
                 conn.close()
 
@@ -52,6 +56,11 @@ class TestGraphRefresh(unittest.TestCase):
             self.assertEqual(edge_count, 1)
             self.assertEqual(schema_version, "1")
             self.assertEqual(digest, out["topology_digest"])
+            self.assertEqual(receipt_count, 1)
+            assert latest_receipt is not None
+            self.assertEqual(latest_receipt[0], out["topology_digest"])
+            self.assertEqual(int(latest_receipt[1]), 2)
+            self.assertEqual(int(latest_receipt[2]), 1)
 
     def test_refresh_topology_is_deterministic_for_reordered_input(self) -> None:
         topology_a = {
@@ -91,6 +100,13 @@ class TestGraphRefresh(unittest.TestCase):
             out_b = refresh_topology(topology_b, db_path=db_path)
 
             self.assertEqual(out_a["topology_digest"], out_b["topology_digest"])
+
+            conn = sqlite3.connect(str(db_path))
+            try:
+                receipt_count = conn.execute("SELECT COUNT(*) FROM graph_refresh_receipts").fetchone()[0]
+            finally:
+                conn.close()
+            self.assertEqual(receipt_count, 2)
 
     def test_refresh_topology_file_json(self) -> None:
         topology = {

--- a/tests/test_optimize_review.py
+++ b/tests/test_optimize_review.py
@@ -5,6 +5,7 @@ from contextlib import redirect_stdout
 from datetime import datetime, timedelta, timezone
 
 from openclaw_mem.cli import _connect, _insert_observation, build_parser, cmd_optimize_review
+from openclaw_mem.optimization import _extract_recall_result_count
 
 
 def _iso_days_ago(days: int) -> str:
@@ -33,6 +34,8 @@ class TestOptimizeReview(unittest.TestCase):
                 "9000",
                 "--orphan-min-tokens",
                 "4",
+                "--miss-min-count",
+                "5",
                 "--scope",
                 "finlife/mvp",
                 "--top",
@@ -48,6 +51,7 @@ class TestOptimizeReview(unittest.TestCase):
         self.assertEqual(args.bloat_summary_chars, 320)
         self.assertEqual(args.bloat_detail_bytes, 9000)
         self.assertEqual(args.orphan_min_tokens, 4)
+        self.assertEqual(args.miss_min_count, 5)
         self.assertEqual(args.scope, "finlife/mvp")
         self.assertEqual(args.top, 7)
 
@@ -164,6 +168,108 @@ class TestOptimizeReview(unittest.TestCase):
 
         conn.close()
 
+    def test_optimize_review_reports_repeated_memory_recall_misses(self):
+        conn = _connect(":memory:")
+
+        _insert_observation(
+            conn,
+            {
+                "ts": _iso_days_ago(1),
+                "kind": "tool",
+                "tool_name": "memory_recall",
+                "summary": "memory recall miss 1",
+                "detail": {"scope": "alpha", "query": "Cache Invalidation Policy", "results": []},
+            },
+        )
+        _insert_observation(
+            conn,
+            {
+                "ts": _iso_days_ago(1),
+                "kind": "tool",
+                "tool_name": "memory_recall",
+                "summary": "memory recall miss 2",
+                "detail": {"scope": "alpha", "query": "cache invalidation policy", "results": 0},
+            },
+        )
+        _insert_observation(
+            conn,
+            {
+                "ts": _iso_days_ago(1),
+                "kind": "tool",
+                "tool_name": "memory_recall",
+                "summary": "memory recall successful",
+                "detail": {"scope": "alpha", "query": "cache invalidation policy", "results": [{"id": "x"}]},
+            },
+        )
+        _insert_observation(
+            conn,
+            {
+                "ts": _iso_days_ago(1),
+                "kind": "tool",
+                "tool_name": "memory_recall",
+                "summary": "memory recall miss beta",
+                "detail": {"scope": "beta", "query": "cache invalidation policy", "results": 0},
+            },
+        )
+        conn.commit()
+
+        args = type(
+            "Args",
+            (),
+            {
+                "limit": 1000,
+                "stale_days": 60,
+                "duplicate_min_count": 2,
+                "bloat_summary_chars": 240,
+                "bloat_detail_bytes": 4096,
+                "orphan_min_tokens": 2,
+                "miss_min_count": 2,
+                "scope": None,
+                "top": 10,
+                "json": True,
+            },
+        )()
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cmd_optimize_review(conn, args)
+
+        out = json.loads(buf.getvalue())
+        misses = out["signals"]["repeated_misses"]
+        self.assertEqual(misses["groups"], 1)
+        self.assertEqual(misses["miss_events"], 2)
+        self.assertEqual(misses["min_count"], 2)
+        self.assertEqual(misses["items"][0]["scope"], "alpha")
+        self.assertEqual(misses["items"][0]["query"], "cache invalidation policy")
+        self.assertEqual(misses["items"][0]["count"], 2)
+
+        rec_types = {r["type"] for r in out.get("recommendations", [])}
+        self.assertIn("widen_scope_candidate", rec_types)
+        self.assertEqual(out["policy"]["writes_performed"], 0)
+
+        conn.close()
+
+    def test_extract_recall_result_count_supports_common_schema_variants(self):
+        cases = [
+            ({"result_count": 3}, 3),
+            ({"results_count": "4"}, 4),
+            ({"results": [{"id": "a"}, {"id": "b"}]}, 2),
+            ({"results": 0}, 0),
+            ({"details": {"results": [{"id": "x"}]}}, 1),
+            ({"details": {"results": "5"}}, 5),
+            ({"receipt": {"lifecycle": {"selected_total": 6}}}, 6),
+            ({"receipt": {"lifecycle": {"selectedTotal": "7"}}}, 7),
+            ({"receipt": {"lifecycle": {"selected_counts": {"must": 2, "nice": 1}}}}, 3),
+            ({"receipt": {"lifecycle": {"selectedCounts": {"must": "2", "nice": 3}}}}, 5),
+            ({"results": True}, None),
+            ({"details": {"results": -1}}, None),
+            ({"receipt": {"lifecycle": {"selected_counts": {"must": "x"}}}}, None),
+        ]
+
+        for detail_obj, expected in cases:
+            with self.subTest(detail_obj=detail_obj):
+                self.assertEqual(_extract_recall_result_count(detail_obj), expected)
+
     def test_optimize_review_reports_sampling_warning_when_limit_is_partial(self):
         conn = _connect(":memory:")
         for i in range(5):
@@ -189,6 +295,7 @@ class TestOptimizeReview(unittest.TestCase):
                 "bloat_summary_chars": 240,
                 "bloat_detail_bytes": 4096,
                 "orphan_min_tokens": 2,
+                "miss_min_count": 2,
                 "top": 10,
                 "json": True,
             },
@@ -205,6 +312,61 @@ class TestOptimizeReview(unittest.TestCase):
         self.assertEqual(out["warnings"][0]["code"], "sample_is_recent_window")
         self.assertEqual(out["policy"]["writes_performed"], 0)
         self.assertEqual(conn.execute("PRAGMA query_only").fetchone()[0], 0)
+
+        conn.close()
+
+
+    def test_optimize_review_respects_miss_min_count_threshold(self):
+        conn = _connect(":memory:")
+
+        _insert_observation(
+            conn,
+            {
+                "ts": _iso_days_ago(1),
+                "kind": "tool",
+                "tool_name": "memory_recall",
+                "summary": "memory recall miss 1",
+                "detail": {"scope": "alpha", "query": "cache invalidation policy", "results": []},
+            },
+        )
+        _insert_observation(
+            conn,
+            {
+                "ts": _iso_days_ago(1),
+                "kind": "tool",
+                "tool_name": "memory_recall",
+                "summary": "memory recall miss 2",
+                "detail": {"scope": "alpha", "query": "cache invalidation policy", "results": 0},
+            },
+        )
+        conn.commit()
+
+        args = type(
+            "Args",
+            (),
+            {
+                "limit": 1000,
+                "stale_days": 60,
+                "duplicate_min_count": 2,
+                "bloat_summary_chars": 240,
+                "bloat_detail_bytes": 4096,
+                "orphan_min_tokens": 2,
+                "miss_min_count": 3,
+                "scope": None,
+                "top": 10,
+                "json": True,
+            },
+        )()
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cmd_optimize_review(conn, args)
+
+        out = json.loads(buf.getvalue())
+        self.assertEqual(out["signals"]["repeated_misses"]["groups"], 0)
+        self.assertEqual(out["signals"]["repeated_misses"]["miss_events"], 0)
+        rec_types = {r["type"] for r in out.get("recommendations", [])}
+        self.assertNotIn("widen_scope_candidate", rec_types)
 
         conn.close()
 

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -1,0 +1,68 @@
+import json
+import sqlite3
+import unittest
+
+from openclaw_mem.cli import _extract_writeback_updates, _normalize_episodic_scope
+from openclaw_mem.optimization import _normalize_scope_token as _optimize_scope_norm
+from openclaw_mem.scope import normalize_scope_token
+
+
+class TestScopeNormalization(unittest.TestCase):
+    def test_shared_scope_normalizer_slugifies_and_trims(self):
+        self.assertEqual(normalize_scope_token("  FinLife MVP  "), "finlife-mvp")
+        self.assertEqual(normalize_scope_token("proj/a_b.c:dev"), "proj/a_b.c:dev")
+        self.assertEqual(normalize_scope_token("中文 Scope"), "scope")
+        self.assertIsNone(normalize_scope_token("///"))
+        self.assertIsNone(normalize_scope_token(None))
+
+    def test_cli_and_optimization_use_same_scope_normalization(self):
+        raw = "  Team/Project Alpha  "
+        self.assertEqual(_normalize_episodic_scope(raw), "team/project-alpha")
+        self.assertEqual(_optimize_scope_norm(raw), "team/project-alpha")
+
+    def test_scope_normalizer_nfkc_normalizes_full_width_tokens(self):
+        raw = "  Ｔｅａｍ／Ｐｒｏｊｅｃｔ　Ａｌｐｈａ  "
+        self.assertEqual(normalize_scope_token(raw), "team/project-alpha")
+        self.assertEqual(_normalize_episodic_scope(raw), "team/project-alpha")
+        self.assertEqual(_optimize_scope_norm(raw), "team/project-alpha")
+
+    def test_cli_scope_validation_rejects_empty_after_normalization(self):
+        with self.assertRaises(ValueError):
+            _normalize_episodic_scope("...///")
+
+    def _make_writeback_row(self, *, detail_obj, kind="note"):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute(
+            "CREATE TABLE obs (kind TEXT, summary TEXT, summary_en TEXT, detail_json TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO obs(kind, summary, summary_en, detail_json) VALUES (?, ?, ?, ?)",
+            (kind, "", "", json.dumps(detail_obj, ensure_ascii=False)),
+        )
+        row = conn.execute("SELECT kind, summary, summary_en, detail_json FROM obs").fetchone()
+        self.assertIsNotNone(row)
+        conn.close()
+        return row
+
+    def test_writeback_scope_uses_shared_normalization(self):
+        row = self._make_writeback_row(
+            detail_obj={
+                "memory_id": "123e4567-e89b-12d3-a456-426614174000",
+                "scope": "  ＦｉｎＬｉｆｅ／ＭＶＰ  ",
+            }
+        )
+
+        packed = _extract_writeback_updates(row)
+        self.assertIsNotNone(packed)
+        self.assertEqual(packed["updates"].get("scope"), "finlife/mvp")
+
+    def test_writeback_scope_falls_back_to_normalized_kind(self):
+        row = self._make_writeback_row(
+            detail_obj={"memory_id": "123e4567-e89b-12d3-a456-426614174000"},
+            kind="Decision Note",
+        )
+
+        packed = _extract_writeback_updates(row)
+        self.assertIsNotNone(packed)
+        self.assertEqual(packed["updates"].get("scope"), "decision-note")


### PR DESCRIPTION
## Summary
- reconcile the current `origin/dev -> origin/main` release-train failure
- resolve the only content conflicts in `README.md` and `CHANGELOG.md`
- preserve both sides' relevant content while keeping the merge minimal

## Why
The release train was blocked by a true merge conflict, not branch policy or CI.
This PR carries the smallest rollbackable reconciliation branch so normal checks can run on GitHub.

## Conflict resolution
- `README.md`: kept the quick-proof timeline command
- `CHANGELOG.md`: kept the provenance/query-receipts additions from `dev`

## Local validation
- `uv lock --check`
- `uv sync --locked`
- `uv run -- python -m unittest discover -s tests -p 'test_*.py'`
- `uv run --with build -- python -m build`
