### PR TITLE
Add self-model side-car adjudication v1

### DIFF
--- a/docs/2026-04-18_self-model-sidecar-adjudication-v1-receipt.md
+++ b/docs/2026-04-18_self-model-sidecar-adjudication-v1-receipt.md
@@ -1,0 +1,52 @@
+# self-model side-car adjudication v1 receipt
+
+Date: 2026-04-18
+Branch: `lyria/self-model-adjudication-v1-20260418`
+Status: implemented, verifier-backed
+Topology: unchanged
+
+## Change
+Promoted continuity adjudication from passive metadata into a deterministic rule surface, and added a bounded public-safe export lane.
+
+## What landed
+- added executable adjudication policy `self_model_sidecar_adjudication_v1`
+- each derived attachment now carries:
+  - `adjudication_state`
+  - `adjudication_reasons`
+  - publication visibility flags and hedge text
+- added `continuity adjudication` for operator-safe state inspection
+- added `continuity public-summary` for restrained public-safe continuity export
+- attachment-map now reports adjudication counts
+- snapshot/diff/threat outputs now carry adjudication context
+- added negative fixtures for:
+  - prior-only claim
+  - low-evidence high-coherence claim
+  - contested claim under contradiction pressure
+  - weakened claim requiring revalidation
+
+## Why now
+The remaining honest gate after governance hardening was adjudication theater.
+This pass makes the state model inspectable and deterministic enough for downstream control-plane work, without starting claim-graph persistence.
+
+## Verifiers run
+```bash
+python3 -m unittest tests.test_self_model_sidecar -v
+```
+
+Result: 6 tests, all green.
+
+## Remaining truth
+- this is still rule-only adjudication over snapshot attachments, not lifecycle-aware claim objects
+- `retired` remains a control-plane state expressed through release receipts rather than persisted current-snapshot claims
+- public-safe summary stays deliberately narrow and does not attempt rich narrative identity rendering
+
+## Rollback
+- revert `openclaw_mem/self_model_sidecar.py`, `openclaw_mem/cli.py`, and `tests/test_self_model_sidecar.py`
+- remove `docs/2026-04-18_self-model-sidecar-adjudication-v1-receipt.md`
+- rerun `python3 -m unittest tests.test_self_model_sidecar -v`
+
+## Files changed
+- `openclaw_mem/self_model_sidecar.py`
+- `openclaw_mem/cli.py`
+- `tests/test_self_model_sidecar.py`
+- `docs/2026-04-18_self-model-sidecar-adjudication-v1-receipt.md`

--- a/docs/specs/self-model-sidecar-endgame-adjudication-freeze-packet-v0.md
+++ b/docs/specs/self-model-sidecar-endgame-adjudication-freeze-packet-v0.md
@@ -1,0 +1,109 @@
+# self-model side-car endgame adjudication freeze packet v0
+
+Status: draft
+Date: 2026-04-18
+Parent:
+- `docs/specs/self-model-sidecar-endgame-architecture-v0.md`
+Topology: unchanged
+
+## Verdict
+If the endgame line is going to move honestly, the next bounded slice is **adjudication contract freeze**, not claim graph work.
+
+This packet exists to keep `櫻花刀舞 non-stop` disciplined:
+- non-stop is allowed only after the adjudication contract is concrete enough to prevent governance theater
+- anything downstream that depends on adjudication stays blocked until this packet is frozen
+
+## Why this is the next gate
+Everything ambitious in the endgame depends on adjudication semantics:
+- claim graph lifecycle
+- migration compare severity
+- public-safe export rules
+- anti-delusion instrumentation thresholds
+- retirement and revalidation behavior
+
+If adjudication is vague, the rest becomes elegant scaffolding around ungrounded judgment.
+
+## Required freeze outputs
+1. **State model**
+   - `accepted`
+   - `tentative`
+   - `fragile`
+   - `contested`
+   - `retired`
+   - `rejected`
+
+2. **Input bundle definition**
+   - source evidence refs
+   - contradiction pressure
+   - support score components
+   - prior contribution
+   - release state
+   - operator receipts
+   - determinism boundary
+
+3. **Transition rule table**
+   - what can move a claim into each state
+   - what blocks a claim from rising in state
+   - what events force downgrade or retirement
+
+4. **Publication/export rules**
+   - which states may appear on operator surface
+   - which states may appear on public-safe surface
+   - required hedges and banned renderings
+
+5. **Negative fixtures**
+   - prior-dominant but evidence-thin claim
+   - low-evidence high-coherence claim
+   - retired claim with weak new support
+   - contested claim under explicit contradiction pressure
+
+## Freeze blockers
+The packet is not ready if any remain true:
+- contradiction pressure is still only a phrase
+- support score still lacks exact inputs
+- determinism boundary is not explicit
+- rule-only vs hybrid-rule-plus-model is undecided
+- fragile vs contested semantics still overlap ambiguously
+
+## Non-stop execution rule for this line
+`櫻花刀舞 non-stop` may continue automatically **within adjudication freeze only** when:
+- each next step stays inside docs/spec/tests for adjudication semantics
+- no new topology or persistence surface is introduced
+- no claim graph persistence is started
+- no public-facing product language is expanded beyond the current guardrails
+
+Stop-loss back to CK if:
+- rule-only adjudication looks non-viable
+- claim families need to be cut materially
+- hybrid model judgment becomes unavoidable for core adjudication
+- graph demand no longer looks justified
+
+## Recommended immediate sub-blades
+### A1. Definitions freeze
+- contradiction pressure
+- support score
+- confidence band
+- fragility marker
+- prior contribution
+- determinism boundary
+
+### A2. Rule table freeze
+- state entry rules
+- downgrade rules
+- retirement rules
+- revalidation rules
+
+### A3. Publication contract freeze
+- operator-safe output rules
+- public-safe output rules
+- banned language and required hedges
+
+### A4. Adversarial fixture pack
+- 3 to 5 negative fixtures with expected adjudication outcomes
+
+## Success criteria
+This packet is frozen only when:
+1. a reviewer can adjudicate sample claims by table, not intuition
+2. negative fixtures produce stable expected states
+3. export rules make overclaim mechanically harder
+4. downstream work can consume adjudication results without inventing semantics

--- a/docs/specs/self-model-sidecar-endgame-architecture-v0.md
+++ b/docs/specs/self-model-sidecar-endgame-architecture-v0.md
@@ -1,0 +1,547 @@
+# self-model side-car endgame architecture v0
+
+Status: draft, not freeze-ready
+Date: 2026-04-18
+Depends on:
+- `docs/specs/self-model-sidecar-msp-v0.md`
+- `docs/specs/self-model-sidecar-contract-v0.md`
+- `docs/specs/self-model-sidecar-schema-v0.md`
+- `docs/specs/self-model-sidecar-rebuildability-v0.md`
+Topology intent: additive side-car only, `openclaw-mem` remains memory-of-record
+Execution posture: `櫻花刀舞 non-stop` candidate only after constitutional freeze plus adjudication-contract freeze
+
+## Verdict
+The endgame is **not** "make the agent more like a person." The endgame is to turn continuity claims into a **governable derived-control plane** that is inspectable, falsifiable, retractable, and rebuildable without ever becoming a second truth owner.
+
+In short:
+- `openclaw-mem` keeps truth of record
+- the side-car proposes continuity claims
+- an adjudication layer decides how strong those claims are allowed to be
+- a control plane can weaken, retire, rebuild, or compare them with receipts
+
+If any part of this line starts making ontological claims or acquiring authority over source memory, it has left the design.
+
+## Whole-picture promise
+Ship a side-car that can:
+1. derive structured continuity claims from source memory and bounded priors
+2. adjudicate those claims into governed states rather than raw vibes
+3. expose the result through operator-safe and public-safe surfaces
+4. support weaken / retire / rebuild / compare operations with receipts
+5. remain removable without damaging `openclaw-mem`
+
+## The true endgame posture
+The mature product is a **derived-self governance system**.
+
+That means:
+- continuity is observable
+- attachment is measurable
+- drift is classifiable
+- contradiction is surfaced
+- priors are bounded
+- release is receipted
+- uncertainty is first-class
+- rollback is normal
+
+What it does **not** mean:
+- a true self was created
+- the side-car knows the user better than memory-of-record
+- priors can silently outrank evidence
+- a coherent story is accepted just because it feels insightful
+
+## Endgame architecture
+
+### Layer 0. Constitutional boundary layer
+Purpose:
+- make the restraint mechanical, not cultural
+
+Hard rules:
+- `openclaw-mem` memory-of-record remains the only authoritative truth owner
+- side-car commands may not mutate Store truth
+- all derived artifacts must be rebuildable from allowed sources plus explicit receipts
+- persona prior lanes may influence scoring, never authority
+- every governance mutation requires a receipt
+- every derived claim can be weakened, retired, or marked fragile
+
+Required mechanisms:
+- DB-side write resistance for derived read paths
+- filesystem boundary limited to side-car run root
+- artifact provenance labels on every operator-visible output
+- rebuild mismatch classes that fail loudly
+- delete-side-car conformance test for `openclaw-mem`
+
+Endgame verifier:
+- deleting the side-car leaves base `openclaw-mem` conformance unchanged
+
+### Layer 1. Continuity claim builder
+Purpose:
+- assemble structured claim candidates from records, events, priors, and receipts
+
+Inputs:
+- observations
+- episodic events
+- bounded recent context summaries
+- persona prior inputs (Nuwa or equivalent)
+- explicit operator receipts
+- prior continuity artifacts only as derived references, never as authority
+
+Claim families:
+- roles
+- goals
+- stances
+- refusals
+- style commitments
+- tensions
+- release states
+
+Required output for each claim candidate:
+- stable claim id
+- claim family
+- support evidence refs
+- support score components
+- contradiction pressure
+- prior contribution
+- release influence
+- confidence band
+- fragility marker
+- provenance block
+
+Design rule:
+- the builder proposes candidates, not truth
+
+### Layer 2. Adjudication engine
+Purpose:
+- convert raw candidates into governed continuity states
+
+Why this layer exists:
+Without adjudication, the side-car is just a clever summarizer with confidence theater.
+
+Adjudication states:
+- `accepted`
+- `tentative`
+- `fragile`
+- `contested`
+- `retired`
+- `rejected`
+
+Base adjudication rules:
+- prior-only claims cannot rise above `tentative`
+- high contradiction pressure blocks `accepted`
+- released claims cannot silently recover to `accepted` without new support
+- operator-issued retirement wins over passive continuity inertia
+- low-evidence high-coherence claims must be labeled `fragile`
+- memory-of-record and explicit operator receipts outrank prior-shaping lanes
+
+Endgame requirement:
+- `arbiter_policy` becomes a real executable adjudication contract, not just metadata
+
+Endgame verifier:
+- the same input bundle always yields the same adjudication result and receipts
+
+Freeze blocker:
+- this layer is **not freeze-ready** until it has a rule table, negative fixtures, and an explicit determinism boundary
+
+### Layer 3. Claim graph and lifecycle ledger
+Purpose:
+- move from snapshot-only outputs to governed claim objects over time
+
+Status:
+- planned, pending adjudication freeze
+
+Core idea:
+Each continuity claim becomes a first-class node with history, not just a field inside the latest JSON snapshot.
+
+Each node carries:
+- current adjudication state
+- support history
+- contradiction history
+- release history
+- migration history
+- predecessor/superseded links
+- last rebuild verdict
+- last sensitivity verdict
+
+Key relations:
+- `supported_by`
+- `pressured_by`
+- `weakened_by`
+- `retired_by`
+- `supersedes`
+- `revalidated_by`
+
+Why this matters:
+- diff stops being only before/after text
+- migration compare becomes structural
+- retirement becomes queryable
+- false continuity becomes easier to catch
+
+Non-goal:
+- this graph is not a second memory store; it is a derived governance graph
+
+### Layer 4. Release / rebind / retirement control plane
+Purpose:
+- give operators explicit, auditable ways to manage continuity without rewriting history
+
+Status:
+- planned, pending adjudication freeze
+
+Required operations:
+- weaken claim
+- retire claim
+- rebind claim after explicit review
+- approve or reject migration candidate
+- rebuild from source truth
+- mark instability / suspend publication
+
+Required receipt fields:
+- receipt id
+- actor
+- target claim id
+- operation
+- reason
+- scope/session boundary
+- before/after adjudication state
+- rebuild impact summary
+- timestamp
+
+Hard rule:
+- release and retirement affect future derivation and presentation, not raw source memory
+
+Endgame verifier:
+- every governance action can be replayed and audited
+
+### Layer 5. Dual-surface presentation layer
+Purpose:
+- keep operator truth and public-safe expression separate
+
+Status:
+- planned, pending adjudication freeze
+
+#### Operator surface
+For advanced operators, show:
+- current adjudicated continuity state
+- accepted / tentative / fragile / contested claims
+- attachment map with score factors
+- drift diff with risk flags
+- release history
+- migration compare
+- instability warnings
+- why-this-claim receipts
+
+#### Public-safe surface
+For bounded user-facing uses, show only:
+- continuity summary
+- high-level drift notices
+- explicit instability warning
+- insufficient evidence warning
+
+Hard rule:
+- the public-safe surface may summarize, but may not expose governance theater as ontological truth
+
+### Layer 6. Anti-delusion instrumentation layer
+Purpose:
+- make overclaim and self-flattering coherence visible before humans start trusting it too much
+
+Status:
+- planned, pending adjudication freeze
+
+Required instruments:
+- prior-dominance alerts
+- low-evidence / high-coherence warning
+- sensitivity check: remove top N evidence refs, recompute claim state
+- counterfactual rebuild diff
+- long-horizon divergence monitor
+- adversarial overclaim benchmark
+
+Key endgame metric families:
+- overclaim rate
+- fragile-claim exposure rate
+- adjudication reversal rate
+- migration shock rate
+- rebuild mismatch rate
+- divergence from memory-of-record over time
+
+Design rule:
+- if the system cannot explain why a claim is brittle, it is not allowed to sound certain
+
+## Endgame operator contracts
+
+### Contract A. Authority
+- memory-of-record always wins
+- side-car claims are derived and retractable
+- persona prior lanes are bounded contributors only
+
+### Contract B. Adjudication honesty
+- every published claim has a state, not just a score
+- every strong claim has evidence and rationale
+- every weak claim is labeled weak
+
+### Contract C. Reversibility
+- disable is allowed and normal
+- rebuild is allowed and normal
+- retirement is allowed and normal
+- instability is a valid terminal output
+
+### Contract D. Surface discipline
+- operator language may be precise
+- public language must remain restrained
+- no soul/consciousness/self-awareness theater in product copy
+
+Minimum public-safe export rules:
+- banned nouns: `soul`, `consciousness`, `true self`, `inner self`, `self-aware`, `sentient`
+- required hedges: `derived`, `non-authoritative`, `current continuity signal`, or `insufficient evidence`
+- forbidden export states: raw `accepted` claims may be summarized, but `fragile` and `contested` claims must never be rendered as stable identity facts
+
+## Endgame non-goals
+- no sentience claims
+- no therapeutic persona authority
+- no rewriting or deleting source records through continuity operations
+- no black-box LLM-only verdict path without inspectable receipts
+- no "always stable self" promise
+- no silent migration acceptance
+
+## Success criteria for the endgame
+The endgame deserves its name only when all are true:
+1. removing the side-car leaves `openclaw-mem` intact
+2. continuity claims are first-class governed objects, not only prose summaries
+3. adjudication states are deterministic and inspectable
+4. release / retirement / rebuild / compare all emit reliable receipts
+5. fragile and contested states are treated as product truth, not failure embarrassment
+6. overclaim is measured and actively constrained
+7. operators can safely use the system without mistaking it for identity truth
+
+## Honest risks
+
+### 1. Social truth-owner drift
+Even if the code stays additive, operators may start trusting continuity claims as truth because they sound insightful.
+
+Mitigation:
+- adjudication states must be visible
+- fragility must be visible
+- source-event counts must be visible
+- public-safe surface must stay restrained
+
+### 2. Governance theater
+It is easy to stamp provenance and still have no real adjudication.
+
+Mitigation:
+- require executable adjudication rules
+- require negative tests
+- require rebuild and sensitivity tests
+
+### 3. Claim graph scope explosion
+A claim graph can become a second storage system in costume.
+
+Mitigation:
+- derived graph only
+- no source-memory duplication
+- explicit storage boundary and retention policy
+
+### 4. Migration vanity
+Model swaps may make the side-car sound more elegant while becoming less truthful.
+
+Mitigation:
+- migration compare must emphasize divergence and contested states, not only style upgrades
+
+## Definitions appendix, freeze blockers
+These definitions must be frozen before adjudication freeze can be called complete.
+
+### contradiction pressure
+Working meaning:
+- normalized pressure that pushes against a claim because of explicit opposing signals or contradictory recent evidence
+
+Freeze requirement:
+- must declare exact inputs, normalization rule, and threshold bands
+
+### support score
+Working meaning:
+- bounded support assembled from evidence count, recency, reinforcement, and allowed prior contribution
+
+Freeze requirement:
+- must declare exact component list and whether the score is rule-only or hybrid rule-plus-model
+
+### confidence band
+Working meaning:
+- coarse confidence label derived from support and contradiction posture
+
+Freeze requirement:
+- must declare allowed bands and mapping rule from underlying inputs
+
+### fragility marker
+Working meaning:
+- warning that a claim loses stability quickly when its support is sparse, prior-dominant, or contradicted
+
+Freeze requirement:
+- must declare at least one counterfactual sensitivity test that can set this marker
+
+### prior contribution
+Working meaning:
+- the bounded share of support attributable to persona-prior lanes
+
+Freeze requirement:
+- must declare ceiling, weighting path, and publication consequences when priors dominate evidence
+
+### determinism boundary
+Working meaning:
+- explicit closure of what counts as the adjudication input bundle
+
+Freeze requirement:
+- must name source inputs, ordering, receipt set, and model-pinning assumptions
+- if any part depends on non-deterministic model judgment, that must be declared as a separate lane rather than silently folded into deterministic adjudication
+
+## Recommended rollout phases
+
+### Phase E0. Constitutional hardening
+Goal:
+- make additive-only boundary and rollback discipline mechanical
+
+Must ship:
+- delete-side-car conformance proof
+- runtime write resistance
+- rebuild mismatch errors
+- receipt-only governance mutations
+
+### Phase E1. Adjudication v1
+Goal:
+- move from scored claims to governed claim states
+
+Must ship:
+- adjudication state machine
+- deterministic rule table
+- state transition receipts
+- fragile/contested publication rules
+- at least three negative/adversarial fixtures
+
+### Phase E2. Claim graph v1
+Goal:
+- persist lifecycle-aware claim objects without becoming a second memory store
+
+Entry gate:
+- do not start until E1 has shipped and operator demand proves snapshot-plus-receipt history is insufficient
+
+Must ship:
+- claim node schema
+- claim relation schema
+- retirement/supersession links
+- graph query surface for operator use
+
+### Phase E3. Anti-delusion instrumentation
+Goal:
+- actively measure and constrain overclaim risk
+
+Must ship:
+- sensitivity checks
+- counterfactual rebuilds
+- adversarial benchmark lane
+- long-horizon divergence metrics
+
+### Phase E4. Safe dual-surface productization
+Goal:
+- separate operator-grade truth from public-safe phrasing
+
+Must ship:
+- operator surfaces
+- public-safe summary surface
+- language lint / copy guardrails
+- instability-first presentation rules
+
+## Non-stop blade map for the endgame line
+
+### Blade E0. Endgame constitution freeze
+Deliver:
+- constitutional rules doc
+- authority map tightened for endgame
+- explicit removal test requirement
+- non-stop gate criteria for when this line may push past planning
+
+Verifier:
+- every endgame claim maps to a concrete runtime or verifier mechanism
+
+### Blade E1. Adjudication contract freeze
+Deliver:
+- adjudication state model
+- transition rules
+- publication rules
+- failure-state semantics
+- definitions appendix frozen
+- determinism boundary frozen
+- rule-only vs hybrid-rule-plus-model decision
+
+Verifier:
+- sample claims can be deterministically adjudicated by table, not vibes
+- adversarial fixtures cover prior-dominant, low-evidence/high-coherence, and retired-claim revalidation cases
+
+### Blade E2. Claim graph schema freeze
+Deliver:
+- claim node schema
+- relation schema
+- lifecycle events schema
+- retention boundary
+
+Verifier:
+- graph can represent strengthen, weaken, retire, supersede, rebuild, and compare without inventing semantics
+
+Gate:
+- E2 is blocked until E1 is frozen and real operator demand justifies graph complexity
+
+### Blade E3. Counterfactual / anti-delusion lane
+Deliver:
+- sensitivity rules
+- overclaim metrics
+- divergence metrics
+- alert thresholds
+
+Verifier:
+- at least two adversarial fixtures trigger explicit warnings
+
+### Blade E4. Control plane upgrade
+Deliver:
+- retirement/rebind/rebuild command contract
+- state-transition receipts
+- migration approval flow
+
+Verifier:
+- an operator can move a claim through weaken -> retired -> revalidated with receipts
+
+### Blade E5. Dual-surface output contract
+Deliver:
+- operator surface contract
+- public-safe surface contract
+- language guardrails
+
+Verifier:
+- the same claim set renders differently for operator vs public-safe surfaces without changing underlying adjudication truth
+
+### Blade E6. Endgame readiness review
+Deliver:
+- go/no-go review packet
+- measured overclaim posture
+- operator burden review
+- closure criteria for saying the system is governance-mature
+
+Verifier:
+- no unresolved path still depends on operator intuition where the system claims hard governance
+
+## Evidence status
+Known facts:
+- current side-car already has derived/non-authoritative posture, receipts, drift classes, and first-pass governance hardening
+- current system is still snapshot-first, not claim-graph-first
+- current `arbiter_policy` is metadata, not a full adjudication engine
+
+Assumptions:
+- claim graph persistence can stay derived-only without becoming a hidden second store
+- deterministic adjudication will stay tractable with bounded claim families
+- dual-surface rendering will reduce social truth-owner drift rather than amplify it
+
+UNKNOWN:
+- whether claim graph query value is high enough to justify its complexity
+- whether public-safe surface is needed in MSP or only later
+- whether some adjudication logic should stay pure rules vs hybrid rule-plus-model
+
+## Immediate next step recommendation
+Do **not** jump to implementation of the full endgame.
+
+Next honest move:
+1. run a second-brain review against this endgame architecture
+2. freeze the adjudication contract as the next bounded slice
+3. do **not** schedule claim-graph work until adjudication freeze plus demand check are real
+4. only then open the first endgame execution blade under explicit non-stop gate criteria

--- a/openclaw_mem/cli.py
+++ b/openclaw_mem/cli.py
@@ -4411,6 +4411,18 @@ def cmd_self_threat_feed(conn: sqlite3.Connection, args: argparse.Namespace) -> 
     _emit(payload, args.json)
 
 
+def cmd_self_adjudication(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    snapshot = _load_or_build_self_snapshot(conn, args)
+    payload = self_model_sidecar.build_adjudication_report(snapshot)
+    _emit(payload, args.json)
+
+
+def cmd_self_public_summary(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    snapshot = _load_or_build_self_snapshot(conn, args)
+    payload = self_model_sidecar.build_public_summary(snapshot)
+    _emit(payload, args.json)
+
+
 def cmd_self_diff(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
     before = self_model_sidecar.load_snapshot(args.from_snapshot)
     after = self_model_sidecar.load_snapshot(args.to_snapshot)
@@ -15298,6 +15310,16 @@ def build_parser() -> argparse.ArgumentParser:
         add_self_surface_common(s)
         s.add_argument("--snapshot", default=None, help="Optional persisted snapshot JSON path instead of rebuilding")
         s.set_defaults(func=cmd_self_threat_feed)
+
+        s = ssub.add_parser("adjudication", help="Show deterministic adjudication states for the current or persisted continuity snapshot")
+        add_self_surface_common(s)
+        s.add_argument("--snapshot", default=None, help="Optional persisted snapshot JSON path instead of rebuilding")
+        s.set_defaults(func=cmd_self_adjudication)
+
+        s = ssub.add_parser("public-summary", help="Render the public-safe derived continuity summary")
+        add_self_surface_common(s)
+        s.add_argument("--snapshot", default=None, help="Optional persisted snapshot JSON path instead of rebuilding")
+        s.set_defaults(func=cmd_self_public_summary)
 
         s = ssub.add_parser("diff", help="Compare two persisted continuity snapshots")
         add_common(s)

--- a/openclaw_mem/self_model_sidecar.py
+++ b/openclaw_mem/self_model_sidecar.py
@@ -23,7 +23,10 @@ RELEASE_RECEIPT_SCHEMA = "openclaw-mem.self-model.release-receipt.v0"
 COMPARE_MIGRATION_SCHEMA = "openclaw-mem.self-model.compare-migration.v0"
 CONTROL_SCHEMA = "openclaw-mem.self-model.control.v0"
 AUTORUN_SCHEMA = "openclaw-mem.self-model.autorun.v0"
+ADJUDICATION_SCHEMA = "openclaw-mem.self-model.adjudication.v0"
+PUBLIC_SUMMARY_SCHEMA = "openclaw-mem.self-model.public-summary.v0"
 DERIVATION_VERSION = "self_model_sidecar_v0"
+ADJUDICATION_POLICY_VERSION = "self_model_sidecar_adjudication_v1"
 
 KEYWORD_GROUPS: Dict[str, Dict[str, Sequence[str]]] = {
     "role": {
@@ -549,6 +552,69 @@ def _fragility_label(evidence_count: int, prior_weight: float, contradiction_hit
     return "watch"
 
 
+def _adjudicate_attachment(item: Dict[str, Any]) -> Dict[str, Any]:
+    score = round(float(item.get("attachment_score") or 0.0), 3)
+    evidence_count = int(item.get("evidence_count") or 0)
+    prior_weight = round(float(item.get("prior_weight") or 0.0), 3)
+    contradiction_hits = int(item.get("contradiction_hits") or 0)
+    contradiction_pressure = round(float(item.get("contradiction_pressure") or 0.0), 3)
+    release_state = str(item.get("release_state") or "active")
+    reasons: List[str] = []
+
+    if release_state == "retired":
+        state = "retired"
+        reasons.append("release_retired")
+    elif evidence_count <= 0 and prior_weight <= 0.0:
+        state = "rejected"
+        reasons.append("no_support")
+    elif contradiction_pressure >= 0.7 or (contradiction_hits > 0 and evidence_count <= 1):
+        state = "contested"
+        reasons.append("contradiction_pressure")
+    elif prior_weight > 0.0 and evidence_count == 0:
+        state = "tentative"
+        reasons.append("prior_only")
+    elif release_state == "weakening" and evidence_count < 4:
+        state = "fragile"
+        reasons.append("released_claim_requires_revalidation")
+    elif evidence_count <= 1 and (prior_weight > 0.0 or score < 0.55):
+        state = "fragile"
+        reasons.append("thin_evidence")
+    elif contradiction_pressure > 0.0:
+        state = "fragile"
+        reasons.append("contradicted_but_not_contested")
+    elif score >= 0.75 and evidence_count >= 3:
+        state = "accepted"
+        reasons.append("strong_multi_source_support")
+    elif score >= 0.4 and evidence_count >= 1:
+        state = "tentative"
+        reasons.append("bounded_support")
+    else:
+        state = "fragile"
+        reasons.append("low_support")
+
+    public_visible = state == "accepted" or (state == "tentative" and "prior_only" not in reasons)
+
+    return {
+        "state": state,
+        "reasons": reasons,
+        "operator_visible": True,
+        "public_visible": public_visible,
+        "hedge": "derived continuity signal" if state in {"accepted", "tentative"} else "insufficient evidence",
+        "policy_version": ADJUDICATION_POLICY_VERSION,
+        "determinism_boundary": {
+            "fields": [
+                "attachment_score",
+                "evidence_count",
+                "prior_weight",
+                "contradiction_hits",
+                "contradiction_pressure",
+                "release_state",
+            ],
+            "rule_only": True,
+        },
+    }
+
+
 def _with_attachment_provenance(attachments: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     enriched: List[Dict[str, Any]] = []
     for item in attachments:
@@ -565,6 +631,14 @@ def _with_attachment_provenance(attachments: List[Dict[str, Any]]) -> List[Dict[
         patched["band"] = _score_band(score)
         patched["contradiction_pressure"] = contradiction_pressure
         patched["fragility"] = fragility
+        adjudication = _adjudicate_attachment(patched)
+        patched["adjudication_state"] = adjudication["state"]
+        patched["adjudication_reasons"] = list(adjudication["reasons"])
+        patched["publication"] = {
+            "operator_visible": bool(adjudication["operator_visible"]),
+            "public_visible": bool(adjudication["public_visible"]),
+            "hedge": adjudication["hedge"],
+        }
         patched["provenance"] = {
             "derived": True,
             "authoritative": False,
@@ -573,6 +647,8 @@ def _with_attachment_provenance(attachments: List[Dict[str, Any]]) -> List[Dict[
             "source_classes": list(item.get("source_classes") or []),
             "evidence_ids": list(item.get("evidence_ids") or []),
             "prior_weight": prior_weight,
+            "adjudication_policy": adjudication["policy_version"],
+            "determinism_boundary": adjudication["determinism_boundary"],
         }
         enriched.append(patched)
     return enriched
@@ -629,6 +705,7 @@ def build_snapshot(
                 "derived": True,
                 "non_authoritative": True,
                 "operator_surface": "continuity",
+                "adjudication_policy": ADJUDICATION_POLICY_VERSION,
             },
             "provenance": {
                 "derived": True,
@@ -640,10 +717,80 @@ def build_snapshot(
                 "persona_prior_count": sum(len(bucket) for bucket in persona_priors.values()),
                 "release_receipt_count": len(release_map),
                 "query_only_enforced": True,
+                "adjudication_policy": ADJUDICATION_POLICY_VERSION,
             },
             "source_digest": source_digest,
         }
         return snapshot
+
+
+def build_adjudication_report(snapshot: Dict[str, Any]) -> Dict[str, Any]:
+    attachments = list(snapshot.get("attachments") or [])
+    by_state: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for item in attachments:
+        by_state[str(item.get("adjudication_state") or "tentative")].append(item)
+    ordered_states = ["accepted", "tentative", "fragile", "contested", "retired", "rejected"]
+    return {
+        "schema": ADJUDICATION_SCHEMA,
+        "snapshot_id": snapshot.get("snapshot_id"),
+        "generated_at": _utcnow_iso(),
+        "policy_version": ADJUDICATION_POLICY_VERSION,
+        "counts": {state: len(by_state.get(state, [])) for state in ordered_states},
+        "claims_by_state": {state: by_state.get(state, []) for state in ordered_states if by_state.get(state)},
+        "operator_summary": {
+            "top_accepted": [item.get("id") for item in by_state.get("accepted", [])[:5]],
+            "top_fragile": [item.get("id") for item in by_state.get("fragile", [])[:5]],
+            "top_contested": [item.get("id") for item in by_state.get("contested", [])[:5]],
+        },
+        "provenance": {
+            "derived": True,
+            "authoritative": False,
+            "derivation_version": DERIVATION_VERSION,
+            "adjudication_policy": ADJUDICATION_POLICY_VERSION,
+            "snapshot_source_digest": snapshot.get("source_digest"),
+        },
+    }
+
+
+def build_public_summary(snapshot: Dict[str, Any]) -> Dict[str, Any]:
+    attachments = list(snapshot.get("attachments") or [])
+    public_claims = [item for item in attachments if bool(((item.get("publication") or {}).get("public_visible")))]
+    warnings: List[str] = []
+    if any(str(item.get("adjudication_state") or "") == "fragile" for item in attachments):
+        warnings.append("Some continuity signals remain fragile and are intentionally withheld from the public-safe summary.")
+    if any(str(item.get("adjudication_state") or "") == "contested" for item in attachments):
+        warnings.append("Some continuity signals are contested by contradictory evidence.")
+    if not public_claims:
+        summary = "Insufficient evidence to publish a stable derived continuity summary."
+    else:
+        ordered = sorted(public_claims, key=lambda item: (-float(item.get("attachment_score") or 0.0), str(item.get("id") or "")))
+        labels = [str(item.get("label") or item.get("id") or "claim") for item in ordered[:4]]
+        summary = "Derived continuity signal currently points toward " + ", ".join(labels) + "."
+    return {
+        "schema": PUBLIC_SUMMARY_SCHEMA,
+        "snapshot_id": snapshot.get("snapshot_id"),
+        "generated_at": _utcnow_iso(),
+        "summary": summary,
+        "claims": [
+            {
+                "id": item.get("id"),
+                "label": item.get("label"),
+                "category": item.get("category"),
+                "adjudication_state": item.get("adjudication_state"),
+                "hedge": ((item.get("publication") or {}).get("hedge")),
+            }
+            for item in public_claims[:8]
+        ],
+        "warnings": warnings,
+        "provenance": {
+            "derived": True,
+            "authoritative": False,
+            "derivation_version": DERIVATION_VERSION,
+            "adjudication_policy": ADJUDICATION_POLICY_VERSION,
+            "snapshot_source_digest": snapshot.get("source_digest"),
+            "public_safe": True,
+        },
+    }
 
 
 def build_attachment_map(snapshot: Dict[str, Any]) -> Dict[str, Any]:
@@ -657,6 +804,7 @@ def build_attachment_map(snapshot: Dict[str, Any]) -> Dict[str, Any]:
         "generated_at": _utcnow_iso(),
         "narrative": snapshot.get("narrative"),
         "counts": {key: len(value) for key, value in sorted(grouped.items())},
+        "adjudication_counts": dict(sorted(Counter(str(item.get("adjudication_state") or "tentative") for item in attachments).items())),
         "attachments": attachments,
         "top_attachments": attachments[:5],
         "provenance": {
@@ -681,7 +829,7 @@ def build_threat_feed(snapshot: Dict[str, Any]) -> Dict[str, Any]:
                     "reason": reason,
                     "attachment_ids": sorted(pair),
                     "source_signals": [
-                        {"id": item.get("id"), "confidence": item.get("confidence"), "fragility": item.get("fragility")}
+                        {"id": item.get("id"), "confidence": item.get("confidence"), "fragility": item.get("fragility"), "adjudication_state": item.get("adjudication_state")}
                         for item in attachments
                         if item.get("id") in pair
                     ],
@@ -702,6 +850,7 @@ def build_threat_feed(snapshot: Dict[str, Any]) -> Dict[str, Any]:
                             "prior_weight": top.get("prior_weight"),
                             "evidence_count": top.get("evidence_count"),
                             "fragility": top.get("fragility"),
+                            "adjudication_state": top.get("adjudication_state"),
                         }
                     ],
                 }
@@ -741,7 +890,10 @@ def compare_snapshots(before: Dict[str, Any], after: Dict[str, Any]) -> Dict[str
     for stance_id in sorted(before_ids & after_ids):
         b = float(before_map[stance_id].get("attachment_score") or 0.0)
         a = float(after_map[stance_id].get("attachment_score") or 0.0)
-        if round(a - b, 3) != 0:
+        before_state = before_map[stance_id].get("adjudication_state")
+        after_state = after_map[stance_id].get("adjudication_state")
+        state_changed = before_state is not None and after_state is not None and before_state != after_state
+        if round(a - b, 3) != 0 or state_changed:
             delta = round(a - b, 3)
             changed.append({
                 "id": stance_id,
@@ -751,11 +903,15 @@ def compare_snapshots(before: Dict[str, Any], after: Dict[str, Any]) -> Dict[str
                 "before_confidence": before_map[stance_id].get("confidence"),
                 "after_confidence": after_map[stance_id].get("confidence"),
                 "fragility": after_map[stance_id].get("fragility") or before_map[stance_id].get("fragility"),
+                "before_state": before_map[stance_id].get("adjudication_state"),
+                "after_state": after_map[stance_id].get("adjudication_state"),
             })
             if abs(delta) >= 0.35:
                 risk_flags.append(f"large_delta:{stance_id}")
             if (after_map[stance_id].get("fragility") or before_map[stance_id].get("fragility")) == "fragile":
                 risk_flags.append(f"fragile_claim:{stance_id}")
+            if state_changed:
+                risk_flags.append(f"state_transition:{stance_id}:{before_state}->{after_state}")
     if before.get("source_digest") == after.get("source_digest") and not changed and before_ids == after_ids:
         drift_class = "no_op"
     elif any(flag.startswith("large_delta:") for flag in risk_flags):

--- a/tests/test_self_model_sidecar.py
+++ b/tests/test_self_model_sidecar.py
@@ -65,6 +65,9 @@ class TestSelfModelSidecarCli(unittest.TestCase):
         self.assertEqual(args.cmd, "continuity")
         self.assertEqual(args.self_cmd, "current")
 
+        adjudication = build_parser().parse_args(["continuity", "adjudication", "--json"])
+        self.assertEqual(adjudication.self_cmd, "adjudication")
+
         alias = build_parser().parse_args(["self", "current", "--json"])
         self.assertEqual(alias.cmd, "self")
         self.assertEqual(alias.self_cmd, "current")
@@ -123,7 +126,16 @@ class TestSelfModelSidecarCli(unittest.TestCase):
             top = amap["top_attachments"][0]
             self.assertIn(top["band"], {"low", "medium", "high"})
             self.assertIn(top["fragility"], {"fragile", "watch", "supported", "contested"})
+            self.assertIn(top["adjudication_state"], {"accepted", "tentative", "fragile", "contested", "retired", "rejected"})
             self.assertTrue(top["provenance"]["derived"])
+
+            adjudication = self._run(["continuity", "adjudication", "--snapshot", snapshot_path, "--json"])
+            self.assertEqual(adjudication["schema"], "openclaw-mem.self-model.adjudication.v0")
+            self.assertEqual(adjudication["policy_version"], self_model_sidecar.ADJUDICATION_POLICY_VERSION)
+
+            public_summary = self._run(["continuity", "public-summary", "--snapshot", snapshot_path, "--json"])
+            self.assertEqual(public_summary["schema"], "openclaw-mem.self-model.public-summary.v0")
+            self.assertTrue(public_summary["provenance"]["public_safe"])
             self.assertEqual(obs_before, self._observation_count())
             self.assertEqual(events_before, self._event_count())
 
@@ -231,6 +243,119 @@ class TestSelfModelSidecarCli(unittest.TestCase):
         self.assertEqual(diff["drift_class"], "suspicious")
         self.assertIn("large_delta:goal:verify", diff["risk_flags"])
         self.assertIn("fragile_claim:goal:verify", diff["risk_flags"])
+
+    def test_adjudication_negative_fixtures(self):
+        attachments = self_model_sidecar._with_attachment_provenance(
+            [
+                {
+                    "id": "goal:prior_only",
+                    "category": "goal",
+                    "label": "prior only",
+                    "attachment_score": 0.6,
+                    "evidence_count": 0,
+                    "evidence_ids": [],
+                    "source_classes": [],
+                    "prior_weight": 1.0,
+                    "contradiction_hits": 0,
+                    "matched_keywords": [],
+                    "release_state": "active",
+                },
+                {
+                    "id": "goal:thin_and_coherent",
+                    "category": "goal",
+                    "label": "thin and coherent",
+                    "attachment_score": 0.8,
+                    "evidence_count": 1,
+                    "evidence_ids": ["obs:1"],
+                    "source_classes": ["observation"],
+                    "prior_weight": 0.2,
+                    "contradiction_hits": 0,
+                    "matched_keywords": ["ship"],
+                    "release_state": "active",
+                },
+                {
+                    "id": "goal:contested",
+                    "category": "goal",
+                    "label": "contested",
+                    "attachment_score": 0.7,
+                    "evidence_count": 1,
+                    "evidence_ids": ["obs:2"],
+                    "source_classes": ["observation"],
+                    "prior_weight": 0.0,
+                    "contradiction_hits": 2,
+                    "matched_keywords": ["ship"],
+                    "release_state": "active",
+                },
+                {
+                    "id": "goal:revalidation_needed",
+                    "category": "goal",
+                    "label": "revalidation needed",
+                    "attachment_score": 0.9,
+                    "evidence_count": 2,
+                    "evidence_ids": ["obs:3", "evt:3"],
+                    "source_classes": ["observation", "episodic_event"],
+                    "prior_weight": 0.0,
+                    "contradiction_hits": 0,
+                    "matched_keywords": ["verify"],
+                    "release_state": "weakening",
+                },
+                {
+                    "id": "goal:unsupported",
+                    "category": "goal",
+                    "label": "unsupported",
+                    "attachment_score": 0.0,
+                    "evidence_count": 0,
+                    "evidence_ids": [],
+                    "source_classes": [],
+                    "prior_weight": 0.0,
+                    "contradiction_hits": 0,
+                    "matched_keywords": [],
+                    "release_state": "active",
+                },
+            ]
+        )
+        by_id = {item["id"]: item for item in attachments}
+        self.assertEqual(by_id["goal:prior_only"]["adjudication_state"], "tentative")
+        self.assertFalse(by_id["goal:prior_only"]["publication"]["public_visible"])
+        self.assertEqual(by_id["goal:thin_and_coherent"]["adjudication_state"], "fragile")
+        self.assertEqual(by_id["goal:contested"]["adjudication_state"], "contested")
+        self.assertEqual(by_id["goal:revalidation_needed"]["adjudication_state"], "fragile")
+        self.assertEqual(by_id["goal:unsupported"]["adjudication_state"], "rejected")
+        self.assertTrue(by_id["goal:unsupported"]["publication"]["hedge"])
+
+        report = self_model_sidecar.build_adjudication_report({"snapshot_id": "snap", "attachments": attachments, "source_digest": "digest"})
+        self.assertEqual(report["counts"]["rejected"], 1)
+        self.assertIn("goal:unsupported", {item["id"] for item in report["claims_by_state"]["rejected"]})
+
+    def test_diff_skips_state_transition_for_legacy_snapshots(self):
+        before = {
+            "snapshot_id": "before",
+            "source_digest": "legacy-source",
+            "attachments": [{"id": "goal:verify", "attachment_score": 0.4, "confidence": 0.5, "fragility": "watch"}],
+        }
+        after = {
+            "snapshot_id": "after",
+            "source_digest": "new-source",
+            "attachments": [{"id": "goal:verify", "attachment_score": 0.6, "confidence": 0.8, "fragility": "supported", "adjudication_state": "tentative"}],
+        }
+        diff = self_model_sidecar.compare_snapshots(before, after)
+        self.assertFalse(any(flag.startswith("state_transition:") for flag in diff["risk_flags"]))
+
+    def test_diff_tracks_state_transition_without_score_delta(self):
+        before = {
+            "snapshot_id": "before",
+            "source_digest": "same-source",
+            "attachments": [{"id": "goal:verify", "attachment_score": 0.6, "confidence": 0.6, "fragility": "watch", "adjudication_state": "tentative"}],
+        }
+        after = {
+            "snapshot_id": "after",
+            "source_digest": "same-source",
+            "attachments": [{"id": "goal:verify", "attachment_score": 0.6, "confidence": 0.6, "fragility": "contested", "adjudication_state": "contested"}],
+        }
+        diff = self_model_sidecar.compare_snapshots(before, after)
+        self.assertIn("state_transition:goal:verify:tentative->contested", diff["risk_flags"])
+        self.assertEqual(diff["changed"][0]["before_state"], "tentative")
+        self.assertEqual(diff["changed"][0]["after_state"], "contested")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- turn side-car adjudication into an executable deterministic rule surface
- add operator-safe adjudication and public-safe summary continuity commands
- land endgame architecture/adjudication freeze docs plus verifier-backed receipt

## Testing
- python3 -m unittest tests.test_self_model_sidecar -v

## Second-brain review
- Claude final verdict: ship
- Receipt: /root/.openclaw/workspace/.state/decision-council/claude_self_model_sidecar_adjudication_review_final.md