### PR TITLE
Document and activate self-model continuity lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,7 @@ When you do promote the engine, the live-turn hook is framed as **Proactive Pack
 - **Bounded packing** — `pack` emits a stable `ContextPack` contract for injection, citations, graph-aware synthesis preference, protected fresh tails, and trace-backed debugging.
 - **Fits real OpenClaw ops** — capture tool outcomes, retain receipts, and keep rollback simple.
 - **Upgradeable path** — sidecar first, engine later; no forced migration on day one.
-- compact memory packs with citations and trace receipts
-- trust-policy controls for excluding quarantined content
-- optional **Proactive Pack** support in `openclaw-mem-engine` for pre-reply bounded recall with receipts and fail-open behavior
-- **Local-first by default** — JSONL + SQLite, no external database required.
-- **Cheap recall loop** — `search → timeline → get` keeps routine lookups fast and inspectable.
-- **Bounded packing** — `pack` emits a stable `ContextPack` contract for injection, citations, graph-aware synthesis preference, protected fresh tails, and trace-backed debugging.
-- **Fits real OpenClaw ops** — capture tool outcomes, retain receipts, and keep rollback simple.
-- **Upgradeable path** — sidecar first, engine later; no forced migration on day one.
+- **Governed continuity side-car** — optional `continuity` surface for derived self/continuity inspection, adjudication, public-safe summaries, and explicit weaken/rebind/retire receipts.
 
 ## Why this exists
 
@@ -78,6 +71,32 @@ The product loop is simple and stable:
 3. **Observe**: use `timeline`, `get`, and `artifact` outputs for explainability and rollback.
 
 When mem-engine is active, **Proactive Pack** extends the same Pack contract into live turns as a small, receipt-backed pre-reply bundle.
+
+## Governed continuity side-car
+
+`openclaw-mem` also ships an optional derived continuity lane.
+This is not a second truth store, and it is not presented as consciousness.
+It is a governed side-car that helps operators inspect what continuity claims the system is currently making, how strong those claims are allowed to be, and when those claims should be weakened, rebound, or retired.
+
+Core operator surfaces:
+
+```bash
+uv run --python 3.13 --frozen -- python -m openclaw_mem continuity current --json
+uv run --python 3.13 --frozen -- python -m openclaw_mem continuity attachment-map --snapshot <snapshot.json> --json
+uv run --python 3.13 --frozen -- python -m openclaw_mem continuity adjudication --snapshot <snapshot.json> --json
+uv run --python 3.13 --frozen -- python -m openclaw_mem continuity public-summary --snapshot <snapshot.json> --json
+uv run --python 3.13 --frozen -- python -m openclaw_mem continuity release-history --json
+```
+
+Control-plane activation is explicit and starts autonomous snapshot + receipt generation under `~/.openclaw/memory/openclaw-mem/self-model-sidecar/` until you disable it:
+
+```bash
+uv run --python 3.13 --frozen -- python -m openclaw_mem continuity enable --cadence-seconds 300 --json
+uv run --python 3.13 --frozen -- python -m openclaw_mem continuity status --json
+uv run --python 3.13 --frozen -- python -m openclaw_mem continuity disable --json
+```
+
+Use it when you need auditable continuity receipts, migration comparison, or public-safe hedged summaries, not when you need a new source of truth. The lane stays rebuildable from memory-of-record by design.
 
 Example:
 
@@ -186,6 +205,7 @@ When a compaction receipt is later selected by `pack`, the response may include:
 - **Docs site:** <https://phenomenoner.github.io/openclaw-mem/>
 - **Reality check / status:** [`docs/reality-check.md`](docs/reality-check.md)
 - **Deployment patterns:** [`docs/deployment.md`](docs/deployment.md)
+- **Continuity side-car ops lane:** [`skills/self-model-sidecar.ops.md`](skills/self-model-sidecar.ops.md)
 - **Auto-capture plugin:** [`docs/auto-capture.md`](docs/auto-capture.md)
 - **Agent memory skill (SOP):** [`docs/agent-memory-skill.md`](docs/agent-memory-skill.md)
 - **Pack policy contract:** [`docs/specs/context-pack-policy-v1.1.md`](docs/specs/context-pack-policy-v1.1.md)

--- a/docs/2026-04-18_self-model-sidecar-activation-and-docs-receipt.md
+++ b/docs/2026-04-18_self-model-sidecar-activation-and-docs-receipt.md
@@ -1,0 +1,50 @@
+# self-model side-car activation and docs receipt
+
+Date: 2026-04-18
+Status: shipped locally, verifier-backed
+Topology: unchanged
+
+## Change
+- updated public-facing docs to expose the governed continuity side-car as a derived, rebuildable lane
+- updated the dedicated ops skill so copy-paste commands match the supported `uv run --python 3.13 -- python -m openclaw_mem ...` entrypoint
+- enabled the live continuity control plane on this host at a 300s cadence
+- generated the first persisted snapshot, autorun receipt, and public-safe summary on the real install
+
+## Why now
+PR #71 landed the control-plane v1 surface. The honest next step was to make the operator-facing docs and skill truthful, then activate the real lane instead of leaving the capability half-shipped.
+
+## Success criteria
+- public docs describe continuity as derived, governed, and not memory-of-record
+- activation guidance includes what enable actually does, where artifacts land, and how to roll back
+- dedicated ops skill matches the documented command shape
+- live install reports `enabled: true` and produces a persisted snapshot + autorun receipt
+
+## Rollback
+- docs/skill: revert this commit
+- live continuity lane: `uv run --python 3.13 -- python -m openclaw_mem continuity disable --json`
+- local residue stays under `~/.openclaw/memory/openclaw-mem/self-model-sidecar/`
+
+## Receipts
+### Docs / skill updated
+- `README.md`
+- `docs/about.md`
+- `docs/install-modes.md`
+- `docs/deployment.md`
+- `skills/self-model-sidecar.ops.md`
+
+### Second-brain review
+- `/root/.openclaw/workspace/.state/decision-council/claude_public_docs_continuity_review.md`
+- `/root/.openclaw/workspace/.state/decision-council/claude_public_docs_continuity_review_pass2.md`
+- `/root/.openclaw/workspace/.state/decision-council/claude_public_docs_continuity_review_final.md`
+
+### Live activation
+- control receipt: `/root/.openclaw/memory/openclaw-mem/self-model-sidecar/control-history/20260418T133318.211456_0000__1776519198211__enable.json`
+- status run dir: `/root/.openclaw/memory/openclaw-mem/self-model-sidecar`
+- first persisted snapshot: `/root/.openclaw/memory/openclaw-mem/self-model-sidecar/snapshots/sms:v0:98bf8da6f3696d3e.json`
+- latest snapshot pointer: `/root/.openclaw/memory/openclaw-mem/self-model-sidecar/snapshots/latest.json`
+- first autorun receipt: `/root/.openclaw/memory/openclaw-mem/self-model-sidecar/autorun/run-1776519203658-1.json`
+
+### Verification excerpts
+- `continuity status` reports `enabled: true`, `cadence_seconds: 300`, `latest_pointer_present: true`
+- `continuity public-summary` returns a bounded public-safe summary and warns when fragile claims are withheld
+- `continuity release-history` is empty, which is expected before any weaken / rebind / retire action

--- a/docs/about.md
+++ b/docs/about.md
@@ -25,6 +25,7 @@ Most agent memory stories sound good until you need all of these in production:
 - trust-policy controls for pack selection
 - sidecar capture on top of an existing OpenClaw install
 - optional promotion to `openclaw-mem-engine` later for hybrid recall and stronger policy controls
+- optional governed continuity side-car for derived self/continuity inspection, adjudication, public-safe summaries, and explicit control-plane receipts
 
 ## How the product is split
 
@@ -70,6 +71,18 @@ Operators also need to see what the system kept, what it cut, and where large ra
 - artifact handles keep raw payloads off-prompt but retrievable
 - local files stay diffable and backup-friendly
 
+### Governed continuity side-car (optional)
+
+For operators who need a safer continuity surface, `openclaw-mem` also exposes a derived `continuity` lane.
+
+- builds inspectable current snapshots from memory-of-record
+- runs deterministic adjudication before stronger continuity phrasing is allowed
+- emits bounded public-safe summaries instead of identity theater
+- records explicit weaken / rebind / retire state transitions with replayable receipts
+
+This lane stays derived and rebuildable by design.
+It does not become a second truth owner.
+
 ## Why local-first matters
 
 A lot of memory tooling gets harder to trust as soon as it becomes harder to inspect.
@@ -112,3 +125,4 @@ The local-first posture keeps the base layer simple:
 - [Governed optimize assist lane](optimize-assist.md)
 - [Ecosystem fit](ecosystem-fit.md)
 - [Mem Engine reference](mem-engine.md)
+- [Optional continuity side-car activation](deployment.md#2b-optional-governed-continuity-side-car)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -258,6 +258,7 @@ Start with `--dry-run` until you have reviewed receipts on fixture or low-risk r
           "kind": "agentTurn",
           "model": "google-antigravity/gemini-3-flash",
           "thinking": "minimal",
+
           "message": "Run exactly one exec, then output ONLY NO_REPLY:\n\ncd /opt/openclaw-mem && uv run --python 3.13 -- python tools/optimize_assist_runner.py --json"
         },
         "delivery": { "mode": "none" }
@@ -338,7 +339,50 @@ Persistent=true
 WantedBy=timers.target
 ```
 
-## 2B. Episodic auto-mode ingestion (new)
+## 2B. Optional governed continuity side-car
+
+If you want derived continuity receipts on top of the normal Store/Pack/Observe flow, you can enable the `continuity` control plane from the same checkout.
+This is optional and stays derived-only. It does **not** replace your memory-of-record.
+When enabled, it starts autonomous snapshot + receipt generation on the configured cadence and writes artifacts under `~/.openclaw/memory/openclaw-mem/self-model-sidecar/`.
+
+Recommended activation path:
+
+```bash
+cd /opt/openclaw-mem
+
+# Inspect current state first
+uv run --python 3.13 -- python -m openclaw_mem continuity status --json
+
+# Enable periodic continuity snapshots + receipts
+uv run --python 3.13 -- python -m openclaw_mem continuity enable --cadence-seconds 300 --json
+
+# Verify control plane status
+uv run --python 3.13 -- python -m openclaw_mem continuity status --json
+```
+
+Recommended first operator checks after enablement:
+
+```bash
+uv run --python 3.13 -- python -m openclaw_mem continuity current --json
+uv run --python 3.13 -- python -m openclaw_mem continuity attachment-map --snapshot <snapshot.json> --json
+uv run --python 3.13 -- python -m openclaw_mem continuity adjudication --snapshot <snapshot.json> --json
+uv run --python 3.13 -- python -m openclaw_mem continuity public-summary --snapshot <snapshot.json> --json
+uv run --python 3.13 -- python -m openclaw_mem continuity release-history --json
+```
+
+Operator notes:
+- `continuity adjudication` is the gate that decides how strong a continuity claim is allowed to be.
+- `continuity public-summary` is the bounded hedge-first surface for restrained external phrasing.
+- `continuity release` now supports `weaken`, `rebind`, and `retire`, and `release-history` gives you replayable receipts.
+- If you do not want autonomous continuity receipts, leave the control plane disabled and run the read surfaces ad hoc.
+
+Rollback:
+
+```bash
+uv run --python 3.13 -- python -m openclaw_mem continuity disable --json
+```
+
+## 2C. Episodic auto-mode ingestion (new)
 
 When `plugins.entries["openclaw-mem"].config.episodes.enabled=true`, run extractor periodically and keep ingest in follow mode (daemon/tailer).
 

--- a/docs/install-modes.md
+++ b/docs/install-modes.md
@@ -64,6 +64,7 @@ Delete the test DB or the repo checkout. No OpenClaw state changed.
 - SQLite recall layer
 - backend-aware observability
 - deterministic triage / ops workflows
+- optional continuity side-car activation later without changing the active memory slot
 - no active memory-backend change
 
 ### First step
@@ -72,8 +73,10 @@ Read:
 
 - [Quickstart](quickstart.md)
 - [Deployment guide](deployment.md)
+- [Optional continuity side-car activation](deployment.md#2b-optional-governed-continuity-side-car)
 - [Governed optimize assist lane](optimize-assist.md)
 - [Auto-capture plugin](auto-capture.md)
+- [Continuity ops lane](../skills/self-model-sidecar.ops.md)
 - [Agent memory skill (SOP)](agent-memory-skill.md) (recommended agent prompt contract)
 
 ### Rollback
@@ -104,6 +107,7 @@ Disable the plugin, stop harvest jobs, remove the symlink if you added one. Your
 - operator-tunable receipts and policies
 - more explicit control over recall/capture behavior
 - optional **Proactive Pack** lane for bounded pre-reply recall during live turns
+- optional continuity side-car activation from the same checkout if you want governed derived continuity receipts
 - one-line rollback to `memory-core` or `memory-lancedb`
 
 ### First step
@@ -114,6 +118,8 @@ Read:
 - [Proactive Pack](proactive-pack.md)
 - [Ecosystem fit](ecosystem-fit.md)
 - [Deployment guide](deployment.md)
+- [Optional continuity side-car activation](deployment.md#2b-optional-governed-continuity-side-car)
+- [Continuity ops lane](../skills/self-model-sidecar.ops.md)
 - [Agent memory skill (SOP)](agent-memory-skill.md) (recommended agent prompt contract)
 - `python tools/route_auto_synthesis_smoke.py` (deterministic route-auto synthesis smoke)
 

--- a/skills/self-model-sidecar.ops.md
+++ b/skills/self-model-sidecar.ops.md
@@ -6,9 +6,12 @@ Purpose: inspect, diff, govern, and selectively release the derived self-model s
 Use this lane when you need any of the following:
 - current derived self snapshot for an agent/session/scope
 - ranked attachment map (what the agent is gripping tightly)
+- deterministic adjudication state review before you trust continuity claims
+- bounded public-safe continuity summary for restrained external/operator-facing phrasing
 - drift / migration comparison before prompt or model changes
 - threat/tension scan for persona-prior dominance or conflicting stances
-- governed weakening/retirement receipts for stale stances
+- governed weaken / rebind / retire receipts for stale or overconfident stances
+- release-history inspection for replayable control-plane audit
 
 ## Hard boundary
 - `openclaw-mem` remains memory-of-record.
@@ -18,29 +21,35 @@ Use this lane when you need any of the following:
 
 ## Default CLI surface
 ```bash
-openclaw-mem continuity current --scope <scope> --session-id <session> --json
-openclaw-mem continuity attachment-map --snapshot <path> --json
-openclaw-mem continuity threat-feed --snapshot <path> --json
-openclaw-mem continuity diff --from <snapshot-a.json> --to <snapshot-b.json> --json
-openclaw-mem continuity release --stance <id> --reason <text> --mode weaken --factor 0.5 --json
-openclaw-mem continuity compare-migration \
+uv run --python 3.13 -- python -m openclaw_mem continuity current --scope <scope> --session-id <session> --json
+uv run --python 3.13 -- python -m openclaw_mem continuity attachment-map --snapshot <path> --json
+uv run --python 3.13 -- python -m openclaw_mem continuity adjudication --snapshot <path> --json
+uv run --python 3.13 -- python -m openclaw_mem continuity public-summary --snapshot <path> --json
+uv run --python 3.13 -- python -m openclaw_mem continuity threat-feed --snapshot <path> --json
+uv run --python 3.13 -- python -m openclaw_mem continuity diff --from <snapshot-a.json> --to <snapshot-b.json> --json
+uv run --python 3.13 -- python -m openclaw_mem continuity release --stance <id> --reason <text> --mode weaken --factor 0.5 --json
+uv run --python 3.13 -- python -m openclaw_mem continuity release --stance <id> --reason <text> --mode rebind --json
+uv run --python 3.13 -- python -m openclaw_mem continuity release-history --scope <scope> --session-id <session> --stance <id> --json
+uv run --python 3.13 -- python -m openclaw_mem continuity compare-migration \
   --baseline-persona-file baseline.json \
   --candidate-persona-file candidate.json \
   --scope <scope> --session-id <session> --json
-openclaw-mem continuity enable --cadence-seconds 300 --json
-openclaw-mem continuity status --json
-openclaw-mem continuity auto-run --scope <scope> --session-id <session> --cycles 1 --json
-openclaw-mem continuity disable --json
+uv run --python 3.13 -- python -m openclaw_mem continuity enable --cadence-seconds 300 --json
+uv run --python 3.13 -- python -m openclaw_mem continuity status --json
+uv run --python 3.13 -- python -m openclaw_mem continuity auto-run --scope <scope> --session-id <session> --cycles 1 --json
+uv run --python 3.13 -- python -m openclaw_mem continuity disable --json
 ```
 
 ## Recommended operating pattern
 1. Build `current` and persist it when you need an audit point.
-2. Inspect `attachment-map` before making release decisions.
+2. Inspect `attachment-map` and `adjudication` before making release decisions.
 3. Check `threat-feed` before claiming the model is stable.
-4. Use `release` only with a concrete operator reason, ideally scoped to the active scope/session.
-5. Use `compare-migration` before prompt/model/persona refreshes.
-6. Enable the control plane only when you actually want autonomous receipts.
-7. Rebuild `current` after release to verify the attachment actually loosened.
+4. Use `public-summary` only for restrained public-safe language, never as identity truth.
+5. Use `release` only with a concrete operator reason, ideally scoped to the active scope/session.
+6. Use `release-history` when you need to replay weaken -> rebind -> retire state transitions.
+7. Use `compare-migration` before prompt/model/persona refreshes.
+8. Enable the control plane only when you actually want autonomous receipts.
+9. Rebuild `current` after release to verify the attachment actually loosened, recovered, or disappeared as expected.
 
 ## Inputs
 - live `openclaw-mem` observations / episodic events DB
@@ -51,9 +60,12 @@ openclaw-mem continuity disable --json
 ## Outputs
 - current snapshot schema: `openclaw-mem.self-model.snapshot.v0`
 - attachment map schema: `openclaw-mem.self-model.attachment-map.v0`
+- adjudication report schema: `openclaw-mem.self-model.adjudication.v0`
+- public summary schema: `openclaw-mem.self-model.public-summary.v0`
 - threat feed schema: `openclaw-mem.self-model.threat-feed.v0`
 - diff schema: `openclaw-mem.self-model.diff.v0`
 - release receipt schema: `openclaw-mem.self-model.release-receipt.v0`
+- release history schema: `openclaw-mem.self-model.release-history.v0`
 - migration compare schema: `openclaw-mem.self-model.compare-migration.v0`
 
 ## Safety reminders


### PR DESCRIPTION
## Summary
- update public-facing docs to describe the governed continuity side-car accurately
- align the dedicated ops skill with the supported `uv run --python 3.13 -- python -m openclaw_mem ...` command shape
- record live continuity enablement, first snapshot, and second-brain doc review receipts

## Verification
- Claude doc review final verdict: Ship
- `uv run --python 3.13 -- python -m openclaw_mem continuity enable --cadence-seconds 300 --json`
- `uv run --python 3.13 -- python -m openclaw_mem continuity current --json`
- `uv run --python 3.13 -- python -m openclaw_mem continuity auto-run --cycles 1 --json`
- `uv run --python 3.13 -- python -m openclaw_mem continuity status --json`
- `uv run --python 3.13 -- python -m openclaw_mem continuity public-summary --snapshot /root/.openclaw/memory/openclaw-mem/self-model-sidecar/snapshots/latest.json --json`

## Receipts
- repo: `docs/2026-04-18_self-model-sidecar-activation-and-docs-receipt.md`
- second brain: `/root/.openclaw/workspace/.state/decision-council/claude_public_docs_continuity_review_final.md`
