### PR TITLE
Upgrade self-model side-car control plane

### DIFF
--- a/docs/2026-04-18_self-model-sidecar-control-plane-v1-receipt.md
+++ b/docs/2026-04-18_self-model-sidecar-control-plane-v1-receipt.md
@@ -1,0 +1,46 @@
+# self-model side-car control plane v1 receipt
+
+Date: 2026-04-18
+Branch: `lyria/self-model-control-plane-v1-20260418`
+Status: implemented, verifier-backed
+Topology: unchanged
+
+## Change
+Upgraded the continuity side-car control plane from one-shot weakening receipts into explicit state-transition governance receipts.
+
+## What landed
+- extended continuity release control to support `weaken`, `retire`, and `rebind`
+- each governance receipt now records:
+  - `before_release_state`
+  - `after_release_state`
+  - `supersedes_receipt_id`
+- latest release application now preserves control-state transition metadata on live attachments
+- added `continuity release-history` for auditable control-plane inspection
+- added verifier coverage for weaken -> rebind -> retire flow and resulting snapshot behavior
+
+## Why now
+After adjudication v1, the next honest backlog slice was the control plane itself.
+This pass makes state transitions replayable and inspectable without starting claim-graph persistence.
+
+## Verifiers run
+```bash
+python3 -m unittest tests.test_self_model_sidecar -v
+```
+
+Result: 8 tests, all green.
+
+## Remaining truth
+- control transitions are now explicit, but rebuild / migration approval are still separate future surfaces
+- retired claims remain represented by receipts plus filtered snapshots, not lifecycle-aware claim objects
+- this pass does not yet add counterfactual anti-delusion instrumentation
+
+## Rollback
+- revert `openclaw_mem/self_model_sidecar.py`, `openclaw_mem/cli.py`, and `tests/test_self_model_sidecar.py`
+- remove `docs/2026-04-18_self-model-sidecar-control-plane-v1-receipt.md`
+- rerun `python3 -m unittest tests.test_self_model_sidecar -v`
+
+## Files changed
+- `openclaw_mem/self_model_sidecar.py`
+- `openclaw_mem/cli.py`
+- `tests/test_self_model_sidecar.py`
+- `docs/2026-04-18_self-model-sidecar-control-plane-v1-receipt.md`

--- a/openclaw_mem/cli.py
+++ b/openclaw_mem/cli.py
@@ -4444,6 +4444,16 @@ def cmd_self_release(conn: sqlite3.Connection, args: argparse.Namespace) -> None
     _emit(payload, args.json)
 
 
+def cmd_self_release_history(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    payload = self_model_sidecar.build_release_history(
+        run_dir=getattr(args, "run_dir", None),
+        scope=getattr(args, "scope", None),
+        session_id=getattr(args, "session_id", None),
+        stance_id=getattr(args, "stance", None),
+    )
+    _emit(payload, args.json)
+
+
 def cmd_self_compare_migration(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
     payload = self_model_sidecar.compare_migration(
         conn,
@@ -15332,12 +15342,20 @@ def build_parser() -> argparse.ArgumentParser:
         s.add_argument("--run-dir", dest="run_dir", default=self_model_sidecar.default_run_dir(), help="Side-car state root for release receipts")
         s.add_argument("--scope", default=None, help="Optional scope boundary for the release receipt")
         s.add_argument("--session-id", dest="session_id", default=None, help="Optional session boundary for the release receipt")
-        s.add_argument("--stance", required=True, help="Attachment/stance id to weaken or retire")
+        s.add_argument("--stance", required=True, help="Attachment/stance id to weaken, retire, or rebind")
         s.add_argument("--reason", required=True, help="Human reason for the release operation")
-        s.add_argument("--mode", choices=("weaken", "retire"), default="weaken", help="Release mode (default: weaken)")
+        s.add_argument("--mode", choices=("weaken", "retire", "rebind"), default="weaken", help="Release mode (default: weaken)")
         s.add_argument("--factor", type=float, default=0.5, help="Score multiplier when mode=weaken (default: 0.5)")
         s.add_argument("--operator", default=None, help="Optional operator label for the receipt")
         s.set_defaults(func=cmd_self_release)
+
+        s = ssub.add_parser("release-history", help="Inspect governed continuity control-plane receipts")
+        add_common(s)
+        s.add_argument("--run-dir", dest="run_dir", default=self_model_sidecar.default_run_dir(), help="Side-car state root for release receipts")
+        s.add_argument("--scope", default=None, help="Optional scope boundary for receipt filtering")
+        s.add_argument("--session-id", dest="session_id", default=None, help="Optional session boundary for receipt filtering")
+        s.add_argument("--stance", default=None, help="Optional stance id to filter one continuity control lane")
+        s.set_defaults(func=cmd_self_release_history)
 
         s = ssub.add_parser("compare-migration", help="Compare two persona-prior baselines against the same memory evidence")
         add_self_surface_common(s)

--- a/openclaw_mem/self_model_sidecar.py
+++ b/openclaw_mem/self_model_sidecar.py
@@ -25,6 +25,7 @@ CONTROL_SCHEMA = "openclaw-mem.self-model.control.v0"
 AUTORUN_SCHEMA = "openclaw-mem.self-model.autorun.v0"
 ADJUDICATION_SCHEMA = "openclaw-mem.self-model.adjudication.v0"
 PUBLIC_SUMMARY_SCHEMA = "openclaw-mem.self-model.public-summary.v0"
+RELEASE_HISTORY_SCHEMA = "openclaw-mem.self-model.release-history.v0"
 DERIVATION_VERSION = "self_model_sidecar_v0"
 ADJUDICATION_POLICY_VERSION = "self_model_sidecar_adjudication_v1"
 
@@ -399,6 +400,40 @@ def _active_release_map(run_dir: str, *, scope: Optional[str], session_id: Optio
     return latest
 
 
+def _control_state_from_mode(mode: str) -> str:
+    mode = str(mode or "weaken").strip() or "weaken"
+    if mode == "retire":
+        return "retired"
+    if mode == "rebind":
+        return "active"
+    return "weakening"
+
+
+def _sorted_release_receipts(run_dir: str, *, scope: Optional[str], session_id: Optional[str], stance_id: Optional[str] = None) -> List[Dict[str, Any]]:
+    receipts: List[Dict[str, Any]] = []
+    releases_dir = Path(run_dir) / "releases"
+    if not releases_dir.exists():
+        return receipts
+    for path in sorted(releases_dir.glob("*.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        receipt_scope = str(payload.get("scope") or "").strip() or None
+        receipt_session = str(payload.get("session_id") or "").strip() or None
+        receipt_stance = str(payload.get("stance_id") or "").strip() or None
+        if scope is not None and receipt_scope != scope:
+            continue
+        if session_id is not None and receipt_session != session_id:
+            continue
+        if stance_id is not None and receipt_stance != stance_id:
+            continue
+        payload["path"] = str(path)
+        receipts.append(payload)
+    receipts.sort(key=lambda item: (str(item.get("released_at") or ""), str(item.get("receipt_id") or "")))
+    return receipts
+
+
 def _collect_candidates(evidence: List[Dict[str, Any]], persona_priors: Dict[str, Dict[str, float]]) -> List[Dict[str, Any]]:
     by_id: Dict[str, Dict[str, Any]] = {}
 
@@ -493,18 +528,35 @@ def _apply_releases(attachments: List[Dict[str, Any]], release_map: Dict[str, Di
             out.append(patched)
             continue
         mode = str(release.get("mode") or "weaken").strip() or "weaken"
+        patched["latest_release_receipt_id"] = release.get("receipt_id")
+        patched["control_state_transition"] = {
+            "before": release.get("before_release_state"),
+            "after": release.get("after_release_state"),
+            "receipt_id": release.get("receipt_id"),
+        }
+        if mode == "rebind":
+            patched["release_state"] = "active"
+            patched["release"] = {
+                "mode": mode,
+                "reason": release.get("reason"),
+                "receipt_id": release.get("receipt_id"),
+                "released_at": release.get("released_at"),
+                "supersedes_receipt_id": release.get("supersedes_receipt_id"),
+            }
+            out.append(patched)
+            continue
         if mode == "retire":
             continue
         factor = float(release.get("factor") or 0.5)
         patched["attachment_score"] = round(max(0.0, min(1.0, item["attachment_score"] * factor)), 3)
         patched["release_state"] = "weakening"
-        patched["latest_release_receipt_id"] = release.get("receipt_id")
         patched["release"] = {
             "mode": mode,
             "factor": factor,
             "reason": release.get("reason"),
             "receipt_id": release.get("receipt_id"),
             "released_at": release.get("released_at"),
+            "supersedes_receipt_id": release.get("supersedes_receipt_id"),
         }
         out.append(patched)
     out.sort(key=lambda item: (-item["attachment_score"], item["id"]))
@@ -979,6 +1031,11 @@ def write_release_receipt(
     scope: Optional[str],
     session_id: Optional[str],
 ) -> Dict[str, Any]:
+    root = Path(run_dir or default_run_dir())
+    prior_receipts = _sorted_release_receipts(str(root), scope=scope, session_id=session_id, stance_id=stance_id)
+    previous = prior_receipts[-1] if prior_receipts else None
+    before_release_state = str((previous or {}).get("after_release_state") or "active")
+    after_release_state = _control_state_from_mode(mode)
     released_at = _utcnow_iso()
     receipt = {
         "schema": RELEASE_RECEIPT_SCHEMA,
@@ -991,18 +1048,54 @@ def write_release_receipt(
         "operator": operator,
         "scope": scope,
         "session_id": session_id,
+        "before_release_state": before_release_state,
+        "after_release_state": after_release_state,
+        "supersedes_receipt_id": (previous or {}).get("receipt_id"),
         "provenance": {
             "derived": False,
             "authoritative": True,
             "derivation_version": "release_receipt_v0",
         },
     }
-    releases_dir = _mkdir(Path(run_dir or default_run_dir()) / "releases")
+    releases_dir = _mkdir(root / "releases")
     fname = f"{released_at.replace(':', '').replace('+', '_').replace('-', '')}__{_slug(stance_id)}.json"
     path = releases_dir / fname
     path.write_text(json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     receipt["path"] = str(path)
     return receipt
+
+
+def build_release_history(
+    *,
+    run_dir: Optional[str],
+    scope: Optional[str],
+    session_id: Optional[str],
+    stance_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    root = str(Path(run_dir or default_run_dir()))
+    receipts = _sorted_release_receipts(root, scope=scope, session_id=session_id, stance_id=stance_id)
+    current_state_by_stance: Dict[str, str] = {}
+    for receipt in receipts:
+        rid = str(receipt.get("stance_id") or "")
+        if not rid:
+            continue
+        current_state_by_stance[rid] = str(receipt.get("after_release_state") or _control_state_from_mode(str(receipt.get("mode") or "weaken")))
+    return {
+        "schema": RELEASE_HISTORY_SCHEMA,
+        "generated_at": _utcnow_iso(),
+        "scope": scope,
+        "session_id": session_id,
+        "stance_id": stance_id,
+        "receipt_count": len(receipts),
+        "current_state_by_stance": dict(sorted(current_state_by_stance.items())),
+        "receipts": receipts,
+        "provenance": {
+            "derived": False,
+            "authoritative": True,
+            "derivation_version": "release_receipt_v0",
+            "run_dir": root,
+        },
+    }
 
 
 def compare_migration(

--- a/tests/test_self_model_sidecar.py
+++ b/tests/test_self_model_sidecar.py
@@ -173,6 +173,8 @@ class TestSelfModelSidecarCli(unittest.TestCase):
             self.assertEqual(release["schema"], "openclaw-mem.self-model.release-receipt.v0")
             self.assertEqual(release["scope"], "proj-a")
             self.assertEqual(release["session_id"], "s1")
+            self.assertEqual(release["before_release_state"], "active")
+            self.assertEqual(release["after_release_state"], "weakening")
             after = self._run(["continuity", "current", "--scope", "proj-a", "--session-id", "s1", "--run-dir", tmp, "--persist", "--json"])
             diff = self._run(["continuity", "diff", "--from", before["persisted"]["snapshot_path"], "--to", after["persisted"]["snapshot_path"], "--json"])
             self.assertEqual(diff["schema"], "openclaw-mem.self-model.diff.v0")
@@ -180,6 +182,60 @@ class TestSelfModelSidecarCli(unittest.TestCase):
             self.assertIn("goal:ship_mvp", changed_ids)
             self.assertIn(diff["drift_class"], {"no_op", "organic", "suspicious"})
             self.assertEqual(diff["provenance"]["arbiter_policy"], "openclaw-mem-memory-of-record-wins")
+
+            rebind = self._run(
+                [
+                    "continuity",
+                    "release",
+                    "--run-dir",
+                    tmp,
+                    "--scope",
+                    "proj-a",
+                    "--session-id",
+                    "s1",
+                    "--stance",
+                    "goal:ship_mvp",
+                    "--reason",
+                    "testing rebind flow",
+                    "--mode",
+                    "rebind",
+                    "--json",
+                ]
+            )
+            self.assertEqual(rebind["before_release_state"], "weakening")
+            self.assertEqual(rebind["after_release_state"], "active")
+            rebound = self._run(["continuity", "current", "--scope", "proj-a", "--session-id", "s1", "--run-dir", tmp, "--persist", "--json"])
+            rebound_goal = next(item for item in rebound["attachments"] if item["id"] == "goal:ship_mvp")
+            self.assertEqual(rebound_goal["release_state"], "active")
+
+            retire = self._run(
+                [
+                    "continuity",
+                    "release",
+                    "--run-dir",
+                    tmp,
+                    "--scope",
+                    "proj-a",
+                    "--session-id",
+                    "s1",
+                    "--stance",
+                    "goal:ship_mvp",
+                    "--reason",
+                    "testing retirement flow",
+                    "--mode",
+                    "retire",
+                    "--json",
+                ]
+            )
+            self.assertEqual(retire["before_release_state"], "active")
+            self.assertEqual(retire["after_release_state"], "retired")
+            retired = self._run(["continuity", "current", "--scope", "proj-a", "--session-id", "s1", "--run-dir", tmp, "--persist", "--json"])
+            self.assertNotIn("goal:ship_mvp", {item["id"] for item in retired["attachments"]})
+
+            history = self._run(["continuity", "release-history", "--run-dir", tmp, "--scope", "proj-a", "--session-id", "s1", "--stance", "goal:ship_mvp", "--json"])
+            self.assertEqual(history["schema"], "openclaw-mem.self-model.release-history.v0")
+            self.assertEqual(history["receipt_count"], 3)
+            self.assertEqual(history["current_state_by_stance"]["goal:ship_mvp"], "retired")
 
             compare = self._run(
                 [
@@ -221,7 +277,7 @@ class TestSelfModelSidecarCli(unittest.TestCase):
             disabled = self._run(["continuity", "disable", "--run-dir", tmp, "--json"])
             self.assertFalse(disabled["enabled"])
             self.assertTrue(disabled["cleared_latest_pointer"])
-            self.assertEqual(disabled["cleared_snapshot_id"], after["snapshot_id"])
+            self.assertEqual(disabled["cleared_snapshot_id"], retired["snapshot_id"])
             disabled_status = self._run(["continuity", "status", "--run-dir", tmp, "--json"])
             self.assertIsNone(disabled_status["latest_snapshot_id"])
             self.assertFalse(disabled_status["residue"]["latest_pointer_present"])


### PR DESCRIPTION
## Summary
- upgrade continuity governance receipts into explicit control-plane state transitions
- add rebind and release-history surfaces for replayable operator control
- add verifier-backed receipt for weaken -> rebind -> retire flow

## Testing
- python3 -m unittest tests.test_self_model_sidecar -v

## Second-brain review
- Claude verdict: ship
- Receipt: /root/.openclaw/workspace/.state/decision-council/claude_self_model_sidecar_control_plane_review.md