### PR TITLE
feat: add gbrain sidecar consult and bounded jobs bridge

### DIFF
--- a/docs/experimental/gbrain-sidecar/README.md
+++ b/docs/experimental/gbrain-sidecar/README.md
@@ -45,6 +45,28 @@ Why this narrow:
 - keeps phase 2 on deterministic helper work
 - widens only after receipts show net value
 
+## Phase 3 shipped here
+
+Governed refresh canary:
+
+- `openclaw-mem gbrain-sidecar recommend-refresh`
+- `openclaw-mem optimize governor-review --approve-refresh`
+- `openclaw-mem gbrain-sidecar refresh-canary`
+
+Current posture:
+
+- recommendation packet is additive and read-only
+- governor packet is still mandatory
+- canary defaults to dry-run
+- actual apply is bounded to one `refresh_card` candidate per run
+- receipts and rollback artifact are always written
+
+Why this shape:
+
+- proves the governed write bridge without opening broad mutation authority
+- reuses the existing governor ladder instead of inventing a bypass lane
+- keeps gbrain in the evidence role while `openclaw-mem` remains writer-of-record
+
 ## Operator notes
 
 - default binary: `gbrain`

--- a/docs/experimental/gbrain-sidecar/README.md
+++ b/docs/experimental/gbrain-sidecar/README.md
@@ -1,0 +1,60 @@
+# gbrain side-car experimental lane
+
+Status: Phase 1 and Phase 2 bounded implementation slice.
+
+## Verdict
+
+`openclaw-mem` stays the memory governor and `ContextPack` owner.
+`gbrain` is consulted as an external brain and used as a bounded deterministic worker substrate.
+
+## Phase 1 shipped here
+
+Read-only consult adapter:
+
+- `openclaw-mem pack --use-gbrain on`
+- `openclaw-mem gbrain-sidecar consult --query ...`
+
+Guardrails:
+
+- baseline `bundle_text` and `context_pack` stay schema-stable
+- gbrain output is normalized into a source-labeled additive payload
+- trace receipts expose `trace.extensions.gbrain`
+- failures are fail-open and do not break Pack
+
+Additive payloads:
+
+- `gbrain`: normalized consult receipt
+- `bundle_text_with_gbrain`: optional combined text for operator-controlled injection
+
+## Phase 2 shipped here
+
+Bounded Minions bridge:
+
+- `openclaw-mem gbrain-sidecar jobs-smoke`
+- `openclaw-mem gbrain-sidecar jobs-submit`
+- `openclaw-mem gbrain-sidecar jobs-list`
+- `openclaw-mem gbrain-sidecar jobs-retry`
+
+Current lane is intentionally narrow:
+
+- allowed job family: `embed`
+
+Why this narrow:
+
+- proves the queue bridge without giving gbrain broad execution authority
+- keeps phase 2 on deterministic helper work
+- widens only after receipts show net value
+
+## Operator notes
+
+- default binary: `gbrain`
+- override with `--gbrain-bin` when needed
+- consult timeout and job timeout are explicit flags
+- if `gbrain` is missing or slow, Pack degrades to baseline behavior
+
+## Non-goals in this slice
+
+- direct writes from gbrain into Store
+- `ContextPack` schema changes tied to gbrain internals
+- broad unrestricted job submission
+- treating gbrain as truth owner

--- a/openclaw_mem/cli.py
+++ b/openclaw_mem/cli.py
@@ -159,6 +159,12 @@ DEFAULT_OPTIMIZE_ASSIST_RUN_DIR = os.path.join(
     "openclaw-mem",
     "optimize-assist",
 )
+DEFAULT_GBRAIN_SIDECAR_RUN_DIR = os.path.join(
+    STATE_DIR,
+    "memory",
+    "openclaw-mem",
+    "gbrain-sidecar",
+)
 DEFAULT_OPENCLAW_SESSIONS_ROOT = os.path.join(STATE_DIR, "sessions")
 DEFAULT_CRON_JOBS_JSON = os.path.join(STATE_DIR, "cron", "jobs.json")
 DEFAULT_DB = os.path.join(STATE_DIR, "memory", "openclaw-mem.sqlite")
@@ -2096,6 +2102,68 @@ def _optimize_assist_load_governor_packet(path_value: Optional[str]) -> Dict[str
     if not isinstance(items, list):
         raise ValueError('packet items must be a list')
     return payload
+
+
+def _gbrain_sidecar_load_consult_packet(path_value: Optional[str]) -> Dict[str, Any]:
+    if path_value:
+        raw = Path(path_value).read_text(encoding='utf-8')
+    else:
+        raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw)
+    except Exception as e:
+        raise ValueError(f'invalid_json: {e}') from e
+    if not isinstance(payload, dict):
+        raise ValueError('packet must be a JSON object')
+    if str(payload.get('schema') or '') != gbrain_sidecar.CONSULT_SCHEMA:
+        raise ValueError('unsupported consult packet kind')
+    return payload
+
+
+def _gbrain_sidecar_load_refresh_governor_packet(path_value: Optional[str]) -> Dict[str, Any]:
+    payload = _optimize_assist_load_governor_packet(path_value)
+    return payload
+
+
+def _gbrain_sidecar_recent_refresh_count(run_dir: Path, *, since_ts: datetime) -> int:
+    if not run_dir.exists():
+        return 0
+    total = 0
+    for path in run_dir.rglob('*.after.json'):
+        try:
+            payload = json.loads(path.read_text(encoding='utf-8'))
+        except Exception:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if str(payload.get('kind') or '') != 'openclaw-mem.gbrain-sidecar.refresh-canary.after.v0':
+            continue
+        ts_value = _parse_iso_utc(payload.get('ts'))
+        if ts_value is None or ts_value < since_ts:
+            continue
+        if str(payload.get('result') or '') != 'applied':
+            continue
+        total += _optimize_policy_int(payload.get('applied_count'), 0, min_value=0)
+    return total
+
+
+def _gbrain_sidecar_prior_packet_attempts(run_dir: Path, *, packet_sha256: str) -> int:
+    if not run_dir.exists() or not packet_sha256:
+        return 0
+    total = 0
+    for path in run_dir.rglob('*.before.json'):
+        try:
+            payload = json.loads(path.read_text(encoding='utf-8'))
+        except Exception:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if str(payload.get('kind') or '') != 'openclaw-mem.gbrain-sidecar.refresh-canary.before.v0':
+            continue
+        if str(payload.get('packet_sha256') or '') != packet_sha256:
+            continue
+        total += 1
+    return total
 
 
 def _optimize_effect_followup_load_packet(path_value: Optional[str]) -> Dict[str, Any]:
@@ -7827,6 +7895,182 @@ def cmd_gbrain_jobs_retry(_conn: sqlite3.Connection, args: argparse.Namespace) -
     _emit(payload, True)
 
 
+def cmd_gbrain_recommend_refresh(_conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    consult_payload = None
+    consult_file = getattr(args, 'consult_file', None)
+    if consult_file:
+        try:
+            consult_payload = _gbrain_sidecar_load_consult_packet(consult_file)
+        except Exception as e:
+            _emit({'error': str(e)}, True)
+            sys.exit(2)
+    try:
+        payload = gbrain_sidecar.build_refresh_recommendation(
+            record_ref=str(getattr(args, 'record_ref', None) or ''),
+            consult_payload=consult_payload,
+            candidate_id=getattr(args, 'candidate_id', None),
+            max_evidence_refs=max(1, int(getattr(args, 'max_evidence_refs', 4) or 4)),
+        )
+    except ValueError as e:
+        _emit({'error': str(e)}, True)
+        sys.exit(2)
+    _emit(payload, True)
+
+
+def cmd_gbrain_refresh_canary(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    try:
+        packet = _gbrain_sidecar_load_refresh_governor_packet(getattr(args, 'from_file', None))
+    except Exception as e:
+        _emit({'error': str(e)}, True)
+        sys.exit(2)
+
+    operator = str(getattr(args, 'operator', None) or 'operator').strip() or 'operator'
+    lane = 'graph.synth.refresh'
+    dry_run = not bool(getattr(args, 'apply', False))
+    run_root = Path(os.path.expanduser(str(getattr(args, 'run_dir', None) or DEFAULT_GBRAIN_SIDECAR_RUN_DIR)))
+    run_dir = run_root / datetime.now(timezone.utc).strftime('%Y-%m-%d')
+    run_dir.mkdir(parents=True, exist_ok=True)
+    max_refresh_writes_per_24h = _optimize_policy_int(getattr(args, 'max_refresh_writes_per_24h', 3), 3, min_value=1)
+    packet_sha256 = _json_sha256(packet)
+
+    approved_items = [
+        item for item in list(packet.get('items') or [])
+        if isinstance(item, dict)
+        and str(item.get('decision') or '') == 'approved_for_apply'
+        and str(item.get('apply_lane') or '') == lane
+        and str(item.get('recommended_action') or '') == 'refresh_card'
+    ]
+
+    blocked_reasons: List[str] = []
+    if not approved_items:
+        blocked_reasons.append('no_approved_refresh_candidates')
+    if len(approved_items) > 1:
+        blocked_reasons.append('max_candidates_per_run_exceeded')
+    if _gbrain_sidecar_prior_packet_attempts(run_root, packet_sha256=packet_sha256) >= 1:
+        blocked_reasons.append('max_retries_per_packet_exceeded')
+    if _gbrain_sidecar_recent_refresh_count(run_root, since_ts=datetime.now(timezone.utc) - timedelta(hours=24)) >= max_refresh_writes_per_24h:
+        blocked_reasons.append('max_refresh_writes_per_24h_exceeded')
+
+    target_ref = None
+    before_snapshot: Dict[str, Any] = {}
+    if approved_items:
+        target_ref = str(((approved_items[0].get('target') or {}).get('recordRef') or '')).strip()
+        if not target_ref:
+            blocked_reasons.append('missing_refresh_target')
+        else:
+            try:
+                oid = _graph_parse_record_ref(target_ref)
+                row = _graph_fetch_rows_by_ids(conn, [oid]).get(oid)
+            except Exception:
+                row = None
+            if row is None:
+                blocked_reasons.append('missing_synthesis_card')
+            else:
+                detail = _pack_parse_detail_json(row['detail_json'])
+                before_snapshot = {
+                    'recordRef': target_ref,
+                    'summary': str(row['summary'] or ''),
+                    'detail_json': detail,
+                    'detail_sha256': _json_sha256(detail),
+                    'status': str((((detail.get('graph_synthesis') if isinstance(detail.get('graph_synthesis'), dict) else {}).get('status')) or '')),
+                }
+
+    run_id = str(uuid.uuid4())
+    ts_now = _utcnow_iso()
+    stamp = _utcnow_compact()
+    before_path = run_dir / f'{stamp}-{run_id}.before.json'
+    rollback_path = run_dir / f'{stamp}-{run_id}.rollback.json'
+    after_path = run_dir / f'{stamp}-{run_id}.after.json'
+
+    before_payload = {
+        'kind': 'openclaw-mem.gbrain-sidecar.refresh-canary.before.v0',
+        'run_id': run_id,
+        'ts': ts_now,
+        'operator': operator,
+        'lane': lane,
+        'dry_run': dry_run,
+        'packet': packet,
+        'packet_sha256': packet_sha256,
+        'target_ref': target_ref,
+        'caps': {
+            'max_candidates_per_run': 1,
+            'max_refresh_writes_per_24h': max_refresh_writes_per_24h,
+            'max_retries_per_packet': 1,
+            'supported_action_classes': ['refresh_card'],
+        },
+        'before_snapshot': before_snapshot,
+        'blocked_reasons': blocked_reasons,
+        'policy': {
+            'mode': 'gbrain_sidecar_refresh_canary',
+            'memory_mutation': 'graph_refresh_pending',
+            'writes_performed': 0,
+        },
+    }
+    before_path.write_text(json.dumps(before_payload, ensure_ascii=False, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+
+    rollback_payload = {
+        'kind': 'openclaw-mem.gbrain-sidecar.refresh-canary.rollback.v0',
+        'run_id': run_id,
+        'ts': ts_now,
+        'operator': operator,
+        'lane': lane,
+        'target_ref': target_ref,
+        'before_snapshot': before_snapshot,
+        'restore_hint': 'restore source card detail_json from before_snapshot and retire any new refresh card recorded in after payload',
+    }
+
+    after_result = 'dry_run' if dry_run else 'applied'
+    refresh_payload = None
+    after_snapshot = None
+    if blocked_reasons:
+        after_result = 'aborted'
+    elif not dry_run:
+        try:
+            refresh_payload = _graph_synth_refresh_payload(conn, record_ref=str(target_ref or ''), force=bool(getattr(args, 'force', False)))
+            conn.commit()
+            result_obj = refresh_payload.get('result') if isinstance(refresh_payload, dict) else {}
+            new_ref = str((result_obj or {}).get('recordRef') or '').strip()
+            row_map = _graph_fetch_rows_by_ids(conn, [_graph_parse_record_ref(new_ref)]) if new_ref else {}
+            new_row = row_map.get(_graph_parse_record_ref(new_ref)) if new_ref else None
+            after_detail = _pack_parse_detail_json(new_row['detail_json']) if new_row is not None else {}
+            after_snapshot = {
+                'recordRef': new_ref or target_ref,
+                'detail_json': after_detail,
+                'detail_sha256': _json_sha256(after_detail) if after_detail else None,
+                'refresh_payload': refresh_payload,
+            }
+            rollback_payload['new_record_ref'] = new_ref or None
+        except Exception as e:
+            conn.rollback()
+            blocked_reasons.append(str(e))
+            after_result = 'aborted'
+
+    rollback_path.write_text(json.dumps(rollback_payload, ensure_ascii=False, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+
+    after_payload = {
+        'kind': 'openclaw-mem.gbrain-sidecar.refresh-canary.after.v0',
+        'run_id': run_id,
+        'ts': _utcnow_iso(),
+        'operator': operator,
+        'lane': lane,
+        'result': after_result,
+        'applied_count': 1 if after_result == 'applied' else 0,
+        'target_ref': target_ref,
+        'blocked_reasons': blocked_reasons,
+        'rollback_ref': str(rollback_path),
+        'before_ref': str(before_path),
+        'after_snapshot': after_snapshot,
+        'refresh_payload': refresh_payload,
+        'policy': {
+            'mode': 'gbrain_sidecar_refresh_canary',
+            'writes_performed': 1 if after_result == 'applied' else 0,
+            'memory_mutation': 'graph_refresh_applied' if after_result == 'applied' else 'none',
+        },
+    }
+    after_path.write_text(json.dumps(after_payload, ensure_ascii=False, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+    _emit(after_payload, True)
+
+
 
 def _atomic_write(path_: Path, content: str) -> None:
     path_.parent.mkdir(parents=True, exist_ok=True)
@@ -11007,153 +11251,27 @@ def cmd_graph_synth(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
             _emit({'error': 'refresh requires exactly one synthesis card ref'}, True)
             sys.exit(2)
         ref = refs[0]
-        oid = _graph_parse_record_ref(ref)
-        row = _graph_fetch_rows_by_ids(conn, [oid]).get(oid)
-        if row is None:
-            _emit({'error': 'missing synthesis card', 'recordRef': ref}, True)
-            sys.exit(2)
-
-        detail = _pack_parse_detail_json(row['detail_json'])
-        synth = detail.get('graph_synthesis') if isinstance(detail.get('graph_synthesis'), dict) else {}
-        if not synth:
-            _emit({'error': 'record is not a synthesis card', 'recordRef': ref}, True)
-            sys.exit(2)
-
-        current_item = _graph_eval_synthesis_card(conn, row)
-        force = bool(getattr(args, 'force', False))
-        if current_item.get('status') == 'fresh' and not force:
-            payload = {
-                'kind': 'openclaw-mem.graph.synth.refresh.v0',
-                'ts': _utcnow_iso(),
-                'sourceCardRef': ref,
-                'result': {
-                    'ok': True,
-                    'refreshed': False,
-                    'reason': 'already_fresh',
-                    'recordRef': ref,
-                    'status': current_item.get('status'),
-                },
-                'staleCheck': current_item,
-            }
-            if bool(args.json):
-                _emit(payload, True)
-                return
-            print(f"recordRef={ref} refreshed=0 reason=already_fresh status=fresh")
-            return
-
         try:
-            selected_refs, selection = _graph_refresh_compile_selection(conn, synth=synth, exclude_refs=[ref])
+            payload = _graph_synth_refresh_payload(
+                conn,
+                record_ref=ref,
+                force=bool(getattr(args, 'force', False)),
+                title=getattr(args, 'title', None),
+                summary_text=getattr(args, 'summary_text', None),
+                why_it_matters=getattr(args, 'why_it_matters', None),
+                write_md=getattr(args, 'write_md', None),
+            )
         except ValueError as e:
             _emit({'error': str(e), 'recordRef': ref}, True)
             sys.exit(2)
-
-        source_ids = [_graph_parse_record_ref(x) for x in selected_refs]
-        source_rows = _graph_fetch_rows_by_ids(conn, source_ids)
-        missing = [x for x in selected_refs if _graph_parse_record_ref(x) not in source_rows]
-        if missing:
-            _emit({'error': 'missing source refs', 'recordRef': ref, 'missing': missing}, True)
-            sys.exit(2)
-
-        snapshots = [_graph_source_snapshot(source_rows[x]) for x in source_ids if x in source_rows]
-        source_digest = _graph_source_digest_from_snapshots(snapshots)
-        compiled_at = _utcnow_iso()
-        title = (getattr(args, 'title', None) or '').strip() or str(synth.get('title') or row['summary'] or ref)
-        summary_text = (getattr(args, 'summary_text', None) or '').strip() or str(synth.get('summary') or row['summary'] or title)
-        why_it_matters = (getattr(args, 'why_it_matters', None) or '').strip() or (synth.get('why_it_matters') or None)
-        scope = _normalize_scope_token((synth.get('scope') or detail.get('scope') or None))
-
-        new_detail = {
-            'scope': scope,
-            'graph_synthesis': {
-                'version': 'v0',
-                'title': title,
-                'summary': summary_text,
-                'why_it_matters': why_it_matters,
-                'source_refs': selected_refs,
-                'source_count': len(selected_refs),
-                'source_digest': source_digest,
-                'compiled_at': compiled_at,
-                'selection': selection,
-                'status': 'fresh',
-                'trust_tier': 'derived',
-                'lifecycle': {
-                    'refresh_of': ref,
-                    'refresh_reasons': list(current_item.get('reasons') or []),
-                    'previous_status': current_item.get('status'),
-                },
-            },
-        }
-
-        obs = {
-            'ts': compiled_at,
-            'kind': 'note',
-            'summary': summary_text,
-            'tool_name': 'graph.synth-compile',
-            'detail': new_detail,
-        }
-        rowid = _insert_observation(conn, obs)
-        new_ref = _graph_record_ref(rowid)
-
-        old_detail = dict(detail)
-        old_synth = dict(synth)
-        old_lifecycle = old_synth.get('lifecycle') if isinstance(old_synth.get('lifecycle'), dict) else {}
-        old_synth['status'] = 'superseded'
-        old_synth['superseded_by'] = new_ref
-        old_synth['superseded_at'] = compiled_at
-        old_synth['lifecycle'] = {
-            **old_lifecycle,
-            'superseded_by': new_ref,
-            'superseded_at': compiled_at,
-            'supersede_reasons': list(current_item.get('reasons') or []),
-        }
-        old_detail['graph_synthesis'] = old_synth
-        _graph_update_observation_detail(conn, rowid=oid, detail=old_detail, summary=str(row['summary'] or ''))
-
-        markdown_path = (getattr(args, 'write_md', None) or '').strip()
-        markdown_written = None
-        markdown_text = _graph_build_synth_markdown(
-            title=title,
-            summary_text=summary_text,
-            why_it_matters=why_it_matters,
-            scope=scope,
-            source_refs=selected_refs,
-            source_digest=source_digest,
-            compiled_at=compiled_at,
-            selection=selection,
-        )
-        if markdown_path:
-            md_path = Path(markdown_path)
-            md_path.parent.mkdir(parents=True, exist_ok=True)
-            md_path.write_text(markdown_text, encoding='utf-8')
-            markdown_written = str(md_path)
-
-        payload = {
-            'kind': 'openclaw-mem.graph.synth.refresh.v0',
-            'ts': compiled_at,
-            'sourceCardRef': ref,
-            'selection': selection,
-            'result': {
-                'ok': True,
-                'refreshed': True,
-                'recordRef': new_ref,
-                'title': title,
-                'summary': summary_text,
-                'whyItMatters': why_it_matters,
-                'sourceRefs': selected_refs,
-                'sourceCount': len(selected_refs),
-                'sourceDigest': source_digest,
-                'markdownPath': markdown_written,
-                'refreshOf': ref,
-                'supersededCardRef': ref,
-            },
-            'staleCheck': current_item,
-            'bundle_text': markdown_text,
-        }
         conn.commit()
         if bool(args.json):
             _emit(payload, True)
             return
-        print(markdown_text, end='')
+        if not bool(((payload.get('result') or {}).get('refreshed'))):
+            print(f"recordRef={ref} refreshed=0 reason=already_fresh status=fresh")
+            return
+        print(str(payload.get('bundle_text') or ''), end='')
         return
 
     if synth_cmd == 'recommend':
@@ -11439,6 +11557,148 @@ def _graph_synth_recommend_payload(conn: sqlite3.Connection) -> Dict[str, Any]:
         'ts': _utcnow_iso(),
         'counts': counts,
         'items': items,
+    }
+
+
+def _graph_synth_refresh_payload(
+    conn: sqlite3.Connection,
+    *,
+    record_ref: str,
+    force: bool = False,
+    title: Optional[str] = None,
+    summary_text: Optional[str] = None,
+    why_it_matters: Optional[str] = None,
+    write_md: Optional[str] = None,
+) -> Dict[str, Any]:
+    ref = str(record_ref or '').strip()
+    oid = _graph_parse_record_ref(ref)
+    row = _graph_fetch_rows_by_ids(conn, [oid]).get(oid)
+    if row is None:
+        raise ValueError('missing synthesis card')
+
+    detail = _pack_parse_detail_json(row['detail_json'])
+    synth = detail.get('graph_synthesis') if isinstance(detail.get('graph_synthesis'), dict) else {}
+    if not synth:
+        raise ValueError('record is not a synthesis card')
+
+    current_item = _graph_eval_synthesis_card(conn, row)
+    if current_item.get('status') == 'fresh' and not force:
+        return {
+            'kind': 'openclaw-mem.graph.synth.refresh.v0',
+            'ts': _utcnow_iso(),
+            'sourceCardRef': ref,
+            'result': {
+                'ok': True,
+                'refreshed': False,
+                'reason': 'already_fresh',
+                'recordRef': ref,
+                'status': current_item.get('status'),
+            },
+            'staleCheck': current_item,
+        }
+
+    selected_refs, selection = _graph_refresh_compile_selection(conn, synth=synth, exclude_refs=[ref])
+
+    source_ids = [_graph_parse_record_ref(x) for x in selected_refs]
+    source_rows = _graph_fetch_rows_by_ids(conn, source_ids)
+    missing = [x for x in selected_refs if _graph_parse_record_ref(x) not in source_rows]
+    if missing:
+        raise ValueError('missing source refs')
+
+    snapshots = [_graph_source_snapshot(source_rows[x]) for x in source_ids if x in source_rows]
+    source_digest = _graph_source_digest_from_snapshots(snapshots)
+    compiled_at = _utcnow_iso()
+    title_value = (title or '').strip() or str(synth.get('title') or row['summary'] or ref)
+    summary_value = (summary_text or '').strip() or str(synth.get('summary') or row['summary'] or title_value)
+    why_value = (why_it_matters or '').strip() or (synth.get('why_it_matters') or None)
+    scope = _normalize_scope_token((synth.get('scope') or detail.get('scope') or None))
+
+    new_detail = {
+        'scope': scope,
+        'graph_synthesis': {
+            'version': 'v0',
+            'title': title_value,
+            'summary': summary_value,
+            'why_it_matters': why_value,
+            'source_refs': selected_refs,
+            'source_count': len(selected_refs),
+            'source_digest': source_digest,
+            'compiled_at': compiled_at,
+            'selection': selection,
+            'status': 'fresh',
+            'trust_tier': 'derived',
+            'lifecycle': {
+                'refresh_of': ref,
+                'refresh_reasons': list(current_item.get('reasons') or []),
+                'previous_status': current_item.get('status'),
+            },
+        },
+    }
+
+    obs = {
+        'ts': compiled_at,
+        'kind': 'note',
+        'summary': summary_value,
+        'tool_name': 'graph.synth-compile',
+        'detail': new_detail,
+    }
+    rowid = _insert_observation(conn, obs)
+    new_ref = _graph_record_ref(rowid)
+
+    old_detail = dict(detail)
+    old_synth = dict(synth)
+    old_lifecycle = old_synth.get('lifecycle') if isinstance(old_synth.get('lifecycle'), dict) else {}
+    old_synth['status'] = 'superseded'
+    old_synth['superseded_by'] = new_ref
+    old_synth['superseded_at'] = compiled_at
+    old_synth['lifecycle'] = {
+        **old_lifecycle,
+        'superseded_by': new_ref,
+        'superseded_at': compiled_at,
+        'supersede_reasons': list(current_item.get('reasons') or []),
+    }
+    old_detail['graph_synthesis'] = old_synth
+    _graph_update_observation_detail(conn, rowid=oid, detail=old_detail, summary=str(row['summary'] or ''))
+
+    markdown_written = None
+    markdown_text = _graph_build_synth_markdown(
+        title=title_value,
+        summary_text=summary_value,
+        why_it_matters=why_value,
+        scope=scope,
+        source_refs=selected_refs,
+        source_digest=source_digest,
+        compiled_at=compiled_at,
+        selection=selection,
+    )
+    markdown_path = (write_md or '').strip()
+    if markdown_path:
+        md_path = Path(markdown_path)
+        md_path.parent.mkdir(parents=True, exist_ok=True)
+        md_path.write_text(markdown_text, encoding='utf-8')
+        markdown_written = str(md_path)
+
+    return {
+        'kind': 'openclaw-mem.graph.synth.refresh.v0',
+        'ts': compiled_at,
+        'sourceCardRef': ref,
+        'selection': selection,
+        'result': {
+            'ok': True,
+            'refreshed': True,
+            'recordRef': new_ref,
+            'title': title_value,
+            'summary': summary_value,
+            'whyItMatters': why_value,
+            'sourceRefs': selected_refs,
+            'sourceCount': len(selected_refs),
+            'sourceDigest': source_digest,
+            'markdownPath': markdown_written,
+            'refreshOf': ref,
+            'supersededCardRef': ref,
+        },
+        'staleCheck': current_item,
+        'bundle_text': markdown_text,
     }
 
 
@@ -15799,6 +16059,22 @@ def build_parser() -> argparse.ArgumentParser:
     g.add_argument("--timeout-ms", type=int, default=gbrain_sidecar.DEFAULT_JOBS_TIMEOUT_MS, help=f"Timeout in ms (default: {gbrain_sidecar.DEFAULT_JOBS_TIMEOUT_MS})")
     g.add_argument("--gbrain-bin", default=gbrain_sidecar.DEFAULT_GBRAIN_BIN, help=f"gbrain binary to invoke (default: {gbrain_sidecar.DEFAULT_GBRAIN_BIN})")
     g.set_defaults(func=cmd_gbrain_jobs_retry)
+
+    g = gsub.add_parser("recommend-refresh", help="Build a bounded refresh recommendation packet for Phase 3 governor review")
+    g.add_argument("--record-ref", required=True, help="Local synthesis card ref to refresh (for example obs:123)")
+    g.add_argument("--consult-file", help="Optional gbrain consult packet JSON path")
+    g.add_argument("--candidate-id", help="Optional candidate id override")
+    g.add_argument("--max-evidence-refs", type=int, default=4, help="Max gbrain evidence refs to attach (default: 4)")
+    g.set_defaults(func=cmd_gbrain_recommend_refresh)
+
+    g = gsub.add_parser("refresh-canary", help="Run the bounded Phase 3 refresh canary from a governor packet")
+    g.add_argument("--from-file", help="Governor packet JSON path (defaults to stdin)")
+    g.add_argument("--operator", default="gbrain-sidecar", help="Operator label for receipts (default: gbrain-sidecar)")
+    g.add_argument("--run-dir", dest="run_dir", default=DEFAULT_GBRAIN_SIDECAR_RUN_DIR, help=f"Directory for before/after/rollback receipts (default: {DEFAULT_GBRAIN_SIDECAR_RUN_DIR})")
+    g.add_argument("--apply", action="store_true", help="Perform the refresh instead of dry-run only")
+    g.add_argument("--force", action="store_true", help="Pass force through to graph synth refresh")
+    g.add_argument("--max-refresh-writes-per-24h", dest="max_refresh_writes_per_24h", type=int, default=3, help="24h cap for applied refresh writes (default: 3)")
+    g.set_defaults(func=cmd_gbrain_refresh_canary)
 
     add_capsule_parser_to_cli(sub)
 

--- a/openclaw_mem/cli.py
+++ b/openclaw_mem/cli.py
@@ -35,6 +35,7 @@ from typing import Iterable, Dict, Any, List, Optional, Set, Tuple
 from openclaw_mem import __version__
 from openclaw_mem import defaults
 from openclaw_mem import context_pack_v1
+from openclaw_mem import gbrain_sidecar
 from openclaw_mem import pack_trace_v1
 from openclaw_mem import self_model_sidecar
 from openclaw_mem.artifact_sidecar import (
@@ -7189,6 +7190,20 @@ def _pack_graph_trace_extension(graph_state: dict) -> dict:
     }
 
 
+def _pack_gbrain_consult_optional(args: argparse.Namespace, query: str) -> Optional[Dict[str, Any]]:
+    use_gbrain = str(getattr(args, "use_gbrain", "off") or "off").strip().lower()
+    if use_gbrain == "off":
+        return None
+
+    return gbrain_sidecar.consult(
+        query,
+        limit=max(1, int(getattr(args, "gbrain_limit", gbrain_sidecar.DEFAULT_CONSULT_LIMIT) or gbrain_sidecar.DEFAULT_CONSULT_LIMIT)),
+        timeout_ms=max(1, int(getattr(args, "gbrain_timeout_ms", gbrain_sidecar.DEFAULT_CONSULT_TIMEOUT_MS) or gbrain_sidecar.DEFAULT_CONSULT_TIMEOUT_MS)),
+        gbrain_bin=str(getattr(args, "gbrain_bin", gbrain_sidecar.DEFAULT_GBRAIN_BIN) or gbrain_sidecar.DEFAULT_GBRAIN_BIN),
+        expand=bool(getattr(args, "gbrain_expand", False)),
+    )
+
+
 def cmd_pack(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
     """Build a compact, cited L1-style bundle from hybrid retrieval."""
     query = (args.query or "").strip()
@@ -7501,6 +7516,17 @@ def cmd_pack(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
         "citations": citations,
         "context_pack": context_pack_v1.to_dict(context_pack),
     }
+
+    gbrain_consult = _pack_gbrain_consult_optional(args, query)
+    if gbrain_consult is not None:
+        payload["gbrain"] = gbrain_consult
+        gbrain_bundle = str(gbrain_consult.get("bundle_text") or "").strip()
+        if gbrain_bundle:
+            base_bundle = str(payload.get("bundle_text_with_graph") or bundle_text).strip()
+            joined_parts = [part for part in [base_bundle, gbrain_bundle] if part]
+            if joined_parts:
+                payload["bundle_text_with_gbrain"] = "\n".join(joined_parts).strip() + "\n"
+
     if compaction_selected:
         compaction_policy_hints = _pack_compaction_policy_hints(compaction_selected)
         payload["compaction_sideband"] = {
@@ -7636,6 +7662,8 @@ def cmd_pack(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
         trace_extensions: Dict[str, Any] = {}
         if (graph_state or {}).get("use_graph") != "off":
             trace_extensions["graph"] = _pack_graph_trace_extension(graph_state)
+        if gbrain_consult is not None:
+            trace_extensions["gbrain"] = gbrain_sidecar.trace_extension(gbrain_consult)
         if trust_policy_mode != "off":
             trace_extensions["trust_policy"] = trust_policy
         if policy_surface is not None:
@@ -7728,6 +7756,75 @@ def cmd_pack(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
         print(json.dumps(payload, ensure_ascii=False, indent=2))
     else:
         print((payload.get("bundle_text_with_graph") or bundle_text))
+
+
+def cmd_gbrain_consult(_conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    payload = gbrain_sidecar.consult(
+        args.query,
+        limit=max(1, int(getattr(args, "limit", gbrain_sidecar.DEFAULT_CONSULT_LIMIT) or gbrain_sidecar.DEFAULT_CONSULT_LIMIT)),
+        timeout_ms=max(1, int(getattr(args, "timeout_ms", gbrain_sidecar.DEFAULT_CONSULT_TIMEOUT_MS) or gbrain_sidecar.DEFAULT_CONSULT_TIMEOUT_MS)),
+        gbrain_bin=str(getattr(args, "gbrain_bin", gbrain_sidecar.DEFAULT_GBRAIN_BIN) or gbrain_sidecar.DEFAULT_GBRAIN_BIN),
+        expand=bool(getattr(args, "expand", False)),
+    )
+    _emit(payload, True)
+
+
+def cmd_gbrain_jobs_smoke(_conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    _emit(
+        gbrain_sidecar.smoke(
+            gbrain_bin=str(getattr(args, "gbrain_bin", gbrain_sidecar.DEFAULT_GBRAIN_BIN) or gbrain_sidecar.DEFAULT_GBRAIN_BIN),
+            timeout_ms=max(1, int(getattr(args, "timeout_ms", gbrain_sidecar.DEFAULT_JOBS_TIMEOUT_MS) or gbrain_sidecar.DEFAULT_JOBS_TIMEOUT_MS)),
+        ),
+        True,
+    )
+
+
+def cmd_gbrain_jobs_submit(_conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    try:
+        params, _, _ = _parse_optional_json_arg(getattr(args, "params_json", None), getattr(args, "params_file", None), "params")
+        payload = gbrain_sidecar.submit_job(
+            name=str(getattr(args, "name", "") or ""),
+            data=dict(params or {}),
+            queue=str(getattr(args, "queue", "default") or "default"),
+            priority=int(getattr(args, "priority", 0) or 0),
+            max_attempts=int(getattr(args, "max_attempts", 3) or 3),
+            delay=(int(getattr(args, "delay_ms", 0) or 0) if getattr(args, "delay_ms", None) is not None else None),
+            gbrain_bin=str(getattr(args, "gbrain_bin", gbrain_sidecar.DEFAULT_GBRAIN_BIN) or gbrain_sidecar.DEFAULT_GBRAIN_BIN),
+            timeout_ms=max(1, int(getattr(args, "timeout_ms", gbrain_sidecar.DEFAULT_JOBS_TIMEOUT_MS) or gbrain_sidecar.DEFAULT_JOBS_TIMEOUT_MS)),
+        )
+    except ValueError as e:
+        _emit({"error": str(e)}, True)
+        sys.exit(2)
+    _emit(payload, True)
+
+
+def cmd_gbrain_jobs_list(_conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    try:
+        payload = gbrain_sidecar.list_jobs(
+            status=getattr(args, "status", None),
+            queue=getattr(args, "queue", None),
+            limit=max(1, int(getattr(args, "limit", 20) or 20)),
+            name=str(getattr(args, "name", gbrain_sidecar.PHASE2_ALLOWED_JOB_NAME) or gbrain_sidecar.PHASE2_ALLOWED_JOB_NAME),
+            gbrain_bin=str(getattr(args, "gbrain_bin", gbrain_sidecar.DEFAULT_GBRAIN_BIN) or gbrain_sidecar.DEFAULT_GBRAIN_BIN),
+            timeout_ms=max(1, int(getattr(args, "timeout_ms", gbrain_sidecar.DEFAULT_JOBS_TIMEOUT_MS) or gbrain_sidecar.DEFAULT_JOBS_TIMEOUT_MS)),
+        )
+    except ValueError as e:
+        _emit({"error": str(e)}, True)
+        sys.exit(2)
+    _emit(payload, True)
+
+
+def cmd_gbrain_jobs_retry(_conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    try:
+        payload = gbrain_sidecar.retry_job(
+            int(args.id),
+            gbrain_bin=str(getattr(args, "gbrain_bin", gbrain_sidecar.DEFAULT_GBRAIN_BIN) or gbrain_sidecar.DEFAULT_GBRAIN_BIN),
+            timeout_ms=max(1, int(getattr(args, "timeout_ms", gbrain_sidecar.DEFAULT_JOBS_TIMEOUT_MS) or gbrain_sidecar.DEFAULT_JOBS_TIMEOUT_MS)),
+        )
+    except ValueError as e:
+        _emit({"error": str(e)}, True)
+        sys.exit(2)
+    _emit(payload, True)
 
 
 
@@ -15586,6 +15683,11 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--tail-file", help="Optional file containing protected tail lines (plain text or JSON list)")
     sp.add_argument("--tail-max-items", type=int, default=4, help="Max protected tail lines to consider (default: 4)")
     sp.add_argument("--tail-budget-tokens", type=int, default=0, help="Reserved token budget for protected tail lines (default: 0, disabled)")
+    sp.add_argument("--use-gbrain", choices=["off", "on"], default="off", help="Experimental gbrain consult adapter: off (default) | on")
+    sp.add_argument("--gbrain-bin", default=gbrain_sidecar.DEFAULT_GBRAIN_BIN, help=f"gbrain binary to invoke (default: {gbrain_sidecar.DEFAULT_GBRAIN_BIN})")
+    sp.add_argument("--gbrain-limit", type=int, default=gbrain_sidecar.DEFAULT_CONSULT_LIMIT, help=f"Max gbrain consult hits to normalize (default: {gbrain_sidecar.DEFAULT_CONSULT_LIMIT})")
+    sp.add_argument("--gbrain-timeout-ms", type=int, default=gbrain_sidecar.DEFAULT_CONSULT_TIMEOUT_MS, help=f"Timeout for gbrain consult in ms (default: {gbrain_sidecar.DEFAULT_CONSULT_TIMEOUT_MS})")
+    sp.add_argument("--gbrain-expand", action="store_true", help="Allow gbrain multi-query expansion for consult lane (default: off)")
 
     # Optional: Graphic Memory preflight integration (default OFF; fail-open)
     sp.add_argument(
@@ -15646,6 +15748,57 @@ def build_parser() -> argparse.ArgumentParser:
 
     sp.add_argument("--trace", action="store_true", help="Include redaction-safe retrieval trace (`openclaw-mem.pack.trace.v1`) with include/exclude decisions")
     sp.set_defaults(func=cmd_pack)
+
+    sp = sub.add_parser("gbrain-sidecar", help="Experimental gbrain consult + bounded phase-2 jobs bridge")
+    sp.add_argument("--db", default=None, help="SQLite DB path")
+    sp.add_argument(
+        "--json",
+        dest="json",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Structured JSON output (default: true).",
+    )
+    gsub = sp.add_subparsers(dest="gbrain_sidecar_cmd", required=True)
+
+    g = gsub.add_parser("consult", help="Run the experimental read-only gbrain consult adapter")
+    g.add_argument("--query", required=True, help="Consult query text")
+    g.add_argument("--limit", type=int, default=gbrain_sidecar.DEFAULT_CONSULT_LIMIT, help=f"Max hits to normalize (default: {gbrain_sidecar.DEFAULT_CONSULT_LIMIT})")
+    g.add_argument("--timeout-ms", type=int, default=gbrain_sidecar.DEFAULT_CONSULT_TIMEOUT_MS, help=f"Timeout in ms (default: {gbrain_sidecar.DEFAULT_CONSULT_TIMEOUT_MS})")
+    g.add_argument("--expand", action="store_true", help="Allow gbrain multi-query expansion")
+    g.add_argument("--gbrain-bin", default=gbrain_sidecar.DEFAULT_GBRAIN_BIN, help=f"gbrain binary to invoke (default: {gbrain_sidecar.DEFAULT_GBRAIN_BIN})")
+    g.set_defaults(func=cmd_gbrain_consult)
+
+    g = gsub.add_parser("jobs-smoke", help="Verify gbrain jobs smoke for the bounded phase-2 lane")
+    g.add_argument("--timeout-ms", type=int, default=gbrain_sidecar.DEFAULT_JOBS_TIMEOUT_MS, help=f"Timeout in ms (default: {gbrain_sidecar.DEFAULT_JOBS_TIMEOUT_MS})")
+    g.add_argument("--gbrain-bin", default=gbrain_sidecar.DEFAULT_GBRAIN_BIN, help=f"gbrain binary to invoke (default: {gbrain_sidecar.DEFAULT_GBRAIN_BIN})")
+    g.set_defaults(func=cmd_gbrain_jobs_smoke)
+
+    g = gsub.add_parser("jobs-submit", help=f"Submit the bounded phase-2 job lane ({gbrain_sidecar.PHASE2_ALLOWED_JOB_NAME})")
+    g.add_argument("--name", default=gbrain_sidecar.PHASE2_ALLOWED_JOB_NAME, help=f"Bounded job name (default and only allowed: {gbrain_sidecar.PHASE2_ALLOWED_JOB_NAME})")
+    g.add_argument("--params-json", help="Job params JSON")
+    g.add_argument("--params-file", help="Path to job params JSON file")
+    g.add_argument("--queue", default="default", help="Queue name (default: default)")
+    g.add_argument("--priority", type=int, default=0, help="Priority (default: 0)")
+    g.add_argument("--max-attempts", type=int, default=3, help="Max attempts (default: 3)")
+    g.add_argument("--delay-ms", type=int, help="Optional delay before eligibility")
+    g.add_argument("--timeout-ms", type=int, default=gbrain_sidecar.DEFAULT_JOBS_TIMEOUT_MS, help=f"Timeout in ms (default: {gbrain_sidecar.DEFAULT_JOBS_TIMEOUT_MS})")
+    g.add_argument("--gbrain-bin", default=gbrain_sidecar.DEFAULT_GBRAIN_BIN, help=f"gbrain binary to invoke (default: {gbrain_sidecar.DEFAULT_GBRAIN_BIN})")
+    g.set_defaults(func=cmd_gbrain_jobs_submit)
+
+    g = gsub.add_parser("jobs-list", help="List bounded phase-2 jobs through the gbrain bridge")
+    g.add_argument("--status", help="Optional status filter")
+    g.add_argument("--queue", help="Optional queue filter")
+    g.add_argument("--name", default=gbrain_sidecar.PHASE2_ALLOWED_JOB_NAME, help=f"Job name filter (default: {gbrain_sidecar.PHASE2_ALLOWED_JOB_NAME})")
+    g.add_argument("--limit", type=int, default=20, help="Max rows (default: 20)")
+    g.add_argument("--timeout-ms", type=int, default=gbrain_sidecar.DEFAULT_JOBS_TIMEOUT_MS, help=f"Timeout in ms (default: {gbrain_sidecar.DEFAULT_JOBS_TIMEOUT_MS})")
+    g.add_argument("--gbrain-bin", default=gbrain_sidecar.DEFAULT_GBRAIN_BIN, help=f"gbrain binary to invoke (default: {gbrain_sidecar.DEFAULT_GBRAIN_BIN})")
+    g.set_defaults(func=cmd_gbrain_jobs_list)
+
+    g = gsub.add_parser("jobs-retry", help="Retry a failed/dead gbrain job by id")
+    g.add_argument("--id", required=True, type=int, help="Job id")
+    g.add_argument("--timeout-ms", type=int, default=gbrain_sidecar.DEFAULT_JOBS_TIMEOUT_MS, help=f"Timeout in ms (default: {gbrain_sidecar.DEFAULT_JOBS_TIMEOUT_MS})")
+    g.add_argument("--gbrain-bin", default=gbrain_sidecar.DEFAULT_GBRAIN_BIN, help=f"gbrain binary to invoke (default: {gbrain_sidecar.DEFAULT_GBRAIN_BIN})")
+    g.set_defaults(func=cmd_gbrain_jobs_retry)
 
     add_capsule_parser_to_cli(sub)
 

--- a/openclaw_mem/cli.py
+++ b/openclaw_mem/cli.py
@@ -8043,6 +8043,7 @@ def cmd_gbrain_refresh_canary(conn: sqlite3.Connection, args: argparse.Namespace
             refresh_payload = _graph_synth_refresh_payload(conn, record_ref=str(target_ref or ''), force=bool(getattr(args, 'force', False)))
             conn.commit()
             result_obj = refresh_payload.get('result') if isinstance(refresh_payload, dict) else {}
+            refreshed = bool((result_obj or {}).get('refreshed'))
             new_ref = str((result_obj or {}).get('recordRef') or '').strip()
             row_map = _graph_fetch_rows_by_ids(conn, [_graph_parse_record_ref(new_ref)]) if new_ref else {}
             new_row = row_map.get(_graph_parse_record_ref(new_ref)) if new_ref else None
@@ -8054,7 +8055,7 @@ def cmd_gbrain_refresh_canary(conn: sqlite3.Connection, args: argparse.Namespace
                 'refresh_payload': refresh_payload,
             }
             rollback_payload['new_record_ref'] = new_ref or None
-            after_result = 'applied'
+            after_result = 'applied' if refreshed else 'noop'
         except Exception as e:
             conn.rollback()
             blocked_reasons.append(str(e))

--- a/openclaw_mem/cli.py
+++ b/openclaw_mem/cli.py
@@ -2162,6 +2162,8 @@ def _gbrain_sidecar_prior_packet_attempts(run_dir: Path, *, packet_sha256: str) 
             continue
         if str(payload.get('packet_sha256') or '') != packet_sha256:
             continue
+        if bool(payload.get('dry_run')):
+            continue
         total += 1
     return total
 
@@ -7272,6 +7274,18 @@ def _pack_gbrain_consult_optional(args: argparse.Namespace, query: str) -> Optio
     )
 
 
+def _pack_gbrain_bundle_text(payload: Dict[str, Any], *, bundle_text: str, gbrain_consult: Optional[Dict[str, Any]]) -> None:
+    if gbrain_consult is None:
+        return
+    gbrain_bundle = str(gbrain_consult.get("bundle_text") or "").strip()
+    if not gbrain_bundle:
+        return
+    base_bundle = str(payload.get("bundle_text_with_graph") or bundle_text).strip()
+    joined_parts = [part for part in [base_bundle, gbrain_bundle] if part]
+    if joined_parts:
+        payload["bundle_text_with_gbrain"] = "\n".join(joined_parts).strip() + "\n"
+
+
 def cmd_pack(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
     """Build a compact, cited L1-style bundle from hybrid retrieval."""
     query = (args.query or "").strip()
@@ -7588,12 +7602,6 @@ def cmd_pack(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
     gbrain_consult = _pack_gbrain_consult_optional(args, query)
     if gbrain_consult is not None:
         payload["gbrain"] = gbrain_consult
-        gbrain_bundle = str(gbrain_consult.get("bundle_text") or "").strip()
-        if gbrain_bundle:
-            base_bundle = str(payload.get("bundle_text_with_graph") or bundle_text).strip()
-            joined_parts = [part for part in [base_bundle, gbrain_bundle] if part]
-            if joined_parts:
-                payload["bundle_text_with_gbrain"] = "\n".join(joined_parts).strip() + "\n"
 
     if compaction_selected:
         compaction_policy_hints = _pack_compaction_policy_hints(compaction_selected)
@@ -7675,6 +7683,8 @@ def cmd_pack(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
             if max_chars and len(combined) > max_chars:
                 combined = combined[:max_chars].rstrip() + "\n"
             payload["bundle_text_with_graph"] = combined
+
+    _pack_gbrain_bundle_text(payload, bundle_text=bundle_text, gbrain_consult=gbrain_consult)
 
     policy_surface = _pack_compose_policy_surface(
         selected_items=selected_items,
@@ -7850,6 +7860,8 @@ def cmd_gbrain_jobs_smoke(_conn: sqlite3.Connection, args: argparse.Namespace) -
 def cmd_gbrain_jobs_submit(_conn: sqlite3.Connection, args: argparse.Namespace) -> None:
     try:
         params, _, _ = _parse_optional_json_arg(getattr(args, "params_json", None), getattr(args, "params_file", None), "params")
+        if params is not None and not isinstance(params, dict):
+            raise ValueError('params must be a JSON object')
         payload = gbrain_sidecar.submit_job(
             name=str(getattr(args, "name", "") or ""),
             data=dict(params or {}),
@@ -7946,7 +7958,8 @@ def cmd_gbrain_refresh_canary(conn: sqlite3.Connection, args: argparse.Namespace
         blocked_reasons.append('no_approved_refresh_candidates')
     if len(approved_items) > 1:
         blocked_reasons.append('max_candidates_per_run_exceeded')
-    if _gbrain_sidecar_prior_packet_attempts(run_root, packet_sha256=packet_sha256) >= 1:
+    prior_apply_attempts = _gbrain_sidecar_prior_packet_attempts(run_root, packet_sha256=packet_sha256)
+    if prior_apply_attempts >= 1:
         blocked_reasons.append('max_retries_per_packet_exceeded')
     if _gbrain_sidecar_recent_refresh_count(run_root, since_ts=datetime.now(timezone.utc) - timedelta(hours=24)) >= max_refresh_writes_per_24h:
         blocked_reasons.append('max_refresh_writes_per_24h_exceeded')
@@ -7998,6 +8011,7 @@ def cmd_gbrain_refresh_canary(conn: sqlite3.Connection, args: argparse.Namespace
             'max_retries_per_packet': 1,
             'supported_action_classes': ['refresh_card'],
         },
+        'prior_apply_attempts': prior_apply_attempts,
         'before_snapshot': before_snapshot,
         'blocked_reasons': blocked_reasons,
         'policy': {
@@ -8019,7 +8033,7 @@ def cmd_gbrain_refresh_canary(conn: sqlite3.Connection, args: argparse.Namespace
         'restore_hint': 'restore source card detail_json from before_snapshot and retire any new refresh card recorded in after payload',
     }
 
-    after_result = 'dry_run' if dry_run else 'applied'
+    after_result = 'dry_run'
     refresh_payload = None
     after_snapshot = None
     if blocked_reasons:
@@ -8040,6 +8054,7 @@ def cmd_gbrain_refresh_canary(conn: sqlite3.Connection, args: argparse.Namespace
                 'refresh_payload': refresh_payload,
             }
             rollback_payload['new_record_ref'] = new_ref or None
+            after_result = 'applied'
         except Exception as e:
             conn.rollback()
             blocked_reasons.append(str(e))

--- a/openclaw_mem/gbrain_sidecar.py
+++ b/openclaw_mem/gbrain_sidecar.py
@@ -15,6 +15,7 @@ DEFAULT_CONSULT_TIMEOUT_MS = 1500
 DEFAULT_JOBS_TIMEOUT_MS = 5000
 DEFAULT_CONSULT_LIMIT = 4
 PHASE2_ALLOWED_JOB_NAME = "embed"
+REFRESH_RECOMMEND_SCHEMA = "openclaw-mem.graph.synth.recommend.v0"
 
 
 @dataclass(frozen=True)
@@ -204,6 +205,79 @@ def trace_extension(consult_payload: Dict[str, Any]) -> Dict[str, Any]:
         "record_refs": [str(item.get("recordRef") or "") for item in items if str(item.get("recordRef") or "")],
         "slugs": [str(item.get("slug") or "") for item in items if str(item.get("slug") or "")],
         "source": "gbrain",
+    }
+
+
+def build_refresh_recommendation(
+    *,
+    record_ref: str,
+    consult_payload: Optional[Dict[str, Any]] = None,
+    candidate_id: Optional[str] = None,
+    max_evidence_refs: int = 4,
+) -> Dict[str, Any]:
+    target_ref = str(record_ref or "").strip()
+    if not target_ref:
+        raise ValueError("record_ref is required")
+
+    consult_items = list((consult_payload or {}).get("items") or [])
+    gbrain_refs = [
+        str(item.get("recordRef") or "").strip()
+        for item in consult_items
+        if isinstance(item, dict) and str(item.get("recordRef") or "").strip()
+    ]
+    evidence_refs = [target_ref] + gbrain_refs[: max(0, int(max_evidence_refs))]
+    query_text = str(((consult_payload or {}).get("query") or {}).get("text") or "").strip()
+    consult_ok = bool((consult_payload or {}).get("ok"))
+
+    reasons = ["gbrain_sidecar_signal"]
+    if query_text:
+        reasons.append(f"consult_query:{query_text}")
+    if not consult_ok and consult_payload is not None:
+        reasons.append("consult_fail_open")
+
+    args = ["graph", "synth", "refresh", target_ref]
+    item = {
+        "candidate_id": str(candidate_id or f"gbrain-refresh:{target_ref}"),
+        "action": "refresh_card",
+        "reasons": reasons,
+        "target": {
+            "recordRef": target_ref,
+        },
+        "suggestion": {
+            "args": args,
+            "command": "openclaw-mem " + " ".join(args),
+        },
+        "evidence_refs": evidence_refs,
+        "evidence": {
+            "source": "gbrain_sidecar",
+            "consult_ok": consult_ok,
+            "consult_result_count": int((consult_payload or {}).get("result_count") or 0),
+            "consult_query": query_text or None,
+        },
+        "auto_apply_eligible": False,
+        "safe_for_auto_apply": False,
+        "risk_level": "low",
+        "risk_reasons": [],
+    }
+    return {
+        "kind": REFRESH_RECOMMEND_SCHEMA,
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "counts": {
+            "refreshSynthesis": 1,
+            "compileSynthesis": 0,
+            "noAction": 0,
+            "items": 1,
+            "synthesisCards": 1,
+            "candidateCardSuggestions": 0,
+        },
+        "items": [item],
+        "source": "gbrain_sidecar",
+        "consult": {
+            "ok": consult_ok,
+            "query": query_text or None,
+            "result_count": int((consult_payload or {}).get("result_count") or 0),
+            "record_refs": gbrain_refs[: max(0, int(max_evidence_refs))],
+        },
     }
 
 

--- a/openclaw_mem/gbrain_sidecar.py
+++ b/openclaw_mem/gbrain_sidecar.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+CONSULT_SCHEMA = "openclaw-mem.gbrain.consult.v0"
+JOBS_SCHEMA_PREFIX = "openclaw-mem.gbrain.jobs"
+DEFAULT_GBRAIN_BIN = "gbrain"
+DEFAULT_CONSULT_TIMEOUT_MS = 1500
+DEFAULT_JOBS_TIMEOUT_MS = 5000
+DEFAULT_CONSULT_LIMIT = 4
+PHASE2_ALLOWED_JOB_NAME = "embed"
+
+
+@dataclass(frozen=True)
+class GBrainCallResult:
+    ok: bool
+    command: List[str]
+    returncode: int
+    stdout: str
+    stderr: str
+    duration_ms: int
+    error: Optional[str] = None
+    payload: Optional[Any] = None
+
+
+def _truncate(text: str, limit: int = 240) -> str:
+    value = str(text or "").strip()
+    if len(value) <= limit:
+        return value
+    return value[:limit].rstrip() + "…"
+
+
+def _run_gbrain_call(
+    tool_name: str,
+    payload: Dict[str, Any],
+    *,
+    gbrain_bin: str = DEFAULT_GBRAIN_BIN,
+    timeout_ms: int = DEFAULT_JOBS_TIMEOUT_MS,
+) -> GBrainCallResult:
+    command = [gbrain_bin, "call", tool_name, json.dumps(payload, ensure_ascii=False)]
+    started = time.perf_counter()
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=max(0.1, timeout_ms / 1000.0),
+            check=False,
+        )
+    except FileNotFoundError:
+        return GBrainCallResult(
+            ok=False,
+            command=command,
+            returncode=127,
+            stdout="",
+            stderr="",
+            duration_ms=int((time.perf_counter() - started) * 1000),
+            error=f"gbrain binary not found: {gbrain_bin}",
+        )
+    except subprocess.TimeoutExpired as e:
+        return GBrainCallResult(
+            ok=False,
+            command=command,
+            returncode=124,
+            stdout=e.stdout or "",
+            stderr=e.stderr or "",
+            duration_ms=int((time.perf_counter() - started) * 1000),
+            error=f"gbrain call timed out after {timeout_ms}ms",
+        )
+
+    duration_ms = int((time.perf_counter() - started) * 1000)
+    stdout = completed.stdout or ""
+    stderr = completed.stderr or ""
+
+    if completed.returncode != 0:
+        return GBrainCallResult(
+            ok=False,
+            command=command,
+            returncode=int(completed.returncode),
+            stdout=stdout,
+            stderr=stderr,
+            duration_ms=duration_ms,
+            error=_truncate(stderr or stdout or f"gbrain call {tool_name} failed"),
+        )
+
+    try:
+        parsed = json.loads(stdout or "null")
+    except Exception as e:
+        return GBrainCallResult(
+            ok=False,
+            command=command,
+            returncode=int(completed.returncode),
+            stdout=stdout,
+            stderr=stderr,
+            duration_ms=duration_ms,
+            error=f"invalid gbrain JSON output: {e}",
+        )
+
+    return GBrainCallResult(
+        ok=True,
+        command=command,
+        returncode=int(completed.returncode),
+        stdout=stdout,
+        stderr=stderr,
+        duration_ms=duration_ms,
+        payload=parsed,
+    )
+
+
+def gbrain_binary_ready(gbrain_bin: str = DEFAULT_GBRAIN_BIN) -> bool:
+    return bool(shutil.which(gbrain_bin))
+
+
+def consult(
+    query: str,
+    *,
+    limit: int = DEFAULT_CONSULT_LIMIT,
+    timeout_ms: int = DEFAULT_CONSULT_TIMEOUT_MS,
+    gbrain_bin: str = DEFAULT_GBRAIN_BIN,
+    expand: bool = False,
+) -> Dict[str, Any]:
+    result = _run_gbrain_call(
+        "query",
+        {
+            "query": str(query or "").strip(),
+            "limit": max(1, int(limit)),
+            "expand": bool(expand),
+        },
+        gbrain_bin=gbrain_bin,
+        timeout_ms=timeout_ms,
+    )
+
+    out: Dict[str, Any] = {
+        "schema": CONSULT_SCHEMA,
+        "source": "gbrain",
+        "query": {"text": str(query or "").strip()},
+        "config": {
+            "gbrain_bin": gbrain_bin,
+            "limit": max(1, int(limit)),
+            "timeout_ms": max(1, int(timeout_ms)),
+            "expand": bool(expand),
+        },
+        "ok": bool(result.ok),
+        "fail_open": not bool(result.ok),
+        "timing": {"duration_ms": int(result.duration_ms)},
+        "command": result.command,
+        "items": [],
+        "result_count": 0,
+        "error": result.error,
+    }
+
+    if not result.ok:
+        return out
+
+    payload = result.payload
+    rows = payload if isinstance(payload, list) else []
+    items: List[Dict[str, Any]] = []
+    for idx, row in enumerate(rows[: max(1, int(limit))], start=1):
+        if not isinstance(row, dict):
+            continue
+        slug = str(row.get("slug") or row.get("id") or f"hit-{idx}")
+        score = row.get("score")
+        try:
+            score_value = round(float(score), 4)
+        except Exception:
+            score_value = None
+        text = _truncate(str(row.get("chunk_text") or row.get("compiled_truth") or row.get("title") or ""), 280)
+        record_ref = f"gbrain:{slug}"
+        items.append(
+            {
+                "rank": idx,
+                "recordRef": record_ref,
+                "slug": slug,
+                "title": row.get("title"),
+                "score": score_value,
+                "text": text,
+                "stale": bool(row.get("stale", False)),
+                "citations": {"recordRef": record_ref, "slug": slug},
+            }
+        )
+
+    out["items"] = items
+    out["result_count"] = len(items)
+    out["bundle_text"] = "\n".join(f"- [{item['recordRef']}] {item['text']}" for item in items)
+    return out
+
+
+def trace_extension(consult_payload: Dict[str, Any]) -> Dict[str, Any]:
+    items = list((consult_payload or {}).get("items") or [])
+    return {
+        "enabled": True,
+        "ok": bool((consult_payload or {}).get("ok")),
+        "fail_open": bool((consult_payload or {}).get("fail_open")),
+        "error": (consult_payload or {}).get("error"),
+        "result_count": int((consult_payload or {}).get("result_count") or 0),
+        "timing": dict((consult_payload or {}).get("timing") or {}),
+        "command": list((consult_payload or {}).get("command") or []),
+        "record_refs": [str(item.get("recordRef") or "") for item in items if str(item.get("recordRef") or "")],
+        "slugs": [str(item.get("slug") or "") for item in items if str(item.get("slug") or "")],
+        "source": "gbrain",
+    }
+
+
+def submit_job(
+    *,
+    name: str,
+    data: Optional[Dict[str, Any]] = None,
+    queue: str = "default",
+    priority: int = 0,
+    max_attempts: int = 3,
+    delay: Optional[int] = None,
+    gbrain_bin: str = DEFAULT_GBRAIN_BIN,
+    timeout_ms: int = DEFAULT_JOBS_TIMEOUT_MS,
+) -> Dict[str, Any]:
+    if str(name or "").strip() != PHASE2_ALLOWED_JOB_NAME:
+        raise ValueError(f"phase-2 job lane is bounded to '{PHASE2_ALLOWED_JOB_NAME}'")
+
+    return _jobs_result(
+        action="submit",
+        call_result=_run_gbrain_call(
+            "submit_job",
+            {
+                "name": PHASE2_ALLOWED_JOB_NAME,
+                "data": dict(data or {}),
+                "queue": str(queue or "default"),
+                "priority": int(priority),
+                "max_attempts": int(max_attempts),
+                **({"delay": int(delay)} if delay is not None else {}),
+            },
+            gbrain_bin=gbrain_bin,
+            timeout_ms=timeout_ms,
+        ),
+        timeout_ms=timeout_ms,
+        gbrain_bin=gbrain_bin,
+    )
+
+
+def list_jobs(
+    *,
+    status: Optional[str] = None,
+    queue: Optional[str] = None,
+    limit: int = 20,
+    name: str = PHASE2_ALLOWED_JOB_NAME,
+    gbrain_bin: str = DEFAULT_GBRAIN_BIN,
+    timeout_ms: int = DEFAULT_JOBS_TIMEOUT_MS,
+) -> Dict[str, Any]:
+    if str(name or PHASE2_ALLOWED_JOB_NAME).strip() != PHASE2_ALLOWED_JOB_NAME:
+        raise ValueError(f"phase-2 job lane is bounded to '{PHASE2_ALLOWED_JOB_NAME}'")
+
+    return _jobs_result(
+        action="list",
+        call_result=_run_gbrain_call(
+            "list_jobs",
+            {
+                **({"status": str(status)} if status else {}),
+                **({"queue": str(queue)} if queue else {}),
+                "name": str(name or PHASE2_ALLOWED_JOB_NAME),
+                "limit": max(1, int(limit)),
+            },
+            gbrain_bin=gbrain_bin,
+            timeout_ms=timeout_ms,
+        ),
+        timeout_ms=timeout_ms,
+        gbrain_bin=gbrain_bin,
+    )
+
+
+def retry_job(
+    job_id: int,
+    *,
+    gbrain_bin: str = DEFAULT_GBRAIN_BIN,
+    timeout_ms: int = DEFAULT_JOBS_TIMEOUT_MS,
+) -> Dict[str, Any]:
+    check = _run_gbrain_call(
+        "get_job",
+        {"id": int(job_id)},
+        gbrain_bin=gbrain_bin,
+        timeout_ms=timeout_ms,
+    )
+    if not check.ok:
+        raise ValueError(check.error or f"unable to verify job {job_id} before retry")
+    payload = check.payload if isinstance(check.payload, dict) else {}
+    if str(payload.get("name") or "").strip() != PHASE2_ALLOWED_JOB_NAME:
+        raise ValueError(f"job {job_id} is not in the '{PHASE2_ALLOWED_JOB_NAME}' family")
+
+    return _jobs_result(
+        action="retry",
+        call_result=_run_gbrain_call(
+            "retry_job",
+            {"id": int(job_id)},
+            gbrain_bin=gbrain_bin,
+            timeout_ms=timeout_ms,
+        ),
+        timeout_ms=timeout_ms,
+        gbrain_bin=gbrain_bin,
+    )
+
+
+def smoke(
+    *,
+    gbrain_bin: str = DEFAULT_GBRAIN_BIN,
+    timeout_ms: int = DEFAULT_JOBS_TIMEOUT_MS,
+) -> Dict[str, Any]:
+    command = [gbrain_bin, "jobs", "smoke"]
+    started = time.perf_counter()
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=max(0.1, timeout_ms / 1000.0),
+            check=False,
+        )
+        error = None
+    except FileNotFoundError:
+        completed = None
+        error = f"gbrain binary not found: {gbrain_bin}"
+        returncode = 127
+        stdout = ""
+        stderr = ""
+    except subprocess.TimeoutExpired as e:
+        completed = None
+        error = f"gbrain jobs smoke timed out after {timeout_ms}ms"
+        returncode = 124
+        stdout = e.stdout or ""
+        stderr = e.stderr or ""
+
+    duration_ms = int((time.perf_counter() - started) * 1000)
+    if completed is not None:
+        returncode = int(completed.returncode)
+        stdout = completed.stdout or ""
+        stderr = completed.stderr or ""
+        if returncode != 0 and error is None:
+            error = _truncate(stderr or stdout or "gbrain jobs smoke failed")
+
+    return {
+        "kind": f"{JOBS_SCHEMA_PREFIX}.smoke.v0",
+        "ok": error is None and returncode == 0,
+        "phase2_allowed_job": PHASE2_ALLOWED_JOB_NAME,
+        "gbrain_bin": gbrain_bin,
+        "timeout_ms": int(timeout_ms),
+        "duration_ms": duration_ms,
+        "command": command,
+        "returncode": returncode,
+        "stdout": stdout,
+        "stderr": stderr,
+        "error": error,
+    }
+
+
+def _jobs_result(*, action: str, call_result: GBrainCallResult, timeout_ms: int, gbrain_bin: str) -> Dict[str, Any]:
+    payload = call_result.payload
+    return {
+        "kind": f"{JOBS_SCHEMA_PREFIX}.{action}.v0",
+        "ok": bool(call_result.ok),
+        "phase2_allowed_job": PHASE2_ALLOWED_JOB_NAME,
+        "gbrain_bin": gbrain_bin,
+        "timeout_ms": int(timeout_ms),
+        "duration_ms": int(call_result.duration_ms),
+        "command": list(call_result.command),
+        "returncode": int(call_result.returncode),
+        "result": payload,
+        "error": call_result.error,
+    }

--- a/tests/test_gbrain_sidecar.py
+++ b/tests/test_gbrain_sidecar.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from openclaw_mem import gbrain_sidecar
-from openclaw_mem.cli import _connect, _insert_observation, build_parser
+from openclaw_mem.cli import _connect, _insert_observation, _pack_gbrain_bundle_text, build_parser
 
 
 class TestGBrainSidecarModule(unittest.TestCase):
@@ -85,6 +85,15 @@ class TestGBrainSidecarModule(unittest.TestCase):
 
 
 class TestGBrainSidecarCLI(unittest.TestCase):
+    def test_pack_gbrain_bundle_prefers_graph_bundle_when_present(self):
+        payload = {"bundle_text_with_graph": "graph bundle\n"}
+        _pack_gbrain_bundle_text(
+            payload,
+            bundle_text="plain bundle\n",
+            gbrain_consult={"bundle_text": "gbrain bundle"},
+        )
+        self.assertEqual(payload.get("bundle_text_with_gbrain"), "graph bundle\ngbrain bundle\n")
+
     def test_pack_adds_gbrain_payload_and_trace_extension(self):
         conn = _connect(":memory:")
         args = build_parser().parse_args(
@@ -183,6 +192,27 @@ class TestGBrainSidecarCLI(unittest.TestCase):
         self.assertTrue(out["ok"])
         self.assertEqual(out["phase2_allowed_job"], "embed")
         self.assertEqual((out.get("result") or {}).get("id"), 7)
+
+    def test_jobs_submit_rejects_non_object_params(self):
+        conn = _connect(":memory:")
+        args = build_parser().parse_args(
+            [
+                "gbrain-sidecar",
+                "jobs-submit",
+                "--name",
+                "embed",
+                "--params-json",
+                "[1,2]",
+            ]
+        )
+        buf = io.StringIO()
+        with redirect_stdout(buf), self.assertRaises(SystemExit) as exc:
+            args.func(conn, args)
+        out = json.loads(buf.getvalue())
+        conn.close()
+
+        self.assertEqual(exc.exception.code, 2)
+        self.assertEqual(out["error"], "params must be a JSON object")
 
     def test_recommend_refresh_emits_graph_recommend_packet(self):
         conn = _connect(":memory:")
@@ -285,6 +315,83 @@ class TestGBrainSidecarCLI(unittest.TestCase):
         self.assertEqual(out["result"], "applied")
         self.assertEqual(out["applied_count"], 1)
         self.assertEqual(old_detail["graph_synthesis"]["status"], "superseded")
+
+    def test_refresh_canary_dry_run_does_not_burn_retry_budget(self):
+        conn = _connect(":memory:")
+        _insert_observation(conn, {"kind": "note", "summary": "alpha source", "tool_name": "memory_store", "detail": {}})
+        compile_args = build_parser().parse_args(
+            [
+                "graph",
+                "--json",
+                "synth",
+                "compile",
+                "--query",
+                "alpha",
+                "--title",
+                "Alpha synthesis",
+                "--summary",
+                "Alpha synthesis",
+            ]
+        )
+        compile_buf = io.StringIO()
+        with redirect_stdout(compile_buf):
+            compile_args.func(conn, compile_args)
+        card_ref = json.loads(compile_buf.getvalue())["cardRef"]
+
+        with tempfile.TemporaryDirectory() as td:
+            packet_path = Path(td) / "governor.json"
+            packet_path.write_text(
+                json.dumps(
+                    {
+                        "kind": "openclaw-mem.optimize.governor-review.v0",
+                        "items": [
+                            {
+                                "candidate_id": "gbrain-refresh:obs:2",
+                                "recommended_action": "refresh_card",
+                                "decision": "approved_for_apply",
+                                "apply_lane": "graph.synth.refresh",
+                                "target": {"recordRef": card_ref},
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            dry_args = build_parser().parse_args(
+                [
+                    "gbrain-sidecar",
+                    "refresh-canary",
+                    "--from-file",
+                    str(packet_path),
+                    "--run-dir",
+                    td,
+                ]
+            )
+            apply_args = build_parser().parse_args(
+                [
+                    "gbrain-sidecar",
+                    "refresh-canary",
+                    "--from-file",
+                    str(packet_path),
+                    "--apply",
+                    "--run-dir",
+                    td,
+                ]
+            )
+            dry_buf = io.StringIO()
+            with redirect_stdout(dry_buf):
+                dry_args.func(conn, dry_args)
+            dry_out = json.loads(dry_buf.getvalue())
+
+            apply_buf = io.StringIO()
+            with redirect_stdout(apply_buf):
+                apply_args.func(conn, apply_args)
+            apply_out = json.loads(apply_buf.getvalue())
+        conn.close()
+
+        self.assertEqual(dry_out["result"], "dry_run")
+        self.assertEqual(apply_out["result"], "applied")
+        self.assertEqual(apply_out["applied_count"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_gbrain_sidecar.py
+++ b/tests/test_gbrain_sidecar.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import io
 import json
 import subprocess
+import tempfile
 import unittest
 from contextlib import redirect_stdout
+from pathlib import Path
 from unittest.mock import patch
 
 from openclaw_mem import gbrain_sidecar
-from openclaw_mem.cli import _connect, build_parser
+from openclaw_mem.cli import _connect, _insert_observation, build_parser
 
 
 class TestGBrainSidecarModule(unittest.TestCase):
@@ -64,6 +66,22 @@ class TestGBrainSidecarModule(unittest.TestCase):
         ):
             with self.assertRaises(ValueError):
                 gbrain_sidecar.retry_job(7)
+
+    def test_build_refresh_recommendation_uses_consult_refs(self):
+        payload = gbrain_sidecar.build_refresh_recommendation(
+            record_ref="obs:123",
+            consult_payload={
+                "schema": gbrain_sidecar.CONSULT_SCHEMA,
+                "ok": True,
+                "query": {"text": "alpha"},
+                "result_count": 1,
+                "items": [{"recordRef": "gbrain:people/alice"}],
+            },
+        )
+        self.assertEqual(payload["kind"], "openclaw-mem.graph.synth.recommend.v0")
+        self.assertEqual(payload["items"][0]["action"], "refresh_card")
+        self.assertEqual(payload["items"][0]["target"]["recordRef"], "obs:123")
+        self.assertIn("gbrain:people/alice", payload["items"][0]["evidence_refs"])
 
 
 class TestGBrainSidecarCLI(unittest.TestCase):
@@ -165,6 +183,108 @@ class TestGBrainSidecarCLI(unittest.TestCase):
         self.assertTrue(out["ok"])
         self.assertEqual(out["phase2_allowed_job"], "embed")
         self.assertEqual((out.get("result") or {}).get("id"), 7)
+
+    def test_recommend_refresh_emits_graph_recommend_packet(self):
+        conn = _connect(":memory:")
+        with tempfile.TemporaryDirectory() as td:
+            consult_path = Path(td) / "consult.json"
+            consult_path.write_text(
+                json.dumps(
+                    {
+                        "schema": gbrain_sidecar.CONSULT_SCHEMA,
+                        "ok": True,
+                        "query": {"text": "alpha"},
+                        "result_count": 1,
+                        "items": [{"recordRef": "gbrain:people/alice"}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            args = build_parser().parse_args(
+                [
+                    "gbrain-sidecar",
+                    "recommend-refresh",
+                    "--record-ref",
+                    "obs:123",
+                    "--consult-file",
+                    str(consult_path),
+                ]
+            )
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                args.func(conn, args)
+            out = json.loads(buf.getvalue())
+        conn.close()
+
+        self.assertEqual(out["kind"], "openclaw-mem.graph.synth.recommend.v0")
+        self.assertEqual(out["items"][0]["target"]["recordRef"], "obs:123")
+        self.assertIn("gbrain:people/alice", out["items"][0]["evidence_refs"])
+
+    def test_refresh_canary_apply_runs_bounded_refresh(self):
+        conn = _connect(":memory:")
+        _insert_observation(conn, {"kind": "note", "summary": "alpha source", "tool_name": "memory_store", "detail": {}})
+        compile_args = build_parser().parse_args(
+            [
+                "graph",
+                "--json",
+                "synth",
+                "compile",
+                "--query",
+                "alpha",
+                "--title",
+                "Alpha synthesis",
+                "--summary",
+                "Alpha synthesis",
+            ]
+        )
+        compile_buf = io.StringIO()
+        with redirect_stdout(compile_buf):
+            compile_args.func(conn, compile_args)
+        card_ref = json.loads(compile_buf.getvalue())["cardRef"]
+        _insert_observation(conn, {"kind": "note", "summary": "alpha newer source", "tool_name": "memory_store", "detail": {}})
+
+        with tempfile.TemporaryDirectory() as td:
+            packet_path = Path(td) / "governor.json"
+            packet_path.write_text(
+                json.dumps(
+                    {
+                        "kind": "openclaw-mem.optimize.governor-review.v0",
+                        "items": [
+                            {
+                                "candidate_id": "gbrain-refresh:obs:2",
+                                "recommended_action": "refresh_card",
+                                "decision": "approved_for_apply",
+                                "apply_lane": "graph.synth.refresh",
+                                "target": {"recordRef": card_ref},
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            args = build_parser().parse_args(
+                [
+                    "gbrain-sidecar",
+                    "refresh-canary",
+                    "--from-file",
+                    str(packet_path),
+                    "--apply",
+                    "--run-dir",
+                    td,
+                ]
+            )
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                args.func(conn, args)
+            out = json.loads(buf.getvalue())
+        old_id = int(card_ref.split(":", 1)[1])
+        old_row = conn.execute("SELECT detail_json FROM observations WHERE id = ?", (old_id,)).fetchone()
+        old_detail = json.loads(old_row["detail_json"] or "{}")
+        conn.close()
+
+        self.assertEqual(out["result"], "applied")
+        self.assertEqual(out["applied_count"], 1)
+        self.assertEqual(old_detail["graph_synthesis"]["status"], "superseded")
 
 
 if __name__ == "__main__":

--- a/tests/test_gbrain_sidecar.py
+++ b/tests/test_gbrain_sidecar.py
@@ -337,6 +337,7 @@ class TestGBrainSidecarCLI(unittest.TestCase):
         with redirect_stdout(compile_buf):
             compile_args.func(conn, compile_args)
         card_ref = json.loads(compile_buf.getvalue())["cardRef"]
+        _insert_observation(conn, {"kind": "note", "summary": "alpha newer source", "tool_name": "memory_store", "detail": {}})
 
         with tempfile.TemporaryDirectory() as td:
             packet_path = Path(td) / "governor.json"
@@ -392,6 +393,68 @@ class TestGBrainSidecarCLI(unittest.TestCase):
         self.assertEqual(dry_out["result"], "dry_run")
         self.assertEqual(apply_out["result"], "applied")
         self.assertEqual(apply_out["applied_count"], 1)
+
+    def test_refresh_canary_noop_does_not_claim_apply(self):
+        conn = _connect(":memory:")
+        _insert_observation(conn, {"kind": "note", "summary": "alpha source", "tool_name": "memory_store", "detail": {}})
+        compile_args = build_parser().parse_args(
+            [
+                "graph",
+                "--json",
+                "synth",
+                "compile",
+                "--query",
+                "alpha",
+                "--title",
+                "Alpha synthesis",
+                "--summary",
+                "Alpha synthesis",
+            ]
+        )
+        compile_buf = io.StringIO()
+        with redirect_stdout(compile_buf):
+            compile_args.func(conn, compile_args)
+        card_ref = json.loads(compile_buf.getvalue())["cardRef"]
+
+        with tempfile.TemporaryDirectory() as td:
+            packet_path = Path(td) / "governor.json"
+            packet_path.write_text(
+                json.dumps(
+                    {
+                        "kind": "openclaw-mem.optimize.governor-review.v0",
+                        "items": [
+                            {
+                                "candidate_id": "gbrain-refresh:obs:1",
+                                "recommended_action": "refresh_card",
+                                "decision": "approved_for_apply",
+                                "apply_lane": "graph.synth.refresh",
+                                "target": {"recordRef": card_ref},
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            args = build_parser().parse_args(
+                [
+                    "gbrain-sidecar",
+                    "refresh-canary",
+                    "--from-file",
+                    str(packet_path),
+                    "--apply",
+                    "--run-dir",
+                    td,
+                ]
+            )
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                args.func(conn, args)
+            out = json.loads(buf.getvalue())
+        conn.close()
+
+        self.assertEqual(out["result"], "noop")
+        self.assertEqual(out["applied_count"], 0)
+        self.assertEqual(((out.get("policy") or {}).get("writes_performed")), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_gbrain_sidecar.py
+++ b/tests/test_gbrain_sidecar.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from openclaw_mem import gbrain_sidecar
+from openclaw_mem.cli import _connect, build_parser
+
+
+class TestGBrainSidecarModule(unittest.TestCase):
+    def test_consult_normalizes_results(self):
+        completed = subprocess.CompletedProcess(
+            args=["gbrain"],
+            returncode=0,
+            stdout=json.dumps([
+                {"slug": "people/alice", "score": 0.93, "chunk_text": "Alice knows the rollout state."},
+                {"slug": "projects/beta", "score": 0.52, "chunk_text": "Beta project timeline."},
+            ]),
+            stderr="",
+        )
+        with patch("openclaw_mem.gbrain_sidecar.subprocess.run", return_value=completed):
+            out = gbrain_sidecar.consult("rollout state", limit=2, gbrain_bin="gbrain")
+
+        self.assertTrue(out["ok"])
+        self.assertFalse(out["fail_open"])
+        self.assertEqual(out["result_count"], 2)
+        self.assertEqual(out["items"][0]["recordRef"], "gbrain:people/alice")
+        self.assertIn("[gbrain:people/alice]", out["bundle_text"])
+
+    def test_consult_fail_open_when_binary_missing(self):
+        with patch("openclaw_mem.gbrain_sidecar.subprocess.run", side_effect=FileNotFoundError()):
+            out = gbrain_sidecar.consult("rollout state", gbrain_bin="missing-gbrain")
+
+        self.assertFalse(out["ok"])
+        self.assertTrue(out["fail_open"])
+        self.assertIn("missing-gbrain", out["error"])
+
+    def test_submit_job_is_bounded_to_embed_lane(self):
+        with self.assertRaises(ValueError):
+            gbrain_sidecar.submit_job(name="sync")
+
+    def test_list_jobs_is_bounded_to_embed_lane(self):
+        with self.assertRaises(ValueError):
+            gbrain_sidecar.list_jobs(name="sync")
+
+    def test_retry_job_prechecks_family(self):
+        with patch(
+            "openclaw_mem.gbrain_sidecar._run_gbrain_call",
+            side_effect=[
+                gbrain_sidecar.GBrainCallResult(
+                    ok=True,
+                    command=["gbrain", "call", "get_job", "{}"],
+                    returncode=0,
+                    stdout="{}",
+                    stderr="",
+                    duration_ms=5,
+                    payload={"id": 7, "name": "sync"},
+                )
+            ],
+        ):
+            with self.assertRaises(ValueError):
+                gbrain_sidecar.retry_job(7)
+
+
+class TestGBrainSidecarCLI(unittest.TestCase):
+    def test_pack_adds_gbrain_payload_and_trace_extension(self):
+        conn = _connect(":memory:")
+        args = build_parser().parse_args(
+            [
+                "pack",
+                "--query",
+                "rollout state",
+                "--trace",
+                "--use-gbrain",
+                "on",
+            ]
+        )
+        pack_state = {
+            "fts_ids": set(),
+            "vec_ids": set(),
+            "vec_en_ids": set(),
+            "rrf_scores": {1: 0.8},
+            "obs_map": {1: {"id": 1, "kind": "fact", "summary": "local memory row", "lang": "en"}},
+            "ordered_ids": [1],
+            "candidate_limit": 12,
+        }
+        consult_payload = {
+            "schema": gbrain_sidecar.CONSULT_SCHEMA,
+            "source": "gbrain",
+            "query": {"text": "rollout state"},
+            "config": {"gbrain_bin": "gbrain", "limit": 4, "timeout_ms": 1500, "expand": False},
+            "ok": True,
+            "fail_open": False,
+            "timing": {"duration_ms": 12},
+            "command": ["gbrain", "call", "query", "{}"],
+            "items": [
+                {
+                    "rank": 1,
+                    "recordRef": "gbrain:people/alice",
+                    "slug": "people/alice",
+                    "title": None,
+                    "score": 0.91,
+                    "text": "Alice knows the rollout state.",
+                    "stale": False,
+                    "citations": {"recordRef": "gbrain:people/alice", "slug": "people/alice"},
+                }
+            ],
+            "result_count": 1,
+            "error": None,
+            "bundle_text": "- [gbrain:people/alice] Alice knows the rollout state.",
+        }
+
+        try:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                with patch("openclaw_mem.cli._hybrid_retrieve", return_value=pack_state), patch(
+                    "openclaw_mem.cli._hybrid_prefer_synthesis_cards",
+                    return_value=([1], {"preferredCardRefs": [], "coveredRawRefs": [], "coverageMap": {}}),
+                ), patch("openclaw_mem.cli._pack_gbrain_consult_optional", return_value=consult_payload):
+                    args.func(conn, args)
+            out = json.loads(buf.getvalue())
+        finally:
+            conn.close()
+
+        self.assertIn("gbrain", out)
+        self.assertIn("bundle_text_with_gbrain", out)
+        trace_gbrain = (((out.get("trace") or {}).get("extensions") or {}).get("gbrain") or {})
+        self.assertEqual(trace_gbrain.get("result_count"), 1)
+        self.assertEqual(trace_gbrain.get("record_refs"), ["gbrain:people/alice"])
+
+    def test_jobs_submit_normalizes_result(self):
+        conn = _connect(":memory:")
+        args = build_parser().parse_args(
+            [
+                "gbrain-sidecar",
+                "jobs-submit",
+                "--name",
+                "embed",
+                "--params-json",
+                '{"slug":"people/alice"}',
+            ]
+        )
+        with patch(
+            "openclaw_mem.gbrain_sidecar._run_gbrain_call",
+            return_value=gbrain_sidecar.GBrainCallResult(
+                ok=True,
+                command=["gbrain", "call", "submit_job", "{}"],
+                returncode=0,
+                stdout="{}",
+                stderr="",
+                duration_ms=15,
+                payload={"id": 7, "name": "embed", "status": "waiting"},
+            ),
+        ):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                args.func(conn, args)
+            out = json.loads(buf.getvalue())
+        conn.close()
+
+        self.assertTrue(out["ok"])
+        self.assertEqual(out["phase2_allowed_job"], "embed")
+        self.assertEqual((out.get("result") or {}).get("id"), 7)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an experimental gbrain side-car module for read-only consult and bounded phase-2 jobs bridging
- extend Pack with additive `gbrain` payloads, `bundle_text_with_gbrain`, and `trace.extensions.gbrain`
- add tests and experimental docs for the Phase 1/2 slice

## What shipped
- Phase 1: fail-open gbrain consult adapter for Pack
- Phase 2: bounded gbrain jobs bridge limited to the `embed` family
- boundary hardening from final review:
  - retry now pre-checks job family via `get_job`
  - list rejects non-`embed` family overrides
  - combined bundle text keeps local Pack text first, gbrain additive second

## Guardrails
- no direct gbrain -> Store write path
- no gbrain schema leak into `ContextPack` v1
- baseline Pack behavior stays unchanged when gbrain is unavailable
- topology unchanged

## Verification
- `python3 -m unittest tests.test_gbrain_sidecar tests.test_context_pack_golden tests.test_pack_trace_v1 tests.test_json_contracts -v`
- `19 tests OK`

## Review focus
- side-car boundary discipline
- fail-open behavior and additive payload shape
- phase-2 jobs bridge remaining truly bounded to `embed`
- trace/provenance shape and Pack contract stability
