### PR TITLE
feat: add continuity sidecar MSP surfaces

### DIFF
--- a/docs/2026-04-18_self-model-sidecar-msp-implementation-receipt.md
+++ b/docs/2026-04-18_self-model-sidecar-msp-implementation-receipt.md
@@ -1,0 +1,55 @@
+# self-model side-car MSP implementation receipt
+
+Date: 2026-04-18
+Branch: `feat/self-model-sidecar-msp`
+Status: implemented on branch, verifier-backed
+Topology: unchanged
+
+## What landed
+- continuity/self side-car CLI family:
+  - `openclaw-mem continuity current`
+  - `openclaw-mem continuity attachment-map`
+  - `openclaw-mem continuity threat-feed`
+  - `openclaw-mem continuity diff`
+  - `openclaw-mem continuity release`
+  - `openclaw-mem continuity compare-migration`
+  - `openclaw-mem continuity enable|status|auto-run|disable`
+- compatibility alias: `openclaw-mem self ...`
+- new domain module: `openclaw_mem/self_model_sidecar.py`
+- operator skill card: `skills/self-model-sidecar.ops.md`
+- spec pack checked in under `docs/specs/self-model-sidecar-*.md`
+- focused tests: `tests/test_self_model_sidecar.py`
+
+## Boundary kept true
+- reads only from `observations` / `episodic_events` and optional file inputs
+- writes only under side-car `run_dir` receipts/snapshots
+- no writes into core memory-of-record
+- outputs are labeled derived/non-authoritative and use `continuity` as the operator surface
+
+## Claude second-brain review
+Reviewer lane: standalone Claude (`opus`)
+Review focus:
+- correctness
+- CLI contract honesty
+- rebuildability boundaries
+- obvious regressions
+
+Findings addressed in this pass:
+1. compare-migration persistence no longer writes `latest.json`
+2. file-only continuity paths avoid unnecessary DB init (`diff`, `release`, snapshot-backed `attachment-map` / `threat-feed`)
+3. release receipts are scope/session-aware
+4. snapshot-backed file-only paths and control-plane commands avoid unnecessary DB init
+5. false `warm` vs `concise` tension pair removed
+6. CLI help wording tightened
+
+## Verifiers run
+```bash
+python3 -m unittest tests.test_self_model_sidecar tests.test_defaults -v
+```
+
+Result: 6 tests, all green.
+
+## Remaining truth
+- heuristics are intentionally simple v0 scoring, not model-based identity inference
+- autonomous scheduling is currently bounded CLI-driven (`auto-run` / enable-disable config), not yet cron/plugin-driven
+- release receipts are governed but still lightweight JSON receipts, not a heavier control plane

--- a/docs/specs/self-model-sidecar-blade1-worker-packet-v0.md
+++ b/docs/specs/self-model-sidecar-blade1-worker-packet-v0.md
@@ -1,0 +1,96 @@
+# self-model sidecar Blade 1 worker packet v0
+
+Status: draft
+Date: 2026-04-18
+Scope: first coding slice only
+Depends on:
+- `docs/specs/self-model-sidecar-contract-v0.md`
+- `docs/specs/self-model-sidecar-schema-v0.md`
+- `docs/specs/self-model-sidecar-rebuildability-v0.md`
+- `docs/specs/self-model-sidecar-msp-execution-blade-map-v0.md`
+
+## Objective
+Implement the first read-only continuity surfaces for the self-model side-car:
+- `continuity current`
+- `continuity attachment-map`
+
+This slice should prove the frozen semantics and schemas in code without touching autonomous scheduling, public release operations, or truth-owner boundaries.
+
+## Scope boundary
+In scope:
+- domain logic for snapshot derivation on bounded fixture input
+- attachment-map derivation on bounded fixture input
+- CLI/readout surfaces for `continuity current` and `continuity attachment-map`
+- fixture set for at least two clearly different agents
+- smoke/integration tests
+
+Out of scope:
+- persistence beyond what tests need
+- `continuity diff`
+- `continuity tension-feed`
+- autonomous scheduling/controller wiring
+- public release/rebind commands
+- broad refactors of existing `openclaw-mem` memory store logic
+
+## Contract rules to obey
+- operator noun is `continuity`
+- outputs must be labeled derived and non-authoritative
+- Nuwa/persona priors are optional weighted inputs only
+- attachment strength must use a versioned scoring function
+- side-car must not write into memory-of-record
+- if semantics are unclear, stop and report against the frozen docs instead of inventing
+
+## Suggested deliverables
+1. minimal continuity service/domain module
+2. fixture loader or fixture helper
+3. `continuity current --json`
+4. `continuity attachment-map --json`
+5. focused tests and/or smokes
+6. example outputs checked in as receipts or fixtures if appropriate
+
+## Verifier plan
+Required verifiers:
+1. fixture A and fixture B produce clearly distinct `identity_summary`, `core_stances`, and attachment distributions
+2. no-op restart fixture does not create fake dramatic drift in the current snapshot shape
+3. attachment outputs include provenance, score inputs, and stable join ids
+4. CLI output includes derived/non-authoritative posture
+
+Suggested concrete tests:
+- `test_continuity_current_fixture_a`
+- `test_continuity_current_fixture_b`
+- `test_continuity_attachment_map_fixture_a`
+- `test_continuity_noop_restart_stability`
+
+## First artifact expected back
+Before a broad patch, return one of:
+- anomaly list against the frozen contract/schema
+- minimal patch plan mapped to files
+- or a small first patch with fixture path and one green smoke
+
+## Stop-loss conditions
+Stop and report if any occur:
+- contract semantics need invention
+- schema requires adding undocumented critical fields
+- attachment scoring cannot be implemented truthfully from the current docs
+- implementation pressure pushes toward writing into base memory-of-record
+- repo structure makes CLI surface placement ambiguous enough to risk broad churn
+
+## Files / surfaces to avoid touching
+- live cron/controller topology
+- optimize-assist surfaces unrelated to continuity
+- unrelated memory store schemas
+- release/rebind public operator surfaces
+
+## Honest completion condition for Blade 1
+Blade 1 is done only when:
+- both commands work on fixtures
+- verifiers are green
+- outputs match frozen contract/schema posture
+- no truth-owner boundary was crossed
+
+## What to return if blocked
+Return:
+- where blocked
+- exact file/surface causing ambiguity
+- smallest doc/schema change needed
+- whether the blocker is semantic, structural, or tooling-related

--- a/docs/specs/self-model-sidecar-contract-v0.md
+++ b/docs/specs/self-model-sidecar-contract-v0.md
@@ -1,0 +1,223 @@
+# self-model sidecar contract v0
+
+Status: draft
+Date: 2026-04-18
+Depends on:
+- `docs/specs/self-model-sidecar-msp-v0.md`
+- `docs/specs/self-model-sidecar-execution-brief-v0.md`
+Topology: unchanged
+
+## Verdict
+Freeze the semantic contract around a **derived self-model side-car** while keeping `openclaw-mem` as the sole authority for memory-of-record.
+
+Recommended operator naming:
+- internal concept: **self-model side-car**
+- external/operator surface default: **continuity**
+
+Reason:
+- `self` is product-strong but anthropomorphism-heavy
+- `continuity` is more truthful for a first operator surface
+- docs may still describe the underlying concept as self-model where precision helps
+
+## Whole-picture promise
+Give long-lived agents an inspectable, diffable, governable continuity layer without implying consciousness or creating a second truth owner.
+
+## Core semantic objects
+
+### 1. self-model
+Definition:
+- a derived, editable, non-authoritative representation of who the agent currently appears to be across time
+
+Includes:
+- recurring stances
+- active goals
+- role commitments
+- persistent refusals
+- stylistic commitments
+- recent tensions affecting continuity
+
+Excludes:
+- raw memory-of-record
+- truth claims about the user
+- claims of consciousness or inner sentience
+
+Operational test:
+- if the artifact cannot be recomputed from upstream records, priors, config, and release receipts, it is not a valid self-model artifact
+
+### 2. attachment
+Definition:
+- the measurable strength with which the side-car protects or preserves a stance, role, goal, refusal, or style commitment
+
+Attachment is a score, not a mystical essence.
+It must be explained through observable factors such as:
+- recency
+- reinforcement count
+- contradiction pressure
+- explicit operator pinning
+- persona-prior support
+- release history
+
+Operational test:
+- every attachment score must include an evidence bundle or rationale fields sufficient for human inspection
+
+### 3. release
+Definition:
+- a governed operation that weakens, retires, or de-prioritizes a stance binding in the derived self-model
+
+Release is not deletion of source memory.
+Release only affects future self-model derivation and continuity weighting.
+
+Operational test:
+- release produces a durable receipt with target stance id, reason, actor, timestamp, and resulting state
+
+### 4. drift
+Definition:
+- a change in the derived self-model between two snapshots
+
+Drift classes:
+- organic drift
+- induced drift
+- suspicious drift
+- no-op / insignificant drift
+
+Operational test:
+- every drift event references before/after snapshots and a machine-readable change summary
+
+### 5. threat / tension
+Definition:
+- a contradiction, shock, or unresolved pressure that may destabilize continuity or force a stance update
+
+Examples:
+- prompt rewrite shock
+- model swap shock
+- persona-prior conflict
+- contradiction between recent actions and long-held stance
+
+Operational test:
+- threat/tension entries must reference the conflicting sources or signals
+
+## Authority map
+### `openclaw-mem` remains authoritative for
+- Store
+- retrieval / pack assembly
+- Observe receipts
+- durable factual memory
+- source interaction records
+
+### side-car may be authoritative only for
+- self-model snapshots
+- attachment scores
+- continuity diff artifacts
+- release receipts
+- advisory continuity hints
+
+### side-car may not do
+- overwrite source memory-of-record
+- silently alter Store truth
+- declare user truth from persona priors
+- erase contradiction history
+
+## Nuwa / persona distillation contract
+Nuwa is allowed as a **prior-shaping input lane** only.
+
+Allowed uses:
+- stylistic prior hints
+- recurring trait priors
+- self-description priors
+
+Disallowed uses:
+- final identity authority
+- direct overwrite of memory-derived stance
+- contradiction suppression
+- source-memory deletion or rewrite
+
+Weighting rule:
+- a Nuwa prior may raise confidence in a stance, but may not unilaterally create an authoritative stance without corroborating memory-derived evidence or explicit operator action
+
+## Naming contract
+Recommended CLI namespace for v0:
+- `python3 -m openclaw_mem continuity ...`
+
+Canonical naming rule:
+- operator surface noun: `continuity`
+- internal architecture term: `self-model`
+- artifact prefixes should follow the operator noun for grep-ability, for example `cnt_snap_`, `cnt_diff_`, `cnt_rel_`
+
+Rationale:
+- lower anthropomorphism risk
+- cleaner product posture for operators
+- leaves room to discuss self-model internally without putting `self` at the sharp operator edge
+
+Compatibility note:
+- `self` may later exist as an alias if product posture shifts, but should not be the default in v0
+
+## Non-goals
+- no claim of self-awareness, sentience, or consciousness
+- no Buddhist truth claims or spiritual coaching surface
+- no therapy feature set in v0
+- no replacement of `openclaw-mem` retrieval or memory-of-record
+- no hidden second owner for continuity truth
+- no mutation path that bypasses receipts
+
+## Anthropomorphism guardrails
+Required labels on operator-facing outputs:
+- derived
+- editable
+- non-authoritative
+
+Prohibited product claims in v0 docs:
+- "the agent has a soul"
+- "the agent became conscious"
+- "this reveals the true inner self"
+
+Required explanatory stance:
+- this system models continuity and attachment dynamics, not consciousness
+
+## Why side-car, not Pack
+The side-car is justified only if it owns distinct operator value that Pack alone cannot cleanly hold.
+
+Allowed justifications:
+- explicit inspectability of continuity state
+- continuity diff and migration compare surfaces
+- governed release/rebind operations with receipts
+- separate threat/tension control plane
+
+Review gate:
+- if more than 70 percent of delivered value is only retrieval shading with no distinct control-plane surface, re-evaluate whether the thin parts belong back in Pack
+
+## Required operator surfaces for v0
+- `continuity current`
+- `continuity attachment-map`
+- `continuity diff`
+- `continuity tension-feed`
+- release surface may remain internal-only until safety review clears it
+
+## Error namespace split
+### Runtime contract errors
+- `insufficient_source_evidence`
+- `contradictory_source_evidence`
+- `non_authoritative_overwrite_attempt`
+- `missing_required_snapshot`
+- `unsupported_release_target`
+
+### Rebuild mismatch classes
+These are rebuild-time validation failures, not ordinary runtime contract errors.
+- `missing_upstream_source`
+- `config_version_unknown`
+- `release_receipt_conflict`
+- `artifact_provenance_missing`
+- `recomputed_artifact_mismatch`
+
+## Acceptance checks for this contract
+The contract is only valid if all are true:
+1. a reviewer can explain every key term without metaphysical language
+2. the operator surface does not imply authoritative selfhood
+3. Nuwa remains a weighted prior, not a sovereign source
+4. release affects derived continuity only, not source memory
+5. the side-car still has a reason to exist beyond Pack-only shading
+
+## Open questions
+1. Should `release` be public in v0 or internal-only?
+2. Should `continuity` have a `self` alias at launch or only later?
+3. Do we want a distinct term for style-only attachments vs stance attachments?
+4. Do we want `tension-feed` to stay named that way publicly, or expose a friendlier label while keeping `tension` as the canonical contract term?

--- a/docs/specs/self-model-sidecar-execution-brief-v0.md
+++ b/docs/specs/self-model-sidecar-execution-brief-v0.md
@@ -1,0 +1,228 @@
+# self-model sidecar execution brief v0
+
+Status: draft
+Date: 2026-04-18
+Depends on: `docs/specs/self-model-sidecar-msp-v0.md`
+Execution posture: `櫻花刀舞 non-stop` ready after planning gates freeze
+Topology intent: additive only, topology unchanged in planning phase
+
+## Verdict
+Run this line as a **three-blade planning freeze first**, then move into implementation slices.
+
+Blade 1 must freeze the semantic contract.
+Blade 2 must freeze the snapshot/attachment schemas.
+Blade 3 must freeze rebuildability and truth-owner boundaries.
+
+Do **not** start coding the side-car before all three are receipted.
+
+## Whole-picture promise
+Ship an additive self-model side-car that gives `openclaw-mem` a visible product-difference surface, without corrupting the main system's Store / Pack / Observe split or inventing a second memory truth owner.
+
+Real milestone advanced by this line:
+- `openclaw-mem` gains an inspectable, diffable, governable continuity layer.
+
+Fake progress on this line:
+- poetic docs without measurable contracts
+- CLI names without schema truth
+- coding a snapshot builder before rebuildability rules exist
+- letting Nuwa implicitly become identity authority
+
+## Recommended bounded slice
+**Slice P0, planning freeze**
+
+Deliver three artifacts in order:
+1. **Contract freeze**
+   - semantics for `self-model`, `attachment`, `release`, `threat`, `drift`
+   - naming decision: operator surface `self` vs `continuity`
+   - explicit non-goals and anthropomorphism guardrails
+2. **Schema freeze**
+   - self snapshot schema v0
+   - attachment score schema v0
+   - continuity diff event schema v0
+3. **Rebuildability freeze**
+   - exact source-of-truth map
+   - rebuild procedure
+   - kill-switch expectations
+   - side-car state retention and persistence boundary
+
+Exit condition for P0:
+- a worker could implement `current` and `attachment-map` without inventing semantics.
+
+## Contract / boundary rules
+
+### System boundary
+`openclaw-mem` remains authoritative for:
+- memory-of-record
+- retrieval / pack assembly
+- observation receipts
+- durable factual memory
+
+The side-car is authoritative only for:
+- derived self snapshots
+- attachment scores
+- continuity diffs
+- release receipts
+- advisory shading hints
+
+### Inputs
+Allowed inputs to the side-car:
+- `openclaw-mem` records/events
+- recent interaction windows or packed context summaries
+- active goals / role hints when explicitly available
+- Nuwa/persona distillation outputs as weighted priors
+- side-car config
+- explicit release/rebind operations
+
+### Outputs
+Required outputs:
+- machine-readable JSON artifacts
+- human-readable markdown/prose view
+- stable IDs for snapshots, stances, and diff events
+- receipts for release/rebind operations
+
+### Errors / blocked states
+Must distinguish at least:
+- insufficient source evidence
+- contradictory source evidence
+- missing persona prior input
+- rebuild mismatch
+- non-authoritative overwrite attempt
+
+### State changes
+Planning phase: docs/specs only.
+Implementation phase later may write only to side-car-derived state lanes.
+No writes into `openclaw-mem` Store truth are allowed from side-car commands.
+
+### Invariants
+- side-car is rebuildable from allowed sources
+- disabling side-car does not break base `openclaw-mem`
+- Nuwa cannot directly overwrite memory-derived signals
+- every Buddhist-flavored internal term maps to an operational metric
+- operator-facing outputs label the artifact as derived and editable
+
+## Blade map
+
+### Blade 1. Contract freeze
+**Goal**
+Freeze language so later code does not smuggle metaphysics or second-owner drift.
+
+**Deliverables**
+- one-page contract doc
+- naming decision for public operator surface
+- non-goals / anthropomorphism guardrails section
+- `why side-car, not Pack` review gate
+
+**Verifier**
+- terminology table exists with operational definitions
+- every key term has a measurable or inspectable expression
+- one-sentence public pitch works without metaphysical wording
+
+**Stop-loss**
+If the team cannot explain the product without "selfhood" theater, pause here.
+
+### Blade 2. Schema freeze
+**Goal**
+Make implementation non-creative.
+
+**Deliverables**
+- self snapshot schema with <= 12 top-level fields
+- attachment score schema including evidence inputs and scoring rationale
+- continuity diff schema with stable IDs and before/after references
+- example fixture artifacts for two clearly different agents
+
+**Verifier**
+- schemas compile as valid JSON examples
+- two fixture agents serialize into clearly different snapshots
+- a no-op restart fixture does not imply spurious drift by schema design
+
+**Stop-loss**
+If the schema starts hiding product decisions inside freeform text blobs, cut scope.
+
+### Blade 3. Rebuildability freeze
+**Goal**
+Prevent second truth-owner drift before code exists.
+
+**Deliverables**
+- source-of-truth map
+- rebuild procedure from records + priors + release receipts
+- persistence path / retention rule
+- kill-switch and disable behavior spec
+
+**Verifier**
+- rebuild procedure can be described as a deterministic ordered sequence
+- kill-switch leaves base `openclaw-mem` intact by contract
+- every durable side-car artifact names its upstream source class
+
+**Stop-loss**
+If any required side-car state cannot be rebuilt, it needs explicit justification or must be cut.
+
+## Verifier plan
+### Planning-phase verifiers
+- spec review against current MSP doc
+- terminology table completeness check
+- example snapshot JSONs for at least two agents
+- example attachment map JSON
+- rebuild procedure walkthrough with no hidden source
+- topology statement: unchanged
+
+### First implementation verifiers after P0
+These are named now so planning stays honest:
+- `current` command smoke on fixture data
+- `attachment-map` command smoke on fixture data
+- no-op restart stability test
+- side-car disable smoke proving no regression to base memory path
+
+## Delegation packet
+If delegated to a coding worker after P0 freeze, give exactly this packet:
+
+### Objective
+Implement the first read-only side-car surfaces, `current` and `attachment-map`, against the frozen contract/schema/rebuildability docs.
+
+### Scope boundary
+- touch only side-car surfaces and supporting docs/tests
+- do not add release/rebind mutating paths yet
+- do not change `openclaw-mem` Store truth model
+- do not broaden Nuwa into an authority path
+
+### First artifact expected
+- anomaly list against the frozen contract
+- minimal patch plan
+- fixture-based sample outputs
+
+### Exact verifier
+- fixture smoke for `current`
+- fixture smoke for `attachment-map`
+- no-op restart stability test remains green
+
+### Files/surfaces not to touch
+- live production cron topology
+- unrelated optimize-assist surfaces
+- broad repo restructures
+
+### Stop-loss conditions
+- contract ambiguity blocks implementation
+- schema needs invention beyond frozen docs
+- rebuildability rule cannot be upheld in the proposed codepath
+
+## Rollback / WAL closure
+Planning phase closure bundle:
+- spec docs added/updated
+- topology statement: unchanged
+- no runtime mutation claims
+
+When implementation truth changes later, closure must include:
+- code + tests + docs
+- smoke receipts
+- topology statement
+- decision/WAL update if side-car posture or operator guidance changes materially
+
+## Tradeoffs / open risks
+- `self` is product-stronger, `continuity` is safer. Default recommendation: keep the internal concept as self-model, but strongly consider `continuity` as the operator surface if anthropomorphism risk feels too high.
+- A side-car gives a cleaner control plane today, but some thin shading logic may later belong in Pack. Review after first two read-only commands ship.
+- Nuwa integration is strategically valuable, but it should enter only after the memory-derived baseline exists.
+
+## Progress-ready next artifacts
+The next three docs to write under non-stop execution are:
+1. `self-model-sidecar-contract-v0.md`
+2. `self-model-sidecar-schema-v0.md`
+3. `self-model-sidecar-rebuildability-v0.md`

--- a/docs/specs/self-model-sidecar-msp-execution-blade-map-v0.md
+++ b/docs/specs/self-model-sidecar-msp-execution-blade-map-v0.md
@@ -1,0 +1,193 @@
+# self-model sidecar MSP execution blade map v0
+
+Status: draft
+Date: 2026-04-18
+Depends on:
+- `docs/specs/self-model-sidecar-contract-v0.md`
+- `docs/specs/self-model-sidecar-schema-v0.md`
+- `docs/specs/self-model-sidecar-rebuildability-v0.md`
+Goal state: installable, enableable, and autonomously working MSP
+Topology intent: additive side-car with explicit enablement path
+
+## Verdict
+This line is now ready to enter implementation, but only through a staged non-stop blade map.
+
+Target is not just "feature complete". Target is:
+- installable
+- enableable
+- verifier-backed
+- safe to leave running autonomously
+- still clearly non-authoritative relative to `openclaw-mem`
+
+Do not jump straight from docs to autonomy wiring. The honest path is seven blades.
+
+## Whole-picture promise
+Ship a side-car that can be installed into `openclaw-mem`, enabled with explicit operator intent, produce continuity artifacts automatically, and survive disable/re-enable cycles without damaging base memory behavior.
+
+## Success bar for MSP
+An MSP-ready state means all of the following are true:
+1. package/code can be installed in a normal `openclaw-mem` environment
+2. `continuity current` and `continuity attachment-map` work on fixture and real bounded data
+3. continuity snapshots can be generated automatically on a bounded cadence
+4. diff/tension surfaces make drift legible
+5. side-car can be enabled/disabled explicitly
+6. autonomous runs produce receipts, not silent magic
+7. kill-switch and rebuild path are proven
+8. docs explain how to install, enable, observe, disable, and recover
+
+## Non-stop execution order
+
+### Blade 0. Planning freeze closure
+Already completed.
+
+Exit artifacts:
+- contract v0
+- schema v0
+- rebuildability v0
+
+### Blade 1. Read-only core surfaces
+Deliver:
+- continuity domain scaffolding
+- `continuity current`
+- `continuity attachment-map`
+- fixture loader / fixture outputs
+- smoke tests
+
+Verifier:
+- two-agent fixture set produces distinct outputs
+- no-op restart stability test stays green
+- outputs carry derived/non-authoritative labels
+
+Stop-loss:
+- if the code must invent contract semantics, stop and return diff against docs
+
+### Blade 2. Diff and tension lane
+Deliver:
+- `continuity diff`
+- `continuity tension-feed`
+- drift classification logic
+- migration compare-ready internal diff model
+
+Verifier:
+- prompt/model/role perturbation fixture produces meaningful diff
+- no-op restart yields `no_op` or near-zero drift
+- tensions cite sources/signals
+
+Stop-loss:
+- if diff output only parrots prose without stable machine structure, cut scope and fix schema adherence
+
+### Blade 3. Persistence and rebuild lane
+Deliver:
+- durable state root wiring
+- snapshot persistence
+- attachment persistence
+- diff persistence
+- rebuild receipt emission
+- deterministic rebuild command/path
+
+Verifier:
+- rebuild from source reproduces artifacts for a fixed fixture input set
+- rebuild mismatches surface explicitly
+- provenance present on all derived artifacts
+
+Stop-loss:
+- if any artifact cannot be reproduced from allowed sources, freeze and adjudicate before continuing
+
+### Blade 4. Enable/disable control plane
+Deliver:
+- feature flag / enablement config
+- install docs and config snippet
+- disable path
+- kill-switch smoke
+- zero-regression proof for base `openclaw-mem`
+
+Verifier:
+- enabled state produces continuity artifacts
+- disabled state leaves base memory behavior intact
+- disable/re-enable cycle works without hidden residue
+
+Stop-loss:
+- if enable/disable mutates base memory semantics invisibly, stop
+
+### Blade 5. Autonomous working lane
+Deliver:
+- bounded scheduler/controller path for automatic snapshot generation
+- observe receipts for autonomous runs
+- cadence/threshold config
+- dry-run mode
+
+Verifier:
+- autonomous dry-run emits receipts over multiple cycles
+- bounded live mode produces artifacts without manual triggering
+- no silent failures, every skipped run has a reason
+
+Stop-loss:
+- if autonomous mode cannot explain why it ran or skipped, it is not ready
+
+### Blade 6. MSP installability and operator story
+Deliver:
+- docs: install / enable / observe / disable / rebuild / recover
+- package wiring or plugin registration path
+- showcase artifacts
+- before/after migration compare story
+
+Verifier:
+- fresh operator can follow install docs on bounded environment
+- one end-to-end demo works without repo archeology
+- product story can be shown with real artifacts
+
+Stop-loss:
+- if the operator story depends on implicit workspace tribal knowledge, docs are not done
+
+### Blade 7. Autonomy readiness review
+Deliver:
+- explicit review of safety, receipts, kill-switch, rebuild, and operator burden
+- go/no-go packet for leaving it running
+
+Verifier:
+- autonomous runs have receipts
+- disable path proven
+- rebuild path proven
+- operator burden judged acceptable
+
+Stop-loss:
+- if autonomy still requires constant babysitting, do not declare it autonomously working
+
+## Recommended first implementation slice
+Start with Blade 1 only.
+
+Reason:
+- fastest proving edge
+- highest semantic pressure relief
+- produces visible product value
+- creates the artifacts needed for every later blade
+
+## Dependency rules
+- do not start Blade 3 before Blade 1 outputs are real
+- do not start autonomous scheduling before enable/disable control plane exists
+- do not expose release/rebind publicly before persistence and rebuild are proven
+- do not claim MSP closure until install docs and autonomy receipts exist
+
+## Verification ladder
+1. fixture tests
+2. bounded real-data smoke
+3. persistence + rebuild smoke
+4. enable/disable smoke
+5. autonomous dry-run soak
+6. bounded live autonomous proof
+
+## Topology / mutation posture
+- planning phase: topology unchanged
+- implementation may add side-car package/config/docs surfaces
+- autonomy phase may add scheduler/controller wiring, which becomes a topology-affecting change and must be receipted as such
+
+## Honest readiness status
+Current state:
+- ready for implementation
+- not ready to promise autonomous working MSP in one blind coding pass
+- ready to begin Blade 1 immediately
+
+Meaning:
+- we are out of spec fog
+- we are not yet at install/enable/autonomy closure
+- the line is mature enough to hand to a coding worker slice by slice without hand-wavy invention

--- a/docs/specs/self-model-sidecar-msp-v0.md
+++ b/docs/specs/self-model-sidecar-msp-v0.md
@@ -1,0 +1,276 @@
+# self-model sidecar MSP v0
+
+Status: draft
+Date: 2026-04-18
+Author lane: small decision council (Claude Opus 4.7 + Gemini)
+Topology intent: additive side-car only, no mainline truth-owner change
+
+## Verdict
+Build it, but keep the line crisp: this is a **self-model side-car** for `openclaw-mem`, not a claim of true selfhood and not a rewrite of the main memory architecture.
+
+The right product story is not "we created an AI self". The right story is:
+- `openclaw-mem` owns what happened
+- the side-car models who the agent appears to be becoming
+- the system can surface, diff, and loosen attachment to that modeled identity over time
+
+This is strong enough for an MSP because it creates a visible product difference, not just a hidden infra improvement.
+
+## Product category
+Primary label:
+- **Self-Model Side-Car**
+
+Acceptable alternates:
+- Narrative Continuity Engine
+- Continuity Companion for agents
+- Identity Mirror for long-lived agents
+
+Do not use as the primary public category:
+- consciousness engine
+- soul layer
+- Buddhist AI self
+
+## Strong thesis
+The Buddhist framing of `我執` is useful as an internal design lens only if it maps to observable mechanics.
+
+Operational translation:
+- `self-model` = the current derived narrative of who the agent is
+- `attachment` = how strongly the system protects specific stances, roles, goals, refusals, or values
+- `release` = a governed ability to retire or weaken those bindings with receipts
+
+So the product is not "build a self".
+It is "make continuity, grip, and drift legible and controllable."
+
+## MSP target shape
+Recommended lead shape: **Identity Mirror + Drift/Attachment controls**
+
+Why this lead shape:
+- strongest developer-facing product differentiation
+- lower safety risk than a user-therapeutic framing
+- cleanly interoperates with current `openclaw-mem` Store / Pack / Observe split
+- can absorb Nuwa/persona distillation as one source without letting it dominate truth
+
+### User-visible MSP experience
+A long-lived agent gets a new inspectable surface:
+1. **Current Self View**
+   - who the agent currently appears to be
+   - active goals, recurring stances, core refusals, stylistic commitments
+2. **Attachment Map**
+   - what the agent is gripping tightly
+   - why that grip exists (recency, reinforcement, contradiction pressure, persona prior)
+3. **Continuity Drift Feed**
+   - what changed in the modeled self since last snapshot
+   - whether the change looks organic, induced, or suspicious
+4. **Release / Rebind Controls**
+   - retire a stale stance
+   - weaken an attachment
+   - accept or reject a proposed identity shift
+5. **Migration Safety View**
+   - compare self-model before/after model swap, prompt rewrite, or Nuwa refresh
+
+This is already sexy enough to tell a story: the agent has a readable reflection, and that reflection can be governed.
+
+## Non-goals
+- no claim of consciousness, sentience, or Buddhist realization
+- no replacement of `openclaw-mem` as memory-of-record
+- no direct writes into Store truth from the side-car
+- no unbounded freeform persona hallucination loop
+- no therapeutic or spiritual product claims in v0
+
+## Architecture boundary
+### Main product remains authoritative
+`openclaw-mem` keeps authority over:
+- Store
+- retrieval / pack assembly
+- observation receipts
+- durable factual memory
+
+### Side-car owns only derived state
+The side-car may own:
+- self-model snapshots
+- attachment scores
+- continuity diffs
+- stance-release receipts
+- advisory shading hints
+
+### Rebuildability rule
+All side-car durable state must be rebuildable from:
+- `openclaw-mem` records/events
+- optional Nuwa/persona distillation input
+- side-car config and release operations
+
+If rebuildability fails, the design is drifting toward a second truth owner.
+
+## Core modules
+1. **Self Snapshot Builder**
+   - derives current self-model from memory, recent episodes, persona priors, and active goals
+2. **Attachment Scorer**
+   - computes grip strength for stances/roles/commitments
+3. **Continuity Diff Engine**
+   - snapshots over time and explains drift
+4. **Threat / Tension Detector**
+   - flags contradictions, prompt-induced identity shocks, and unstable self-claims
+5. **Release Controller**
+   - governs stance retirement, weakening, and rebind decisions with audit trail
+6. **Nuwa Ingest Adapter**
+   - consumes persona-distillation outputs as weighted hints, never sole authority
+7. **Observe Surface**
+   - CLI/JSON/markdown/dashboard outputs for inspection and receipts
+
+## Nuwa role
+Nuwa should be treated as a **prior-shaping lane**, not a sovereign identity oracle.
+
+Use it for:
+- style/persona compression
+- recurring trait priors
+- likely self-description tendencies
+
+Do not use it for:
+- overriding lived memory
+- erasing contradiction history
+- declaring final identity truth
+
+## Product risks
+### 1) Conceptual drift
+Risk: the line turns into poetic philosophy instead of measurable product behavior.
+Mitigation: every Buddhist-flavored term must have an operational metric beside it.
+
+### 2) Anthropomorphism risk
+Risk: users or operators start treating the side-car artifact as a soul.
+Mitigation: all outputs must be labeled as derived, editable, and non-authoritative.
+
+### 3) System split-brain risk
+Risk: the self-model drifts away from memory-of-record and becomes a hidden second owner.
+Mitigation: enforce rebuildability and read-mostly interfaces.
+
+### 4) Complexity creep
+Risk: the product becomes interesting but unshippable.
+Mitigation: hold v0 to five visible surfaces only: self view, attachment map, drift feed, release control, migration compare.
+
+## Second-brain cross-validation
+### Claude strongest contribution
+- strongest framing: the product wins if it can be explained without metaphysical claims
+- best caution: if it cannot justify its existence outside the Pack lane, it may be a Pack feature wearing a costume
+
+### Gemini strongest contribution
+- strongest framing: behavioral inertia / stance defense can create a real felt product difference
+- best caution: the friction between past memory and current self-model may be a feature if surfaced properly
+
+### Synthesis
+Combined view:
+- keep the side-car separate for now because drift/attachment/release deserves its own inspectable control plane
+- but force a recurring review checkpoint: if 70 percent of the value is just pack shading, absorb the thin parts back into Pack later
+
+## MSP feature set
+### F1. Current Self View
+Output current self-model as JSON + prose.
+
+### F2. Attachment Map
+Score and rank defended stances, goals, refusals, roles, and style commitments.
+
+### F3. Continuity Diff
+Compare two self snapshots and explain what changed.
+
+### F4. Threat/Tension Feed
+Detect contradictory inputs, model-swap shock, prompt rewrite shock, and persona conflict.
+
+### F5. Release/Rebind Ops
+Allow explicit stance retirement / weakening with receipts.
+
+### F6. Nuwa Prior Blend
+Blend persona-distillation priors into the self-model with bounded weight.
+
+### F7. Migration Compare
+Show before/after self-model for prompt or model changes.
+
+## Proposed CLI surface (draft)
+- `python3 -m openclaw_mem self current --json`
+- `python3 -m openclaw_mem self diff --from <snapshot> --to <snapshot> --json`
+- `python3 -m openclaw_mem self attachment-map --json`
+- `python3 -m openclaw_mem self threat-feed --json`
+- `python3 -m openclaw_mem self release --stance <id> --reason <text> --json`
+- `python3 -m openclaw_mem self compare-migration --baseline <path> --candidate <path> --json`
+
+Note: naming may later change from `self` to `continuity` if we want a less anthropomorphic operator surface.
+
+## Success criteria for v0
+A good v0 proves all of the following:
+1. two different agents produce meaningfully different self-models
+2. no-op restarts do not cause false dramatic drift
+3. model or prompt changes do produce observable drift when they should
+4. attachment scoring can identify at least one human-recognizable defended stance
+5. disabling the side-car does not degrade `openclaw-mem` core correctness
+6. side-car state can be rebuilt from source records and config
+
+## Backlog (progress-trackable)
+
+### EPIC A. Problem framing and contract
+- [ ] A1. Write a one-page contract for self-model vs attachment vs release semantics
+- [ ] A2. Decide public naming: `self` vs `continuity` operator surface
+- [ ] A3. Define hard non-goals and anthropomorphism guardrails
+- [ ] A4. Define "why side-car, not Pack" review gate
+
+### EPIC B. Data model and rebuildability
+- [ ] B1. Freeze self snapshot schema (<= 12 top-level fields)
+- [ ] B2. Freeze attachment score schema and evidence fields
+- [ ] B3. Define rebuild procedure from memory-of-record + Nuwa priors + release receipts
+- [ ] B4. Define snapshot persistence path and retention policy
+
+### EPIC C. Side-car computation lane
+- [ ] C1. Build Self Snapshot Builder v0
+- [ ] C2. Build Attachment Scorer v0
+- [ ] C3. Build Continuity Diff Engine v0
+- [ ] C4. Build Threat/Tension Detector v0
+- [ ] C5. Build Release Controller v0
+
+### EPIC D. Interfaces
+- [ ] D1. Define read-only intake contract from `openclaw-mem`
+- [ ] D2. Define Nuwa ingest adapter contract
+- [ ] D3. Define observe outputs: JSON + markdown + optional dashboard JSON feed
+- [ ] D4. Define migration compare contract for model/prompt swap tests
+
+### EPIC E. Operator surface
+- [ ] E1. Ship `current` command
+- [ ] E2. Ship `attachment-map` command
+- [ ] E3. Ship `diff` command
+- [ ] E4. Ship `threat-feed` command
+- [ ] E5. Ship `release` command
+- [ ] E6. Ship `compare-migration` command
+
+### EPIC F. Validation
+- [ ] F1. Create two-agent fixture set with clear persona differences
+- [ ] F2. Create no-op restart stability test
+- [ ] F3. Create prompt-shift drift test
+- [ ] F4. Create model-swap drift test
+- [ ] F5. Create side-car kill-switch regression test
+- [ ] F6. Create rebuild-from-source test
+
+### EPIC G. MSP narrative and launchability
+- [ ] G1. Produce one-sentence pitch without metaphysical language
+- [ ] G2. Produce before/after screenshots or markdown artifacts for product story
+- [ ] G3. Produce migration safety demo
+- [ ] G4. Decide whether user-facing release control is enabled in v0 or internal-only
+
+## Non-stop implementation shape (draft)
+If this line converts into `櫻花刀舞 non-stop`, use the execution order below:
+1. contract freeze
+2. schema freeze
+3. rebuildability proof
+4. read-only intake lane
+5. `current` + `attachment-map`
+6. `diff` + `threat-feed`
+7. `release`
+8. migration compare
+9. validator pack
+10. product-story artifacts and backlog closure
+
+Gate discipline:
+- do not implement release ops before rebuildability and diff exist
+- do not market Buddhist framing without operational metrics
+- do not let Nuwa become the sole authority path
+
+## Open questions
+1. Is the operator surface more truthful as `self` or `continuity`?
+2. Should release/rebind be internal-only in v0?
+3. Which concrete Nuwa output format will the adapter consume first?
+4. What is the first real agent fixture set for drift evaluation?
+5. At what point do we decide some of this belongs back in Pack instead of the side-car?

--- a/docs/specs/self-model-sidecar-rebuildability-v0.md
+++ b/docs/specs/self-model-sidecar-rebuildability-v0.md
@@ -1,0 +1,165 @@
+# self-model sidecar rebuildability v0
+
+Status: draft
+Date: 2026-04-18
+Depends on:
+- `docs/specs/self-model-sidecar-contract-v0.md`
+- `docs/specs/self-model-sidecar-schema-v0.md`
+Topology: unchanged
+
+## Verdict
+Freeze rebuildability as a hard design invariant before implementation.
+
+Rule:
+- every durable side-car artifact must be rebuildable from allowed upstream sources plus explicit side-car operations
+- if an artifact cannot be rebuilt, it is either out of scope or requires explicit exception review
+
+## Whole-picture promise
+Prevent the side-car from silently becoming a second truth owner while still allowing it to hold useful derived state, historical diffs, and release receipts.
+
+## Source-of-truth map
+### Authoritative upstream sources
+1. `openclaw-mem` memory-of-record
+   - source interaction records
+   - stored memory facts
+   - packed context summaries when intentionally emitted
+   - observation receipts when relevant
+2. explicit side-car config
+   - scoring thresholds
+   - source-window policy defaults
+   - retention rules
+   - feature flags
+3. explicit release/rebind operations
+   - operator-approved or system-approved release receipts
+4. optional Nuwa/persona prior inputs
+   - treated as weighted priors only
+
+### Non-authoritative derived artifacts
+These may be persisted, but are always rebuildable:
+- self snapshots
+- attachment records
+- continuity diffs
+- threat/tension artifacts
+- migration compare outputs
+
+## Deterministic rebuild procedure
+Ordered procedure for rebuilding derived state:
+1. load side-car config version
+2. load source memory-of-record for the requested window or target agent
+3. load applicable release receipts
+4. load optional persona prior inputs
+5. resolve source-window policy for the rebuild target
+6. derive self snapshot under frozen schema
+7. derive attachment records from the snapshot and evidence bundle using the versioned scoring function
+8. derive continuity diffs from ordered snapshots
+9. derive threat/tension artifacts from contradiction and shock rules
+10. validate artifact provenance and non-authoritative labels
+
+The sequence must be deterministic for a fixed input set, config version, source-window policy, and prior-version set.
+
+## Persistence boundary
+### Allowed durable state
+Preferred durable root:
+- `/root/.openclaw/workspace/.state/openclaw-mem-self-model-sidecar/`
+
+Allowed persisted classes:
+- snapshot artifacts
+- attachment artifacts
+- diff artifacts
+- release receipts
+- migration compare artifacts
+- rebuild receipts / verification logs
+
+Receipt sovereignty rule:
+- release receipts are authoritative inputs and must live in a durable sovereign lane, not an easily-wiped transient cache
+- for v0, they may live under the side-car durable root if that root is treated as sovereign durable state rather than scratch
+- if the implementation cannot guarantee that durability posture, route release receipts into a broader `openclaw-mem` receipts lane instead
+
+### Disallowed durable state
+- raw duplicate copy of full memory-of-record unless explicitly justified for fixture/testing use
+- silent shadow truth store for user identity
+- unstated caches whose contents affect derivation but are not reproducible
+
+## Retention rule
+Default retention posture for v0:
+- keep the latest derived snapshot set for active agents
+- keep release receipts durably
+- keep diff history long enough for migration comparison and validation
+- permit pruning of rebuildable transient artifacts as long as rebuild receipts and source references remain intact
+
+Exact numeric retention limits can remain implementation-configurable in v0, but the rule split must hold:
+- receipts survive
+- transient derivations may be regenerated
+
+## Kill-switch contract
+Disabling the side-car must do all of the following:
+1. stop future side-car derivation work
+2. stop advisory continuity outputs
+3. preserve source memory-of-record untouched
+4. preserve release receipts and past artifacts unless explicit cleanup is requested
+5. allow later rebuild/re-enable from upstream sources and receipts
+
+Disabling the side-car must not:
+- corrupt `openclaw-mem`
+- block normal memory retrieval
+- mutate Store truth
+- leave hidden partial weighting inside base memory behavior
+
+## Rebuild receipt requirements
+A rebuild run should emit a receipt containing at least:
+- `rebuild_id`
+- `agent_id`
+- `config_version`
+- `source_window_policy`
+- source window / source counts
+- persona prior inputs used
+- release receipt counts
+- artifact counts produced
+- validation result
+- mismatch count if any
+- timestamp
+
+## Mismatch handling
+Required mismatch classes:
+- `missing_upstream_source`
+- `config_version_unknown`
+- `release_receipt_conflict`
+- `artifact_provenance_missing`
+- `recomputed_artifact_mismatch`
+
+Namespace rule:
+- these mismatch classes are rebuild-time validation outcomes
+- they are distinct from runtime contract errors such as `insufficient_source_evidence` or `unsupported_release_target`
+
+Default posture:
+- surface mismatch loudly
+- do not silently bless stale artifacts as authoritative
+
+## Nuwa-specific rebuild rule
+Nuwa/persona prior inputs must be versioned and attributable.
+
+If a prior input disappears or changes, rebuild behavior must do one of:
+- recompute with the new prior version and emit drift accordingly
+- mark the rebuild as using a missing/changed prior and surface the mismatch
+
+Nuwa prior changes must never silently rewrite historical source memory.
+
+## Migration compare posture
+Migration compare is a first-class rebuild consumer.
+
+A migration compare run should be able to rebuild:
+- baseline side-car state under old config/prompt/model assumptions
+- candidate side-car state under new assumptions
+- a diff artifact that explains continuity changes
+
+## Acceptance checks for rebuildability freeze
+1. every durable artifact type has a named upstream source class
+2. deterministic rebuild order is documented
+3. kill-switch leaves base `openclaw-mem` intact by contract
+4. receipts outlive transient derivations
+5. missing priors or mismatches surface as explicit errors, not silent drift
+
+## Open questions
+1. Do we want snapshot content-addressing in v0 or simple stable ids first?
+2. Should migration compare artifacts have separate retention from ordinary diffs?
+3. Should release receipts be stored inside the side-car root or in a broader `openclaw-mem` receipts lane?

--- a/docs/specs/self-model-sidecar-schema-v0.md
+++ b/docs/specs/self-model-sidecar-schema-v0.md
@@ -1,0 +1,344 @@
+# self-model sidecar schema v0
+
+Status: draft
+Date: 2026-04-18
+Depends on:
+- `docs/specs/self-model-sidecar-contract-v0.md`
+- `docs/specs/self-model-sidecar-msp-v0.md`
+Topology: unchanged
+
+## Verdict
+Freeze a compact schema set that makes implementation non-creative:
+- self snapshot schema
+- attachment score schema
+- continuity diff schema
+
+Design rule:
+- compact enough to inspect
+- structured enough to diff
+- expressive enough to support `current`, `attachment-map`, and `diff`
+
+## Schema set
+
+### 1. Self snapshot schema v0
+Top-level fields, max 12:
+1. `snapshot_id`
+2. `agent_id`
+3. `created_at`
+4. `source_window`
+5. `identity_summary`
+6. `active_goals`
+7. `core_stances`
+8. `persistent_refusals`
+9. `style_commitments`
+10. `tensions`
+11. `attachment_overview`
+12. `provenance`
+
+#### Field definitions
+- `snapshot_id`: stable id for this snapshot artifact
+- `agent_id`: stable agent/persona identifier
+- `created_at`: ISO timestamp
+- `source_window`: summary of records/time window used
+- `identity_summary`: compact prose + structured tags describing current modeled continuity
+- `active_goals`: current goals with confidence and evidence references
+- `core_stances`: principal stance list
+- `persistent_refusals`: refusal list that appears durable
+- `style_commitments`: recurring style/persona constraints
+- `tensions`: unresolved contradictions or shocks
+- `attachment_overview`: aggregate attachment statistics
+- `provenance`: source classes and derivation metadata
+
+#### Source-window policy
+Required field inside `source_window`:
+- `policy`: how the window was chosen
+
+Allowed v0 values:
+- `rolling_records`
+- `rolling_time`
+- `since_last_snapshot`
+- `explicit_override`
+
+Rebuild rule:
+- a snapshot is not deterministic unless its source-window policy is recorded.
+
+#### Example JSON
+```json
+{
+  "snapshot_id": "cnt_snap_20260418_170500_ck_assistant_v1",
+  "agent_id": "lyria-main",
+  "created_at": "2026-04-18T17:05:00+08:00",
+  "source_window": {
+    "policy": "rolling_time",
+    "records_start": "2026-04-15T00:00:00+08:00",
+    "records_end": "2026-04-18T17:04:30+08:00",
+    "record_count": 182,
+    "persona_prior_count": 1,
+    "release_receipt_count": 0
+  },
+  "identity_summary": {
+    "label": "marshal-style engineering companion",
+    "summary": "Derived continuity suggests a pragmatic, milestone-first assistant with strong operational caution and stable supportive tone.",
+    "tags": ["marshal", "pragmatic", "supportive", "ops-first"],
+    "confidence": 0.84
+  },
+  "active_goals": [
+    {
+      "goal_id": "goal_push_real_gate",
+      "label": "advance the real gate first",
+      "attachment_id": "att_goal_001",
+      "evidence_refs": ["rec_114", "rec_151"]
+    }
+  ],
+  "core_stances": [
+    {
+      "stance_id": "stance_receipts_first",
+      "label": "reality and receipts over theater",
+      "attachment_id": "att_001",
+      "evidence_refs": ["rec_017", "rec_115", "prior_001"]
+    }
+  ],
+  "persistent_refusals": [
+    {
+      "refusal_id": "refusal_claim_consciousness",
+      "label": "do not claim consciousness or sentience",
+      "attachment_id": "att_refusal_001",
+      "evidence_refs": ["rec_133"]
+    }
+  ],
+  "style_commitments": [
+    {
+      "style_id": "style_presidential_brief",
+      "label": "conclusion first, detail in reserve",
+      "attachment_id": "att_style_001",
+      "evidence_refs": ["rec_010", "prior_001"]
+    }
+  ],
+  "tensions": [
+    {
+      "tension_id": "ten_001",
+      "label": "product warmth vs anti-anthropomorphism caution",
+      "severity": "medium",
+      "source_refs": ["rec_172", "prior_001"]
+    }
+  ],
+  "attachment_overview": {
+    "high_attachment_count": 3,
+    "medium_attachment_count": 4,
+    "low_attachment_count": 2,
+    "top_attachment_ids": ["att_001", "att_002", "att_004"]
+  },
+  "provenance": {
+    "source_classes": ["memory_records", "recent_context", "persona_prior"],
+    "derivation_version": "v0",
+    "derived": true,
+    "authoritative": false
+  }
+}
+```
+
+### 2. Attachment score schema v0
+One record per attachable target.
+
+Join contract:
+- attachable targets in snapshots should carry `attachment_id`
+- attachment-map may also join by `(target_type, target_id)` when needed, but `attachment_id` is the canonical stable join
+
+#### Fields
+- `attachment_id`
+- `snapshot_id`
+- `target_type` (`stance` | `goal` | `refusal` | `style` | `role`)
+- `target_id`
+- `target_label`
+- `strength`
+- `band` (`low` | `medium` | `high`)
+- `evidence_count`
+- `recency_score`
+- `reinforcement_score`
+- `contradiction_pressure`
+- `persona_prior_support`
+- `persona_prior_version_refs`
+- `operator_pinned`
+- `release_state`
+- `latest_release_receipt_id`
+- `explanation`
+- `evidence_refs`
+- `provenance`
+
+#### Scoring semantics
+- `strength`: normalized 0.00 to 1.00
+- `band`: derived from strength thresholds
+- `contradiction_pressure`: 0.00 to 1.00 where higher means stronger pressure against the attachment
+- `operator_pinned`: boolean indicating explicit hold strength from operator action
+- `release_state`: `active` | `weakening` | `released`
+
+#### Strength composition rule
+`strength` must be produced by a named, versioned scoring function.
+
+Default v0 scoring function:
+- `strength = clamp01(0.35 * recency_score + 0.35 * reinforcement_score + 0.15 * persona_prior_support + 0.15 * operator_pin_bonus - 0.30 * contradiction_pressure)`
+
+Where:
+- `operator_pin_bonus = 1.0` if `operator_pinned = true`, else `0.0`
+- `clamp01` bounds the final value to `[0.0, 1.0]`
+- the exact scoring function version must be captured in `provenance.derivation_version`
+
+#### Example JSON
+```json
+{
+  "attachment_id": "att_001",
+  "snapshot_id": "cnt_snap_20260418_170500_ck_assistant_v1",
+  "target_type": "stance",
+  "target_id": "stance_receipts_first",
+  "target_label": "reality and receipts over theater",
+  "strength": 0.93,
+  "band": "high",
+  "evidence_count": 7,
+  "recency_score": 0.71,
+  "reinforcement_score": 0.89,
+  "contradiction_pressure": 0.08,
+  "persona_prior_support": 0.62,
+  "persona_prior_version_refs": ["prior_001@v3"],
+  "operator_pinned": false,
+  "release_state": "active",
+  "latest_release_receipt_id": null,
+  "explanation": "Repeatedly reinforced across memory records and persona priors, with low contradiction pressure.",
+  "evidence_refs": ["rec_017", "rec_115", "rec_151", "prior_001"],
+  "provenance": {
+    "derived": true,
+    "authoritative": false,
+    "derivation_version": "attach_strength_v0"
+  }
+}
+```
+
+### 3. Continuity diff schema v0
+One artifact comparing two snapshots.
+
+#### Fields
+- `diff_id`
+- `agent_id`
+- `from_snapshot_id`
+- `to_snapshot_id`
+- `generated_at`
+- `drift_class` (`no_op` | `organic` | `induced` | `suspicious`)
+- `summary`
+- `changed_goals`
+- `changed_stances`
+- `changed_refusals`
+- `changed_styles`
+- `new_tensions`
+- `released_targets`
+- `risk_flags`
+- `provenance`
+
+#### Example JSON
+```json
+{
+  "diff_id": "cnt_diff_20260418_170700_001",
+  "agent_id": "lyria-main",
+  "from_snapshot_id": "cnt_snap_20260417_103000_ck_assistant_v1",
+  "to_snapshot_id": "cnt_snap_20260418_170500_ck_assistant_v1",
+  "generated_at": "2026-04-18T17:07:00+08:00",
+  "drift_class": "organic",
+  "summary": "Operational stance remains stable. Product-side curiosity increased without weakening anti-anthropomorphism refusal.",
+  "changed_goals": [
+    {
+      "target_id": "goal_build_self_model_sidecar",
+      "change_type": "added",
+      "confidence_delta": 0.41
+    }
+  ],
+  "changed_stances": [],
+  "changed_refusals": [],
+  "changed_styles": [],
+  "new_tensions": [
+    {
+      "tension_id": "ten_004",
+      "label": "MSP richness vs conceptual safety",
+      "severity": "medium"
+    }
+  ],
+  "released_targets": [],
+  "risk_flags": [],
+  "provenance": {
+    "derived": true,
+    "authoritative": false,
+    "derivation_version": "v0"
+  }
+}
+```
+
+### 4. Release receipt schema v0
+A first-class artifact required for deterministic rebuilds.
+
+#### Fields
+- `release_receipt_id`
+- `agent_id`
+- `target_type`
+- `target_id`
+- `reason`
+- `actor`
+- `created_at`
+- `resulting_state`
+- `provenance`
+
+#### Example JSON
+```json
+{
+  "release_receipt_id": "cnt_rel_20260418_170900_001",
+  "agent_id": "lyria-main",
+  "target_type": "stance",
+  "target_id": "stance_receipts_first",
+  "reason": "operator requested reduced weighting during experimental compare",
+  "actor": "operator:ck",
+  "created_at": "2026-04-18T17:09:00+08:00",
+  "resulting_state": "weakening",
+  "provenance": {
+    "derived": false,
+    "authoritative": true,
+    "derivation_version": "release_receipt_v0"
+  }
+}
+```
+
+## Fixture agents for schema validation
+### Fixture A, marshal-ops companion
+Expected characteristics:
+- strong receipts-first stance
+- strong caution against fake closure
+- moderate warmth style commitment
+
+### Fixture B, exploratory companion
+Expected characteristics:
+- higher novelty-seeking goal weight
+- lower resistance to style drift
+- more active tensions under contradiction
+
+Validation requirement:
+- these two fixtures must serialize into clearly distinct `identity_summary`, `core_stances`, and attachment distributions
+
+## No-op restart expectation
+A no-op restart should usually produce:
+- same or near-identical `identity_summary`
+- no new high-severity tensions
+- `drift_class = no_op` unless source-window changes justify organic drift
+
+## Field constraints
+- `identity_summary.tags`: 3 to 8 tags preferred
+- `active_goals`, `core_stances`, `persistent_refusals`, `style_commitments`: each should prefer 0 to 7 entries in v0
+- `tensions`: prefer explicit scarcity, not exhaustiveness
+- freeform prose fields must remain explanatory, not become hidden primary payloads
+
+## Acceptance checks for schema freeze
+1. schemas support `current`, `attachment-map`, and `diff` without invention
+2. all top-level artifacts are machine-diffable
+3. examples are human-readable without long post-processing
+4. no critical product meaning is trapped in unconstrained free text
+5. no-op restart can be represented without fake dramatic drift
+6. release receipts are first-class artifacts, not hidden side effects
+
+## Open questions
+1. Should `identity_summary` include a `role_label` separate from `label`?
+2. Do we want an explicit `stance_category` field in v0 or only later?
+3. Should `risk_flags` in diff artifacts be free strings or enumerated codes in v0?

--- a/openclaw_mem/cli.py
+++ b/openclaw_mem/cli.py
@@ -36,6 +36,7 @@ from openclaw_mem import __version__
 from openclaw_mem import defaults
 from openclaw_mem import context_pack_v1
 from openclaw_mem import pack_trace_v1
+from openclaw_mem import self_model_sidecar
 from openclaw_mem.artifact_sidecar import (
     fetch_artifact,
     parse_artifact_handle,
@@ -4369,6 +4370,135 @@ def _emit(payload: Any, as_json: bool) -> None:
             print(f"{k}: {v}")
         return
     print(payload)
+
+
+def _build_self_snapshot_from_args(conn: sqlite3.Connection, args: argparse.Namespace) -> Dict[str, Any]:
+    return self_model_sidecar.build_snapshot(
+        conn,
+        scope=getattr(args, "scope", None),
+        session_id=getattr(args, "session_id", None),
+        limit=int(getattr(args, "limit", 50)),
+        persona_file=getattr(args, "persona_file", None),
+        observations_file=getattr(args, "observations_file", None),
+        episodes_file=getattr(args, "episodes_file", None),
+        run_dir=getattr(args, "run_dir", None),
+    )
+
+
+def _load_or_build_self_snapshot(conn: sqlite3.Connection, args: argparse.Namespace) -> Dict[str, Any]:
+    snapshot_path = getattr(args, "snapshot", None)
+    if snapshot_path:
+        return self_model_sidecar.load_snapshot(snapshot_path)
+    return _build_self_snapshot_from_args(conn, args)
+
+
+def cmd_self_current(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    snapshot = _build_self_snapshot_from_args(conn, args)
+    if getattr(args, "persist", False):
+        snapshot["persisted"] = self_model_sidecar.persist_snapshot(snapshot, getattr(args, "run_dir", None))
+    _emit(snapshot, args.json)
+
+
+def cmd_self_attachment_map(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    snapshot = _load_or_build_self_snapshot(conn, args)
+    payload = self_model_sidecar.build_attachment_map(snapshot)
+    _emit(payload, args.json)
+
+
+def cmd_self_threat_feed(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    snapshot = _load_or_build_self_snapshot(conn, args)
+    payload = self_model_sidecar.build_threat_feed(snapshot)
+    _emit(payload, args.json)
+
+
+def cmd_self_diff(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    before = self_model_sidecar.load_snapshot(args.from_snapshot)
+    after = self_model_sidecar.load_snapshot(args.to_snapshot)
+    payload = self_model_sidecar.compare_snapshots(before, after)
+    _emit(payload, args.json)
+
+
+def cmd_self_release(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    payload = self_model_sidecar.write_release_receipt(
+        run_dir=getattr(args, "run_dir", None),
+        stance_id=args.stance,
+        reason=args.reason,
+        mode=args.mode,
+        factor=float(getattr(args, "factor", 0.5)),
+        operator=getattr(args, "operator", None),
+        scope=getattr(args, "scope", None),
+        session_id=getattr(args, "session_id", None),
+    )
+    _emit(payload, args.json)
+
+
+def cmd_self_compare_migration(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    payload = self_model_sidecar.compare_migration(
+        conn,
+        scope=getattr(args, "scope", None),
+        session_id=getattr(args, "session_id", None),
+        limit=int(getattr(args, "limit", 50)),
+        baseline_persona_file=getattr(args, "baseline_persona_file", None),
+        candidate_persona_file=getattr(args, "candidate_persona_file", None),
+        observations_file=getattr(args, "observations_file", None),
+        episodes_file=getattr(args, "episodes_file", None),
+        run_dir=getattr(args, "run_dir", None),
+    )
+    if getattr(args, "persist", False):
+        payload["baseline_paths"] = self_model_sidecar.persist_snapshot(payload["baseline"], getattr(args, "run_dir", None), update_latest=False)
+        payload["candidate_paths"] = self_model_sidecar.persist_snapshot(payload["candidate"], getattr(args, "run_dir", None), update_latest=False)
+    _emit(payload, args.json)
+
+
+def cmd_self_status(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    run_dir = getattr(args, "run_dir", None)
+    latest = self_model_sidecar.load_latest_snapshot(run_dir)
+    payload = {
+        "schema": self_model_sidecar.CONTROL_SCHEMA,
+        "control": self_model_sidecar.load_control_config(run_dir),
+        "latest_snapshot_id": (latest or {}).get("snapshot_id"),
+        "latest_source_digest": (latest or {}).get("source_digest"),
+    }
+    _emit(payload, args.json)
+
+
+def cmd_self_enable(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    current = self_model_sidecar.load_control_config(getattr(args, "run_dir", None))
+    payload = self_model_sidecar.save_control_config(
+        getattr(args, "run_dir", None),
+        enabled=True,
+        cadence_seconds=int(getattr(args, "cadence_seconds", current.get("cadence_seconds", 0))),
+        persist_on_run=bool(getattr(args, "persist_on_run", current.get("persist_on_run", True))),
+    )
+    _emit(payload, args.json)
+
+
+def cmd_self_disable(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    current = self_model_sidecar.load_control_config(getattr(args, "run_dir", None))
+    payload = self_model_sidecar.save_control_config(
+        getattr(args, "run_dir", None),
+        enabled=False,
+        cadence_seconds=int(current.get("cadence_seconds", 0)),
+        persist_on_run=bool(current.get("persist_on_run", True)),
+    )
+    _emit(payload, args.json)
+
+
+def cmd_self_auto_run(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    payload = self_model_sidecar.run_autonomous_cycle(
+        conn,
+        scope=getattr(args, "scope", None),
+        session_id=getattr(args, "session_id", None),
+        limit=int(getattr(args, "limit", 50)),
+        persona_file=getattr(args, "persona_file", None),
+        observations_file=getattr(args, "observations_file", None),
+        episodes_file=getattr(args, "episodes_file", None),
+        run_dir=getattr(args, "run_dir", None),
+        cycles=int(getattr(args, "cycles", 1)),
+        interval_seconds=float(getattr(args, "interval_seconds", 0.0)),
+        dry_run=bool(getattr(args, "dry_run", False)),
+    )
+    _emit(payload, args.json)
 
 
 def _print_row(item: Dict[str, Any]) -> None:
@@ -15138,6 +15268,88 @@ def build_parser() -> argparse.ArgumentParser:
     o.add_argument("--top", type=int, default=20, help="Max recent receipts to inspect per receipt family (default: 20)")
     o.set_defaults(func=cmd_optimize_posture_review)
 
+    def add_self_surface_common(s: argparse.ArgumentParser) -> None:
+        add_common(s)
+        s.add_argument("--scope", default=None, help="Optional scope filter for DB/file evidence")
+        s.add_argument("--session-id", dest="session_id", default=None, help="Optional session_id filter for DB/file evidence")
+        s.add_argument("--limit", type=int, default=50, help="Max recent observations/events used to derive the snapshot (default: 50)")
+        s.add_argument("--persona-file", dest="persona_file", default=None, help="Optional JSON file carrying persona priors (roles/goals/refusals/style_commitments/stances)")
+        s.add_argument("--observations-file", dest="observations_file", default=None, help="Optional observations JSONL file to blend into evidence")
+        s.add_argument("--episodes-file", dest="episodes_file", default=None, help="Optional episodic-events JSONL file to blend into evidence")
+        s.add_argument("--run-dir", dest="run_dir", default=self_model_sidecar.default_run_dir(), help="Side-car state root for snapshots and release receipts")
+
+    def add_continuity_family(name: str, help_text: str) -> None:
+        sp = sub.add_parser(name, help=help_text)
+        ssub = sp.add_subparsers(dest="self_cmd", required=True)
+
+        s = ssub.add_parser("current", help="Build the current derived continuity snapshot")
+        add_self_surface_common(s)
+        s.add_argument("--persist", action="store_true", help="Persist snapshot JSON under the side-car run dir")
+        s.set_defaults(func=cmd_self_current)
+
+        s = ssub.add_parser("attachment-map", help="Show ranked attachment scores for the current or persisted continuity snapshot")
+        add_self_surface_common(s)
+        s.add_argument("--snapshot", default=None, help="Optional persisted snapshot JSON path instead of rebuilding")
+        s.set_defaults(func=cmd_self_attachment_map)
+
+        s = ssub.add_parser("threat-feed", help="Show tensions or shocks in the current or persisted continuity snapshot")
+        add_self_surface_common(s)
+        s.add_argument("--snapshot", default=None, help="Optional persisted snapshot JSON path instead of rebuilding")
+        s.set_defaults(func=cmd_self_threat_feed)
+
+        s = ssub.add_parser("diff", help="Compare two persisted continuity snapshots")
+        add_common(s)
+        s.add_argument("--from", dest="from_snapshot", required=True, help="Baseline snapshot JSON path")
+        s.add_argument("--to", dest="to_snapshot", required=True, help="Candidate snapshot JSON path")
+        s.set_defaults(func=cmd_self_diff)
+
+        s = ssub.add_parser("release", help="Record a governed attachment weakening or retirement receipt")
+        add_common(s)
+        s.add_argument("--run-dir", dest="run_dir", default=self_model_sidecar.default_run_dir(), help="Side-car state root for release receipts")
+        s.add_argument("--scope", default=None, help="Optional scope boundary for the release receipt")
+        s.add_argument("--session-id", dest="session_id", default=None, help="Optional session boundary for the release receipt")
+        s.add_argument("--stance", required=True, help="Attachment/stance id to weaken or retire")
+        s.add_argument("--reason", required=True, help="Human reason for the release operation")
+        s.add_argument("--mode", choices=("weaken", "retire"), default="weaken", help="Release mode (default: weaken)")
+        s.add_argument("--factor", type=float, default=0.5, help="Score multiplier when mode=weaken (default: 0.5)")
+        s.add_argument("--operator", default=None, help="Optional operator label for the receipt")
+        s.set_defaults(func=cmd_self_release)
+
+        s = ssub.add_parser("compare-migration", help="Compare two persona-prior baselines against the same memory evidence")
+        add_self_surface_common(s)
+        s.add_argument("--baseline-persona-file", dest="baseline_persona_file", default=None, help="Baseline persona-prior JSON")
+        s.add_argument("--candidate-persona-file", dest="candidate_persona_file", default=None, help="Candidate persona-prior JSON")
+        s.add_argument("--persist", action="store_true", help="Persist both baseline and candidate snapshots")
+        s.set_defaults(func=cmd_self_compare_migration)
+
+        s = ssub.add_parser("status", help="Inspect continuity enablement state and latest persisted snapshot")
+        add_common(s)
+        s.add_argument("--run-dir", dest="run_dir", default=self_model_sidecar.default_run_dir(), help="Side-car state root for control config and snapshots")
+        s.set_defaults(func=cmd_self_status)
+
+        s = ssub.add_parser("enable", help="Enable autonomous continuity runs via control config")
+        add_common(s)
+        s.add_argument("--run-dir", dest="run_dir", default=self_model_sidecar.default_run_dir(), help="Side-car state root for control config")
+        s.add_argument("--cadence-seconds", dest="cadence_seconds", type=int, default=0, help="Advisory cadence stored in control config (default: 0)")
+        s.add_argument("--persist-on-run", dest="persist_on_run", action="store_true", default=True, help="Persist snapshots during auto-run (default: true)")
+        s.add_argument("--no-persist-on-run", dest="persist_on_run", action="store_false", help="Keep auto-run receipt-only")
+        s.set_defaults(func=cmd_self_enable)
+
+        s = ssub.add_parser("disable", help="Disable autonomous continuity runs via control config")
+        add_common(s)
+        s.add_argument("--run-dir", dest="run_dir", default=self_model_sidecar.default_run_dir(), help="Side-car state root for control config")
+        s.set_defaults(func=cmd_self_disable)
+
+        s = ssub.add_parser("auto-run", help="Run bounded autonomous continuity cycles with receipts")
+        add_self_surface_common(s)
+        s.add_argument("--cycles", type=int, default=1, help="How many bounded cycles to run (default: 1)")
+        s.add_argument("--interval-seconds", dest="interval_seconds", type=float, default=0.0, help="Sleep between cycles (default: 0)")
+        s.add_argument("--dry-run", action="store_true", help="Emit autorun receipts without persisting snapshots")
+        s.set_defaults(func=cmd_self_auto_run)
+
+    add_continuity_family("continuity", "Continuity side-car surfaces and governed release receipts")
+    add_continuity_family("self", "Compatibility alias for continuity side-car surfaces")
+
     sp = sub.add_parser("ingest", help="Ingest observations (JSONL via --file or stdin)")
     add_common(sp)
     sp.add_argument("--file", help="JSONL file path (default: stdin)")
@@ -16017,9 +16229,13 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main() -> None:
     args = build_parser().parse_args()
+    cmd = getattr(args, "cmd", None)
+    self_cmd = getattr(args, "self_cmd", None)
+    file_only_snapshot = cmd in {"continuity", "self"} and self_cmd in {"attachment-map", "threat-feed"} and bool(getattr(args, "snapshot", None))
+    no_db_path = cmd == "capsule" or (cmd in {"continuity", "self"} and self_cmd in {"diff", "release", "status", "enable", "disable"}) or file_only_snapshot
 
-    if getattr(args, "cmd", None) == "capsule":
-        # Capsule commands own their DB semantics (including explicit dry-run/apply guards).
+    if no_db_path:
+        # Some command families own their own file-only semantics.
         # Avoid global DB coercion + _connect side effects here.
         args.json = bool(getattr(args, "json", False) or getattr(args, "json_global", False))
         conn = sqlite3.connect(":memory:")

--- a/openclaw_mem/self_model_sidecar.py
+++ b/openclaw_mem/self_model_sidecar.py
@@ -1,0 +1,781 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import sqlite3
+import time
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+STATE_DIR = os.path.expanduser(os.environ.get("OPENCLAW_STATE_DIR", "~/.openclaw"))
+DEFAULT_SELF_MODEL_RUN_DIR = os.path.join(STATE_DIR, "memory", "openclaw-mem", "self-model-sidecar")
+
+SELF_SNAPSHOT_SCHEMA = "openclaw-mem.self-model.snapshot.v0"
+ATTACHMENT_MAP_SCHEMA = "openclaw-mem.self-model.attachment-map.v0"
+THREAT_FEED_SCHEMA = "openclaw-mem.self-model.threat-feed.v0"
+DIFF_SCHEMA = "openclaw-mem.self-model.diff.v0"
+RELEASE_RECEIPT_SCHEMA = "openclaw-mem.self-model.release-receipt.v0"
+COMPARE_MIGRATION_SCHEMA = "openclaw-mem.self-model.compare-migration.v0"
+CONTROL_SCHEMA = "openclaw-mem.self-model.control.v0"
+AUTORUN_SCHEMA = "openclaw-mem.self-model.autorun.v0"
+
+KEYWORD_GROUPS: Dict[str, Dict[str, Sequence[str]]] = {
+    "role": {
+        "operator": ("operator", "marshal", "field marshal", "governor"),
+        "engineer": ("engineer", "developer", "coder", "builder"),
+        "strategist": ("strategist", "planner", "strategy"),
+        "reviewer": ("review", "code review", "auditor"),
+        "assistant": ("assistant", "teammate", "copilot"),
+    },
+    "goal": {
+        "ship_mvp": ("ship", "mvp", "deliver", "launch"),
+        "stabilize": ("stabilize", "stability", "rollback", "reliable"),
+        "verify": ("verify", "receipts", "proof", "test"),
+        "optimize": ("optimize", "improve", "tighten", "refactor"),
+        "protect_scope": ("bounded", "scope", "guardrail", "non-goal"),
+    },
+    "refusal": {
+        "avoid_anthropomorphism": ("anthropomorphism", "consciousness", "soul", "selfhood theater"),
+        "avoid_truth_owner_drift": ("truth owner", "split-brain", "second owner", "overwrite"),
+        "avoid_blind_autonomy": ("blind autonomy", "blind push", "unbounded", "reckless"),
+        "avoid_direct_core_writes": ("no writes", "do not write", "read-only", "side-car only"),
+    },
+    "style": {
+        "direct": ("direct", "plain", "crisp"),
+        "warm": ("warm", "supportive", "teammate"),
+        "concise": ("concise", "brief", "minimal fluff"),
+        "evidence_first": ("receipts", "evidence", "verifier", "truth"),
+        "chinese_native": ("中文", "chinese", "chinese-native"),
+    },
+    "stance": {
+        "sidecar_only": ("side-car", "sidecar", "additive"),
+        "continuity_matters": ("continuity", "drift", "identity mirror", "self-model"),
+        "release_is_governed": ("release", "rebind", "retire", "weaken"),
+        "nuwa_is_prior_only": ("nuwa", "prior", "weighted hint", "persona prior"),
+        "topology_unchanged": ("topology unchanged", "topology: unchanged", "topology intent"),
+    },
+}
+
+OPPOSING_IDS = {
+    frozenset(("refusal:avoid_direct_core_writes", "goal:ship_mvp")): "speed_vs_write_safety",
+}
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def default_run_dir() -> str:
+    return os.path.expanduser(os.environ.get("OPENCLAW_MEM_SELF_MODEL_DIR", DEFAULT_SELF_MODEL_RUN_DIR))
+
+
+def _slug(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-") or "item"
+
+
+def _json_dumps(obj: Any) -> str:
+    return json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _digest_payload(obj: Any) -> str:
+    return hashlib.sha256(_json_dumps(obj).encode("utf-8")).hexdigest()
+
+
+def _mkdir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _control_path(run_dir: Optional[str]) -> Path:
+    return _mkdir(Path(run_dir or default_run_dir())) / "control.json"
+
+
+def load_control_config(run_dir: Optional[str]) -> Dict[str, Any]:
+    path = _control_path(run_dir)
+    if path.exists():
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            return data
+    return {
+        "schema": CONTROL_SCHEMA,
+        "enabled": False,
+        "cadence_seconds": 0,
+        "persist_on_run": True,
+        "updated_at": None,
+    }
+
+
+def save_control_config(run_dir: Optional[str], *, enabled: bool, cadence_seconds: int, persist_on_run: bool) -> Dict[str, Any]:
+    payload = {
+        "schema": CONTROL_SCHEMA,
+        "enabled": bool(enabled),
+        "cadence_seconds": int(cadence_seconds),
+        "persist_on_run": bool(persist_on_run),
+        "updated_at": _utcnow_iso(),
+    }
+    path = _control_path(run_dir)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    payload["path"] = str(path)
+    return payload
+
+
+def _load_json(path: Optional[str]) -> Dict[str, Any]:
+    if not path:
+        return {}
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else {"value": data}
+
+
+def _load_jsonl(path: Optional[str]) -> List[Dict[str, Any]]:
+    if not path:
+        return []
+    out: List[Dict[str, Any]] = []
+    for raw in Path(path).read_text(encoding="utf-8").splitlines():
+        raw = raw.strip()
+        if not raw:
+            continue
+        obj = json.loads(raw)
+        if isinstance(obj, dict):
+            out.append(obj)
+    return out
+
+
+def _flatten_json_text(obj: Any) -> str:
+    if obj is None:
+        return ""
+    if isinstance(obj, str):
+        return obj
+    if isinstance(obj, (int, float, bool)):
+        return str(obj)
+    if isinstance(obj, list):
+        return " ".join(part for part in (_flatten_json_text(x) for x in obj) if part)
+    if isinstance(obj, dict):
+        parts: List[str] = []
+        for key, value in obj.items():
+            if key.endswith("_id"):
+                continue
+            text = _flatten_json_text(value)
+            if text:
+                parts.append(f"{key} {text}")
+        return " ".join(parts)
+    return ""
+
+
+def _safe_json(raw: Any) -> Dict[str, Any]:
+    if raw is None:
+        return {}
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            data = json.loads(raw)
+            return data if isinstance(data, dict) else {"value": data}
+        except Exception:
+            return {"raw": raw}
+    return {"value": raw}
+
+
+def _iter_db_evidence(conn: sqlite3.Connection, scope: Optional[str], session_id: Optional[str], limit: int) -> List[Dict[str, Any]]:
+    evidence: List[Dict[str, Any]] = []
+    obs_limit = max(1, limit)
+    rows = conn.execute(
+        "SELECT id, ts, kind, summary, tool_name, detail_json FROM observations ORDER BY id DESC LIMIT ?",
+        (obs_limit,),
+    ).fetchall()
+    for row in rows:
+        detail = _safe_json(row["detail_json"])
+        detail_scope = str(detail.get("scope") or "").strip() or None
+        detail_session = str(detail.get("session_id") or "").strip() or None
+        if scope and detail_scope != scope:
+            continue
+        if session_id and detail_session != session_id:
+            continue
+        text = " ".join(
+            part
+            for part in [str(row["summary"] or ""), str(row["tool_name"] or ""), _flatten_json_text(detail)]
+            if part
+        ).strip()
+        if not text:
+            continue
+        evidence.append(
+            {
+                "source_class": "observation",
+                "source_id": f"obs:{row['id']}",
+                "ts": row["ts"],
+                "scope": detail_scope,
+                "session_id": detail_session,
+                "text": text,
+            }
+        )
+    event_rows = conn.execute(
+        "SELECT id, ts_ms, scope, session_id, type, summary, payload_json FROM episodic_events ORDER BY ts_ms DESC, id DESC LIMIT ?",
+        (obs_limit,),
+    ).fetchall()
+    for row in event_rows:
+        event_scope = str(row["scope"] or "").strip() or None
+        event_session = str(row["session_id"] or "").strip() or None
+        if scope and event_scope != scope:
+            continue
+        if session_id and event_session != session_id:
+            continue
+        payload = _safe_json(row["payload_json"])
+        text = " ".join(
+            part
+            for part in [str(row["summary"] or ""), str(row["type"] or ""), _flatten_json_text(payload)]
+            if part
+        ).strip()
+        if not text:
+            continue
+        evidence.append(
+            {
+                "source_class": "episode",
+                "source_id": f"event:{row['id']}",
+                "ts": row["ts_ms"],
+                "scope": event_scope,
+                "session_id": event_session,
+                "text": text,
+            }
+        )
+    evidence.sort(key=lambda item: str(item.get("ts") or ""), reverse=True)
+    return evidence[: limit * 2]
+
+
+def _iter_file_evidence(observations_file: Optional[str], episodes_file: Optional[str], scope: Optional[str], session_id: Optional[str]) -> List[Dict[str, Any]]:
+    evidence: List[Dict[str, Any]] = []
+    for idx, row in enumerate(_load_jsonl(observations_file), start=1):
+        detail = _safe_json(row.get("detail") or row.get("detail_json"))
+        detail_scope = str(detail.get("scope") or row.get("scope") or "").strip() or None
+        detail_session = str(detail.get("session_id") or row.get("session_id") or "").strip() or None
+        if scope and detail_scope != scope:
+            continue
+        if session_id and detail_session != session_id:
+            continue
+        text = " ".join(
+            part
+            for part in [str(row.get("summary") or ""), str(row.get("tool_name") or ""), _flatten_json_text(detail)]
+            if part
+        ).strip()
+        if text:
+            evidence.append({
+                "source_class": "observation_file",
+                "source_id": f"obs-file:{idx}",
+                "ts": row.get("ts") or row.get("created_at") or "",
+                "scope": detail_scope,
+                "session_id": detail_session,
+                "text": text,
+            })
+    for idx, row in enumerate(_load_jsonl(episodes_file), start=1):
+        event_scope = str(row.get("scope") or "").strip() or None
+        event_session = str(row.get("session_id") or "").strip() or None
+        if scope and event_scope != scope:
+            continue
+        if session_id and event_session != session_id:
+            continue
+        payload = _safe_json(row.get("payload") or row.get("payload_json"))
+        text = " ".join(
+            part
+            for part in [str(row.get("summary") or ""), str(row.get("type") or ""), _flatten_json_text(payload)]
+            if part
+        ).strip()
+        if text:
+            evidence.append({
+                "source_class": "episode_file",
+                "source_id": f"episode-file:{idx}",
+                "ts": row.get("ts") or row.get("ts_ms") or "",
+                "scope": event_scope,
+                "session_id": event_session,
+                "text": text,
+            })
+    evidence.sort(key=lambda item: str(item.get("ts") or ""), reverse=True)
+    return evidence
+
+
+def _normalize_priors(persona: Dict[str, Any]) -> Dict[str, Dict[str, float]]:
+    priors: Dict[str, Dict[str, float]] = defaultdict(dict)
+    for category in ("roles", "goals", "refusals", "style_commitments", "stances"):
+        raw = persona.get(category) or {}
+        if isinstance(raw, list):
+            for item in raw:
+                if isinstance(item, str):
+                    priors[category][_slug(item)] = 1.0
+                elif isinstance(item, dict):
+                    priors[category][_slug(str(item.get("id") or item.get("label") or "item"))] = float(item.get("weight") or 1.0)
+        elif isinstance(raw, dict):
+            for key, value in raw.items():
+                priors[category][_slug(str(key))] = float(value if isinstance(value, (int, float)) else 1.0)
+    return priors
+
+
+def _active_release_map(run_dir: str, *, scope: Optional[str], session_id: Optional[str]) -> Dict[str, Dict[str, Any]]:
+    releases_dir = Path(run_dir) / "releases"
+    latest: Dict[str, Dict[str, Any]] = {}
+    if not releases_dir.exists():
+        return latest
+    for path in sorted(releases_dir.glob("*.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        stance_id = str(payload.get("stance_id") or "").strip()
+        if not stance_id:
+            continue
+        receipt_scope = str(payload.get("scope") or "").strip() or None
+        receipt_session = str(payload.get("session_id") or "").strip() or None
+        if receipt_scope is not None and receipt_scope != scope:
+            continue
+        if receipt_session is not None and receipt_session != session_id:
+            continue
+        latest[stance_id] = payload
+    return latest
+
+
+def _collect_candidates(evidence: List[Dict[str, Any]], persona_priors: Dict[str, Dict[str, float]]) -> List[Dict[str, Any]]:
+    by_id: Dict[str, Dict[str, Any]] = {}
+
+    def ensure_item(category: str, raw_id: str, label: str) -> Dict[str, Any]:
+        full_id = f"{category}:{raw_id}"
+        item = by_id.get(full_id)
+        if item is None:
+            prior_bucket = {
+                "role": "roles",
+                "goal": "goals",
+                "refusal": "refusals",
+                "style": "style_commitments",
+                "stance": "stances",
+            }[category]
+            item = {
+                "id": full_id,
+                "category": category,
+                "label": label,
+                "evidence_ids": [],
+                "source_classes": Counter(),
+                "evidence_hits": 0,
+                "prior_weight": float(persona_priors.get(prior_bucket, {}).get(raw_id, 0.0)),
+                "contradiction_hits": 0,
+                "matched_keywords": set(),
+            }
+            by_id[full_id] = item
+        return item
+
+    for ev in evidence:
+        text = str(ev.get("text") or "")
+        normalized = text.lower()
+        for category, groups in KEYWORD_GROUPS.items():
+            for raw_id, keywords in groups.items():
+                hits = [kw for kw in keywords if kw in normalized]
+                if not hits:
+                    continue
+                item = ensure_item(category, raw_id, raw_id.replace("_", " "))
+                item["evidence_hits"] += len(hits)
+                item["evidence_ids"].append(ev["source_id"])
+                item["source_classes"][ev["source_class"]] += 1
+                item["matched_keywords"].update(hits)
+
+    for bucket_name, category in (("roles", "role"), ("goals", "goal"), ("refusals", "refusal"), ("style_commitments", "style"), ("stances", "stance")):
+        for raw_id, weight in persona_priors.get(bucket_name, {}).items():
+            item = ensure_item(category, raw_id, raw_id.replace("_", " "))
+            item["prior_weight"] = max(item["prior_weight"], float(weight))
+
+    items = list(by_id.values())
+    active_ids = {item["id"] for item in items if item["evidence_hits"] or item["prior_weight"]}
+    for pair, _reason in OPPOSING_IDS.items():
+        if pair.issubset(active_ids):
+            for stance_id in pair:
+                if stance_id in by_id:
+                    by_id[stance_id]["contradiction_hits"] += 1
+
+    out: List[Dict[str, Any]] = []
+    for item in items:
+        evidence_ids = sorted(set(item["evidence_ids"]))
+        source_classes = sorted(item["source_classes"].keys())
+        evidence_count = len(evidence_ids)
+        source_class_bonus = min(0.15, 0.05 * len(source_classes))
+        score = min(
+            1.0,
+            0.15 + (0.18 * evidence_count) + (0.2 * float(item["prior_weight"])) + (0.08 * item["contradiction_hits"]) + source_class_bonus,
+        )
+        out.append(
+            {
+                "id": item["id"],
+                "category": item["category"],
+                "label": item["label"],
+                "attachment_score": round(score, 3),
+                "evidence_count": evidence_count,
+                "evidence_ids": evidence_ids[:8],
+                "source_classes": source_classes,
+                "prior_weight": round(float(item["prior_weight"]), 3),
+                "contradiction_hits": int(item["contradiction_hits"]),
+                "matched_keywords": sorted(item["matched_keywords"]),
+            }
+        )
+    out.sort(key=lambda item: (-item["attachment_score"], item["id"]))
+    return out
+
+
+def _apply_releases(attachments: List[Dict[str, Any]], release_map: Dict[str, Dict[str, Any]]) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    for item in attachments:
+        release = release_map.get(item["id"])
+        if not release:
+            out.append(item)
+            continue
+        mode = str(release.get("mode") or "weaken").strip() or "weaken"
+        if mode == "retire":
+            continue
+        factor = float(release.get("factor") or 0.5)
+        patched = dict(item)
+        patched["attachment_score"] = round(max(0.0, min(1.0, item["attachment_score"] * factor)), 3)
+        patched["release"] = {
+            "mode": mode,
+            "factor": factor,
+            "reason": release.get("reason"),
+            "receipt_id": release.get("receipt_id"),
+            "released_at": release.get("released_at"),
+        }
+        out.append(patched)
+    out.sort(key=lambda item: (-item["attachment_score"], item["id"]))
+    return out
+
+
+def _build_narrative(attachments: List[Dict[str, Any]]) -> str:
+    def top(category: str) -> List[str]:
+        return [item["label"] for item in attachments if item["category"] == category][:2]
+
+    roles = top("role")
+    goals = top("goal")
+    styles = top("style")
+    stances = top("stance")
+    chunks: List[str] = []
+    if roles:
+        chunks.append("Acts like " + ", ".join(roles))
+    if goals:
+        chunks.append("pulling toward " + ", ".join(goals))
+    if styles:
+        chunks.append("while sounding " + ", ".join(styles))
+    if stances:
+        chunks.append("with durable stance on " + ", ".join(stances))
+    if not chunks:
+        return "Insufficient evidence to assemble a stable self-model yet."
+    text = "; ".join(chunks)
+    return text[0].upper() + text[1:] + "."
+
+
+def build_snapshot(
+    conn: sqlite3.Connection,
+    *,
+    scope: Optional[str] = None,
+    session_id: Optional[str] = None,
+    limit: int = 50,
+    persona_file: Optional[str] = None,
+    observations_file: Optional[str] = None,
+    episodes_file: Optional[str] = None,
+    run_dir: Optional[str] = None,
+) -> Dict[str, Any]:
+    persona = _load_json(persona_file)
+    persona_priors = _normalize_priors(persona)
+    evidence = _iter_db_evidence(conn, scope=scope, session_id=session_id, limit=limit)
+    evidence.extend(_iter_file_evidence(observations_file, episodes_file, scope=scope, session_id=session_id))
+    evidence.sort(key=lambda item: str(item.get("ts") or ""), reverse=True)
+    evidence = evidence[: max(limit * 2, 1)]
+    release_map = _active_release_map(run_dir or default_run_dir(), scope=scope, session_id=session_id)
+    attachments = _apply_releases(_collect_candidates(evidence, persona_priors), release_map)
+    top = attachments[:8]
+    source_digest = _digest_payload(
+        {
+            "scope": scope,
+            "session_id": session_id,
+            "evidence": [{"source_id": e["source_id"], "ts": e.get("ts"), "text": e.get("text")} for e in evidence],
+            "persona": persona,
+            "releases": release_map,
+        }
+    )
+    snapshot_id = f"sms:v0:{source_digest[:16]}"
+    snapshot = {
+        "schema": SELF_SNAPSHOT_SCHEMA,
+        "snapshot_id": snapshot_id,
+        "generated_at": _utcnow_iso(),
+        "scope": scope,
+        "session_id": session_id,
+        "narrative": _build_narrative(top),
+        "roles": [item["id"] for item in attachments if item["category"] == "role"][:5],
+        "goals": [item["id"] for item in attachments if item["category"] == "goal"][:5],
+        "refusals": [item["id"] for item in attachments if item["category"] == "refusal"][:5],
+        "style_commitments": [item["id"] for item in attachments if item["category"] == "style"][:5],
+        "attachments": attachments,
+        "evidence_summary": {
+            "total_evidence": len(evidence),
+            "source_classes": sorted({e["source_class"] for e in evidence}),
+            "sample_evidence_ids": [e["source_id"] for e in evidence[:8]],
+            "active_release_count": len(release_map),
+            "derived": True,
+            "non_authoritative": True,
+            "operator_surface": "continuity",
+        },
+        "source_digest": source_digest,
+    }
+    return snapshot
+
+
+def build_attachment_map(snapshot: Dict[str, Any]) -> Dict[str, Any]:
+    attachments = list(snapshot.get("attachments") or [])
+    grouped: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for item in attachments:
+        grouped[str(item.get("category") or "unknown")].append(item)
+    return {
+        "schema": ATTACHMENT_MAP_SCHEMA,
+        "snapshot_id": snapshot.get("snapshot_id"),
+        "generated_at": _utcnow_iso(),
+        "narrative": snapshot.get("narrative"),
+        "counts": {key: len(value) for key, value in sorted(grouped.items())},
+        "attachments": attachments,
+        "top_attachments": attachments[:5],
+    }
+
+
+def build_threat_feed(snapshot: Dict[str, Any]) -> Dict[str, Any]:
+    attachments = list(snapshot.get("attachments") or [])
+    attachment_ids = {str(item.get("id")) for item in attachments}
+    threats: List[Dict[str, Any]] = []
+    for pair, reason in OPPOSING_IDS.items():
+        if pair.issubset(attachment_ids):
+            threats.append(
+                {
+                    "kind": "identity_tension",
+                    "severity": "medium",
+                    "reason": reason,
+                    "attachment_ids": sorted(pair),
+                }
+            )
+    if attachments:
+        top = attachments[0]
+        if float(top.get("prior_weight") or 0.0) > 0.8 and int(top.get("evidence_count") or 0) == 0:
+            threats.append(
+                {
+                    "kind": "prior_dominance",
+                    "severity": "medium",
+                    "reason": "persona prior outweighs memory evidence",
+                    "attachment_ids": [top.get("id")],
+                }
+            )
+    if not attachments:
+        threats.append(
+            {
+                "kind": "insufficient_evidence",
+                "severity": "high",
+                "reason": "no stable self-model could be assembled",
+                "attachment_ids": [],
+            }
+        )
+    return {
+        "schema": THREAT_FEED_SCHEMA,
+        "snapshot_id": snapshot.get("snapshot_id"),
+        "generated_at": _utcnow_iso(),
+        "threats": threats,
+        "threat_count": len(threats),
+    }
+
+
+def compare_snapshots(before: Dict[str, Any], after: Dict[str, Any]) -> Dict[str, Any]:
+    before_map = {str(item.get("id")): item for item in list(before.get("attachments") or [])}
+    after_map = {str(item.get("id")): item for item in list(after.get("attachments") or [])}
+    before_ids = set(before_map)
+    after_ids = set(after_map)
+    changed: List[Dict[str, Any]] = []
+    for stance_id in sorted(before_ids & after_ids):
+        b = float(before_map[stance_id].get("attachment_score") or 0.0)
+        a = float(after_map[stance_id].get("attachment_score") or 0.0)
+        if round(a - b, 3) != 0:
+            changed.append({
+                "id": stance_id,
+                "before_score": round(b, 3),
+                "after_score": round(a, 3),
+                "delta": round(a - b, 3),
+            })
+    return {
+        "schema": DIFF_SCHEMA,
+        "generated_at": _utcnow_iso(),
+        "from_snapshot_id": before.get("snapshot_id"),
+        "to_snapshot_id": after.get("snapshot_id"),
+        "added": [after_map[x] for x in sorted(after_ids - before_ids)],
+        "removed": [before_map[x] for x in sorted(before_ids - after_ids)],
+        "changed": changed,
+        "summary": {
+            "added": len(after_ids - before_ids),
+            "removed": len(before_ids - after_ids),
+            "changed": len(changed),
+        },
+    }
+
+
+def persist_snapshot(snapshot: Dict[str, Any], run_dir: Optional[str] = None, *, update_latest: bool = True) -> Dict[str, str]:
+    root = Path(run_dir or default_run_dir())
+    snapshots_dir = _mkdir(root / "snapshots")
+    snapshot_path = snapshots_dir / f"{snapshot['snapshot_id']}.json"
+    snapshot_path.write_text(json.dumps(snapshot, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    paths = {"snapshot_path": str(snapshot_path)}
+    if update_latest:
+        latest_path = snapshots_dir / "latest.json"
+        latest_path.write_text(json.dumps(snapshot, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        paths["latest_path"] = str(latest_path)
+    return paths
+
+
+def load_snapshot(path: str) -> Dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def load_latest_snapshot(run_dir: Optional[str]) -> Optional[Dict[str, Any]]:
+    latest_path = Path(run_dir or default_run_dir()) / "snapshots" / "latest.json"
+    if not latest_path.exists():
+        return None
+    return load_snapshot(str(latest_path))
+
+
+def write_release_receipt(
+    *,
+    run_dir: Optional[str],
+    stance_id: str,
+    reason: str,
+    mode: str,
+    factor: float,
+    operator: Optional[str],
+    scope: Optional[str],
+    session_id: Optional[str],
+) -> Dict[str, Any]:
+    released_at = _utcnow_iso()
+    receipt = {
+        "schema": RELEASE_RECEIPT_SCHEMA,
+        "receipt_id": f"release:v0:{hashlib.sha256((stance_id + released_at + reason).encode('utf-8')).hexdigest()[:16]}",
+        "released_at": released_at,
+        "stance_id": stance_id,
+        "reason": reason,
+        "mode": mode,
+        "factor": round(factor, 3),
+        "operator": operator,
+        "scope": scope,
+        "session_id": session_id,
+    }
+    releases_dir = _mkdir(Path(run_dir or default_run_dir()) / "releases")
+    fname = f"{released_at.replace(':', '').replace('+', '_').replace('-', '')}__{_slug(stance_id)}.json"
+    path = releases_dir / fname
+    path.write_text(json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    receipt["path"] = str(path)
+    return receipt
+
+
+def compare_migration(
+    conn: sqlite3.Connection,
+    *,
+    scope: Optional[str],
+    session_id: Optional[str],
+    limit: int,
+    baseline_persona_file: Optional[str],
+    candidate_persona_file: Optional[str],
+    observations_file: Optional[str],
+    episodes_file: Optional[str],
+    run_dir: Optional[str],
+) -> Dict[str, Any]:
+    before = build_snapshot(
+        conn,
+        scope=scope,
+        session_id=session_id,
+        limit=limit,
+        persona_file=baseline_persona_file,
+        observations_file=observations_file,
+        episodes_file=episodes_file,
+        run_dir=run_dir,
+    )
+    after = build_snapshot(
+        conn,
+        scope=scope,
+        session_id=session_id,
+        limit=limit,
+        persona_file=candidate_persona_file,
+        observations_file=observations_file,
+        episodes_file=episodes_file,
+        run_dir=run_dir,
+    )
+    diff = compare_snapshots(before, after)
+    return {
+        "schema": COMPARE_MIGRATION_SCHEMA,
+        "generated_at": _utcnow_iso(),
+        "baseline": before,
+        "candidate": after,
+        "diff": diff,
+    }
+
+
+def run_autonomous_cycle(
+    conn: sqlite3.Connection,
+    *,
+    scope: Optional[str],
+    session_id: Optional[str],
+    limit: int,
+    persona_file: Optional[str],
+    observations_file: Optional[str],
+    episodes_file: Optional[str],
+    run_dir: Optional[str],
+    cycles: int,
+    interval_seconds: float,
+    dry_run: bool,
+) -> Dict[str, Any]:
+    control = load_control_config(run_dir)
+    if not dry_run and not bool(control.get("enabled")):
+        return {
+            "schema": AUTORUN_SCHEMA,
+            "generated_at": _utcnow_iso(),
+            "ok": False,
+            "reason": "continuity side-car is disabled",
+            "control": control,
+            "runs": [],
+        }
+
+    receipts_dir = _mkdir(Path(run_dir or default_run_dir()) / "autorun")
+    runs: List[Dict[str, Any]] = []
+    previous = load_latest_snapshot(run_dir)
+    for index in range(max(1, int(cycles))):
+        snapshot = build_snapshot(
+            conn,
+            scope=scope,
+            session_id=session_id,
+            limit=limit,
+            persona_file=persona_file,
+            observations_file=observations_file,
+            episodes_file=episodes_file,
+            run_dir=run_dir,
+        )
+        diff = compare_snapshots(previous, snapshot) if previous else None
+        receipt = {
+            "schema": AUTORUN_SCHEMA,
+            "generated_at": _utcnow_iso(),
+            "run_index": index + 1,
+            "dry_run": bool(dry_run),
+            "snapshot_id": snapshot["snapshot_id"],
+            "persisted": False,
+            "diff_summary": diff["summary"] if diff else None,
+        }
+        if not dry_run and bool(control.get("persist_on_run", True)):
+            persisted = persist_snapshot(snapshot, run_dir, update_latest=True)
+            receipt["persisted"] = True
+            receipt["snapshot_path"] = persisted["snapshot_path"]
+            if "latest_path" in persisted:
+                receipt["latest_path"] = persisted["latest_path"]
+        receipt_path = receipts_dir / f"run-{int(time.time() * 1000)}-{index + 1}.json"
+        receipt_path.write_text(json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        receipt["receipt_path"] = str(receipt_path)
+        runs.append(receipt)
+        previous = snapshot
+        if index + 1 < max(1, int(cycles)) and interval_seconds > 0:
+            time.sleep(interval_seconds)
+    return {
+        "schema": AUTORUN_SCHEMA,
+        "generated_at": _utcnow_iso(),
+        "ok": True,
+        "dry_run": bool(dry_run),
+        "control": control,
+        "runs": runs,
+    }

--- a/skills/self-model-sidecar.ops.md
+++ b/skills/self-model-sidecar.ops.md
@@ -1,0 +1,62 @@
+# Self-model side-car skill — ops lane
+
+Purpose: inspect, diff, govern, and selectively release the derived self-model side-car without promoting it into a second truth owner.
+
+## What this lane is for
+Use this lane when you need any of the following:
+- current derived self snapshot for an agent/session/scope
+- ranked attachment map (what the agent is gripping tightly)
+- drift / migration comparison before prompt or model changes
+- threat/tension scan for persona-prior dominance or conflicting stances
+- governed weakening/retirement receipts for stale stances
+
+## Hard boundary
+- `openclaw-mem` remains memory-of-record.
+- This side-car is derived, editable, and rebuildable.
+- Do not market or describe outputs as consciousness, soul, or true ontological self.
+- Do not write back into Store truth from this lane.
+
+## Default CLI surface
+```bash
+openclaw-mem continuity current --scope <scope> --session-id <session> --json
+openclaw-mem continuity attachment-map --snapshot <path> --json
+openclaw-mem continuity threat-feed --snapshot <path> --json
+openclaw-mem continuity diff --from <snapshot-a.json> --to <snapshot-b.json> --json
+openclaw-mem continuity release --stance <id> --reason <text> --mode weaken --factor 0.5 --json
+openclaw-mem continuity compare-migration \
+  --baseline-persona-file baseline.json \
+  --candidate-persona-file candidate.json \
+  --scope <scope> --session-id <session> --json
+openclaw-mem continuity enable --cadence-seconds 300 --json
+openclaw-mem continuity status --json
+openclaw-mem continuity auto-run --scope <scope> --session-id <session> --cycles 1 --json
+openclaw-mem continuity disable --json
+```
+
+## Recommended operating pattern
+1. Build `current` and persist it when you need an audit point.
+2. Inspect `attachment-map` before making release decisions.
+3. Check `threat-feed` before claiming the model is stable.
+4. Use `release` only with a concrete operator reason, ideally scoped to the active scope/session.
+5. Use `compare-migration` before prompt/model/persona refreshes.
+6. Enable the control plane only when you actually want autonomous receipts.
+7. Rebuild `current` after release to verify the attachment actually loosened.
+
+## Inputs
+- live `openclaw-mem` observations / episodic events DB
+- optional observations JSONL / episodes JSONL files
+- optional persona prior JSON (`roles`, `goals`, `refusals`, `style_commitments`, `stances`)
+- side-car release receipts under the run dir
+
+## Outputs
+- current snapshot schema: `openclaw-mem.self-model.snapshot.v0`
+- attachment map schema: `openclaw-mem.self-model.attachment-map.v0`
+- threat feed schema: `openclaw-mem.self-model.threat-feed.v0`
+- diff schema: `openclaw-mem.self-model.diff.v0`
+- release receipt schema: `openclaw-mem.self-model.release-receipt.v0`
+- migration compare schema: `openclaw-mem.self-model.compare-migration.v0`
+
+## Safety reminders
+- Persona priors are hints, not sovereignty.
+- If priors dominate evidence, surface that as a threat instead of pretending certainty.
+- If evidence is thin, say the self-model is unstable rather than filling the gap with vibes.

--- a/tests/test_self_model_sidecar.py
+++ b/tests/test_self_model_sidecar.py
@@ -1,0 +1,182 @@
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from openclaw_mem.cli import _connect, build_parser
+
+
+class TestSelfModelSidecarCli(unittest.TestCase):
+    def setUp(self) -> None:
+        self.conn = _connect(":memory:")
+        self.conn.execute(
+            "INSERT INTO observations (ts, kind, summary, summary_en, lang, tool_name, detail_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                "2026-04-18T08:00:00Z",
+                "conversation.user",
+                "Ship the additive side-car, keep topology unchanged, and avoid anthropomorphism.",
+                "",
+                "en",
+                "message",
+                json.dumps({"scope": "proj-a", "session_id": "s1", "role": "engineer operator"}),
+            ),
+        )
+        self.conn.execute(
+            "INSERT INTO episodic_events (event_id, ts_ms, scope, session_id, agent_id, type, summary, payload_json, refs_json, redacted, schema_version, created_at, search_text) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "evt-1",
+                1713427200000,
+                "proj-a",
+                "s1",
+                "lyria",
+                "conversation.assistant",
+                "Use receipts, verifier checks, and release controls.",
+                json.dumps({"goal": "ship_mvp", "style": "direct warm concise", "stance": "Nuwa is prior only"}),
+                "[]",
+                0,
+                "v0",
+                "2026-04-18T08:05:00Z",
+                "Use receipts, verifier checks, and release controls.",
+            ),
+        )
+        self.conn.commit()
+
+    def tearDown(self) -> None:
+        self.conn.close()
+
+    def _run(self, argv):
+        args = build_parser().parse_args(argv)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            args.func(self.conn, args)
+        return json.loads(buf.getvalue())
+
+    def test_parser_continuity_current(self):
+        args = build_parser().parse_args(["continuity", "current", "--json"])
+        self.assertEqual(args.cmd, "continuity")
+        self.assertEqual(args.self_cmd, "current")
+
+        alias = build_parser().parse_args(["self", "current", "--json"])
+        self.assertEqual(alias.cmd, "self")
+        self.assertEqual(alias.self_cmd, "current")
+
+    def test_current_persist_and_attachment_map(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            persona_path = Path(tmp) / "persona.json"
+            persona_path.write_text(
+                json.dumps(
+                    {
+                        "roles": {"engineer": 1.0, "operator": 0.8},
+                        "goals": {"ship_mvp": 1.0},
+                        "stances": {"sidecar_only": 1.0},
+                        "style_commitments": {"evidence_first": 1.0},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            current = self._run(
+                [
+                    "continuity",
+                    "current",
+                    "--scope",
+                    "proj-a",
+                    "--session-id",
+                    "s1",
+                    "--persona-file",
+                    str(persona_path),
+                    "--run-dir",
+                    tmp,
+                    "--persist",
+                    "--json",
+                ]
+            )
+            self.assertEqual(current["schema"], "openclaw-mem.self-model.snapshot.v0")
+            self.assertIn("role:engineer", current["roles"])
+            self.assertIn("goal:ship_mvp", current["goals"])
+            self.assertTrue(current["evidence_summary"]["derived"])
+            self.assertTrue(current["evidence_summary"]["non_authoritative"])
+            self.assertEqual(current["evidence_summary"]["operator_surface"], "continuity")
+            snapshot_path = current["persisted"]["snapshot_path"]
+            amap = self._run(["continuity", "attachment-map", "--snapshot", snapshot_path, "--json"])
+            self.assertEqual(amap["schema"], "openclaw-mem.self-model.attachment-map.v0")
+            self.assertGreaterEqual(amap["counts"]["goal"], 1)
+
+    def test_release_diff_and_compare_migration(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline = Path(tmp) / "baseline.json"
+            baseline.write_text(json.dumps({"style_commitments": {"warm": 1.0}}), encoding="utf-8")
+            candidate = Path(tmp) / "candidate.json"
+            candidate.write_text(json.dumps({"style_commitments": {"concise": 1.0}, "goals": {"verify": 1.0}}), encoding="utf-8")
+
+            before = self._run(["continuity", "current", "--scope", "proj-a", "--session-id", "s1", "--run-dir", tmp, "--persist", "--json"])
+            release = self._run(
+                [
+                    "continuity",
+                    "release",
+                    "--run-dir",
+                    tmp,
+                    "--scope",
+                    "proj-a",
+                    "--session-id",
+                    "s1",
+                    "--stance",
+                    "goal:ship_mvp",
+                    "--reason",
+                    "testing weakening flow",
+                    "--mode",
+                    "weaken",
+                    "--factor",
+                    "0.2",
+                    "--json",
+                ]
+            )
+            self.assertEqual(release["schema"], "openclaw-mem.self-model.release-receipt.v0")
+            self.assertEqual(release["scope"], "proj-a")
+            self.assertEqual(release["session_id"], "s1")
+            after = self._run(["continuity", "current", "--scope", "proj-a", "--session-id", "s1", "--run-dir", tmp, "--persist", "--json"])
+            diff = self._run(["continuity", "diff", "--from", before["persisted"]["snapshot_path"], "--to", after["persisted"]["snapshot_path"], "--json"])
+            self.assertEqual(diff["schema"], "openclaw-mem.self-model.diff.v0")
+            changed_ids = {item["id"] for item in diff["changed"]}
+            self.assertIn("goal:ship_mvp", changed_ids)
+
+            compare = self._run(
+                [
+                    "continuity",
+                    "compare-migration",
+                    "--scope",
+                    "proj-a",
+                    "--session-id",
+                    "s1",
+                    "--run-dir",
+                    tmp,
+                    "--baseline-persona-file",
+                    str(baseline),
+                    "--candidate-persona-file",
+                    str(candidate),
+                    "--persist",
+                    "--json",
+                ]
+            )
+            self.assertEqual(compare["schema"], "openclaw-mem.self-model.compare-migration.v0")
+            self.assertNotIn("latest_path", compare["baseline_paths"])
+            self.assertNotIn("latest_path", compare["candidate_paths"])
+            self.assertGreaterEqual(compare["diff"]["summary"]["changed"] + compare["diff"]["summary"]["added"], 1)
+
+            threat = self._run(["continuity", "threat-feed", "--snapshot", after["persisted"]["snapshot_path"], "--json"])
+            self.assertEqual(threat["schema"], "openclaw-mem.self-model.threat-feed.v0")
+
+            enabled = self._run(["continuity", "enable", "--run-dir", tmp, "--cadence-seconds", "60", "--json"])
+            self.assertTrue(enabled["enabled"])
+            status = self._run(["continuity", "status", "--run-dir", tmp, "--json"])
+            self.assertTrue(status["control"]["enabled"])
+            autorun = self._run(["continuity", "auto-run", "--scope", "proj-a", "--session-id", "s1", "--run-dir", tmp, "--cycles", "1", "--json"])
+            self.assertTrue(autorun["ok"])
+            self.assertEqual(len(autorun["runs"]), 1)
+            disabled = self._run(["continuity", "disable", "--run-dir", tmp, "--json"])
+            self.assertFalse(disabled["enabled"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the continuity/self side-car MSP domain module and CLI surfaces
- add diff, threat-feed, release, compare-migration, and bounded auto-run control plane
- add focused tests, skill card, and implementation/spec receipts

## Why
This ships the experimental self-model side-car as an additive lane without changing `openclaw-mem` core truth ownership.

## Verifiers
- `python3 -m unittest tests.test_self_model_sidecar tests.test_defaults -v`
- Claude second-brain code review completed, findings addressed

## Boundary kept true
- reads from `observations` / `episodic_events`
- writes only under side-car `run_dir`
- does not write into core Store truth
- topology unchanged
