### PR TITLE
feat: add self-improvement goal pilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.12] - 2026-05-12
+
+### Added
+
+- Added the read-only self-improvement surface validator via `openclaw-mem surface validate` for inventory/receipt contract checks with protected-surface and write-authority guardrails.
+- Added the read-only goal primitive status command via `openclaw-mem goal status` for normalizing controller/goal receipts without enabling auto-continuation.
+- Added public Advanced Labs documentation and an operator skill card for the self-improvement goal pilot.
+
+### Testing
+
+- Added regression coverage for surface inventory validation, protected/L3/L4 authority checks, goal status normalization, and invalid goal status handling.
+- Verified targeted tests, CLI smoke, MkDocs strict build, Claude public-facing review, and local editable install smoke for this slice.
+
 ## [1.9.11] - 2026-05-08
 
 ### Added

--- a/docs/2026-05-12_self-improvement-goal-pilot-receipt.md
+++ b/docs/2026-05-12_self-improvement-goal-pilot-receipt.md
@@ -1,0 +1,146 @@
+# Self-improvement goal pilot receipt — 2026-05-12
+
+## Summary
+
+Implemented the first OpenClaw Mem self-improvement consolidation slice:
+
+- shared read-only surface inventory / receipt validation substrate
+- read-only `goal status` command
+- public-facing Advanced Labs documentation
+- ops skill card
+- local install smoke
+
+No cron, gateway, plugin config, model routing, or external delivery topology changed.
+
+## Changed files
+
+- `openclaw_mem/self_improvement_surface.py`
+- `openclaw_mem/goal_primitive.py`
+- `openclaw_mem/cli.py`
+- `tests/test_self_improvement_surface.py`
+- `tests/test_goal_primitive.py`
+- `docs/self-improvement-goal-pilot.md`
+- `docs/specs/self-improvement-goal-pilot-blade-map-v0.md`
+- `skills/goal-primitive.ops.md`
+- `mkdocs.yml`
+
+## Verification
+
+### Unit tests
+
+Command:
+
+```bash
+uv run python -m pytest tests/test_self_improvement_surface.py tests/test_goal_primitive.py tests/test_active_line_context.py
+```
+
+Result:
+
+```text
+17 passed in 0.08s
+```
+
+### CLI smoke
+
+Commands exercised:
+
+```bash
+uv run python -m openclaw_mem surface validate \
+  --inventory .state/self-improvement-goal-pilot/smoke/surfaces.valid.json \
+  --receipt .state/self-improvement-goal-pilot/smoke/receipt.safe.json \
+  --out .state/self-improvement-goal-pilot/smoke/surface-valid.receipt.json \
+  --json
+
+uv run python -m openclaw_mem surface validate \
+  --inventory .state/self-improvement-goal-pilot/smoke/surfaces.valid.json \
+  --receipt .state/self-improvement-goal-pilot/smoke/receipt.blocked.json \
+  --json
+
+uv run python -m openclaw_mem goal status \
+  --file .state/self-improvement-goal-pilot/smoke/goal.active.json \
+  --out .state/self-improvement-goal-pilot/smoke/goal-status.receipt.json \
+  --json
+```
+
+Assertions:
+
+- safe surface validation returns `ok=true` and `writes_performed=false`
+- protected-surface blocked receipt returns `ok=false` and `protected_touched=true`
+- goal status returns `ok=true`, `writes_performed=false`, and `goal.active=true`
+- default `goal status` receipt does not leak the input file path through `source_ref`
+
+### Documentation build
+
+Command:
+
+```bash
+uv run --with mkdocs --with mkdocs-material mkdocs build --strict
+```
+
+Result: documentation built successfully.
+
+### Public-facing review
+
+Claude second-brain review was run twice before public push.
+
+First review verdict: hold for fixes.
+
+Must-fix items addressed:
+
+- removed default local path leak from `goal status` `source_ref`
+- replaced internal continuation owner example with neutral `operator`
+- removed undefined comparator jargon from public docs
+- tightened authority validation for non-empty `applied[]`, `writes_performed=true`, protected L3, and L4 surfaces
+- clarified CLI help text and public doc authority wording
+
+Second review verdict:
+
+```text
+clear to push — no must-fix blockers
+```
+
+Review artifacts are under `.state/self-improvement-goal-pilot/` in the working tree.
+
+### Local install smoke
+
+Command:
+
+```bash
+uv tool install --force --editable .
+```
+
+Result:
+
+```text
+Installed 3 executables: openclaw-mem, openclaw-mem-gateway, openclaw-mem-pack-capsule
+```
+
+Installed CLI smoke:
+
+```bash
+openclaw-mem goal status --file .state/self-improvement-goal-pilot/smoke/goal.active.json --json
+openclaw-mem surface validate --inventory .state/self-improvement-goal-pilot/smoke/surfaces.valid.json --receipt .state/self-improvement-goal-pilot/smoke/receipt.safe.json --json
+```
+
+Result: installed `openclaw-mem` smoke passed.
+
+## Counterfactual coverage
+
+- invalid inventory state fails validation
+- protected L3 surface rejects `stage` authority
+- protected L3 surface accepts sufficient `apply-local` authority
+- L4 surface requires `apply-publish`
+- non-empty `applied[]` requires at least `suggest`
+- `writes_performed=true` requires at least `apply-local`
+- unknown surface id warns rather than failing when policy context is absent
+- invalid goal status fails validation
+
+## Topology impact
+
+Unchanged.
+
+No cron, gateway, plugin config, model routing, or channel routing changes were made.
+
+## Rollback
+
+Revert the implementation commit or remove the listed files/CLI registrations. Local editable install can be restored by reinstalling from the previous `openclaw-mem` checkout or tag.

--- a/docs/self-improvement-goal-pilot.md
+++ b/docs/self-improvement-goal-pilot.md
@@ -1,0 +1,137 @@
+# Self-improvement consolidation: surface validation and goal status
+
+OpenClaw Mem's self-improvement work is split into deliberately small, reviewable pieces. This page documents the first read-only slice:
+
+1. a shared surface/receipt validation contract, and
+2. a goal status readback command.
+
+The slice is intentionally local-only and non-mutating. It is meant to make future memory, skill-curator, and goal-continuation work safer by establishing a common receipt and authority shape before any background loop is allowed to write durable state.
+
+## Why this exists
+
+Agents feel more useful when they can preserve unfinished work and improve reusable procedures. OpenClaw's product posture is that this self-improvement must be observable, feature-flagged, rollbackable, and gated by write authority.
+
+This pilot therefore starts with validation and status, not automation.
+
+## Surface inventory contract
+
+A surface inventory lists self-improvement-related components and their current authority level.
+
+Example:
+
+```json
+{
+  "surfaces": [
+    {
+      "surface_id": "goal.primitive",
+      "state": "lab",
+      "owner": "openclaw-mem",
+      "write_authority": "stage",
+      "risk_class": "L1",
+      "protected": false,
+      "rollback": null
+    },
+    {
+      "surface_id": "skills.operator-rule",
+      "state": "stable",
+      "owner": "operator",
+      "write_authority": "none",
+      "risk_class": "L3",
+      "protected": true,
+      "rollback": "manual review required"
+    }
+  ]
+}
+```
+
+Supported states:
+
+- `stable`
+- `lab`
+- `shadow`
+- `retired`
+
+Supported write authorities:
+
+- `none`
+- `suggest`
+- `stage`
+- `apply-local`
+- `apply-publish`
+
+Supported risk classes:
+
+- `L0` — read-only/report only
+- `L1` — staged local artifact, no live runtime effect
+- `L2` — local durable memory/skill addition
+- `L3` — edit/delete/retire existing load-bearing rule/skill/memory
+- `L4` — external publish, config/routing/cron/topology mutation
+
+Protected surfaces require at least `apply-local` authority, and L4/external surfaces require `apply-publish` authority with explicit approval.
+
+## Validate a surface inventory or receipt
+
+```bash
+openclaw-mem surface validate --inventory surfaces.json --json
+```
+
+Validate a receipt against an inventory:
+
+```bash
+openclaw-mem surface validate \
+  --inventory surfaces.json \
+  --receipt receipt.json \
+  --out validation-receipt.json \
+  --json
+```
+
+The command returns a validation receipt with `writes_performed=false`.
+
+## Goal status readback
+
+`goal status` normalizes a goal/controller receipt into a small, read-only status object.
+
+Example input:
+
+```json
+{
+  "goal": {
+    "goal_id": "self-improvement-pilot",
+    "objective": "Ship read-only goal status",
+    "status": "active",
+    "phase": "phase-1",
+    "next_gate": "run tests",
+    "continuation_owner": "operator",
+    "completion_verifier": "pytest"
+  }
+}
+```
+
+Run:
+
+```bash
+openclaw-mem goal status --file goal.json --json
+```
+
+Write a status receipt:
+
+```bash
+openclaw-mem goal status \
+  --file goal.json \
+  --out goal-status.receipt.json \
+  --json
+```
+
+The command is read-only except for the optional explicit `--out` file.
+
+## Relationship to context packing
+
+This pilot does not implement runtime continuation or compaction behavior. For compaction-safe injection, the intended future seam is an OpenClaw context engine. Prompt hooks can provide fallback context, but the durable goal/todo state should be owned by a context/packing layer rather than pasted into every turn unconditionally.
+
+## Non-goals
+
+- no automatic skill mutation
+- no live auto-continuation
+- no cron or gateway topology changes
+- no retirement of legacy memory surfaces
+- no external publishing without review and explicit approval

--- a/docs/specs/self-improvement-goal-pilot-blade-map-v0.md
+++ b/docs/specs/self-improvement-goal-pilot-blade-map-v0.md
@@ -1,0 +1,82 @@
+# Self-improvement consolidation goal pilot — blade map v0
+
+Date: 2026-05-12
+Status: implementation blade map
+
+## Goal
+
+Ship the first OpenClaw Mem consolidation slice from the self-improvement plan:
+
+1. Shared governance substrate for self-improvement surfaces.
+2. Read-only `goal status` pilot as the first low-blast-radius product slice.
+3. Public-facing docs and ops skill guidance.
+4. Local install/readback proof.
+
+## Non-goals
+
+- No live auto-continuation runtime.
+- No automatic skill mutation.
+- No public push before review.
+- No retirement of legacy memory surfaces.
+- No cron or OpenClaw gateway topology changes.
+
+## Inputs
+
+- Ledger report: `lyria-working-ledger/REPORTS/openclaw/2026-05-12_openclaw-self-improvement-consolidation-plan.md`
+- Existing openclaw-mem surfaces:
+  - `active-line pack`
+  - `self-curator`
+  - `steward review`
+  - `ingest-review source`
+
+## Outputs / artifacts
+
+- Python substrate module for surface inventory / receipt validation.
+- CLI commands:
+  - `openclaw-mem surface validate ...`
+  - `openclaw-mem goal status ...`
+- Unit tests for inventory/receipt validation and goal status.
+- Public-facing docs.
+- Ops skill card/update.
+- Review receipt from Claude second brain before public push.
+- WAL / ledger handoff.
+
+## Invariants
+
+- Commands are read-only unless writing an explicit `--out` receipt/report.
+- `writes_performed=false` for Phase -1 and `goal status` commands.
+- Protected surfaces cannot appear in `applied[]` without sufficient authority.
+- `registerContextEngine` remains the recommended compaction-safe seam; this slice does not implement runtime context-engine integration.
+- Existing CLI commands keep behavior.
+
+## Topology / config impact
+
+Unchanged. No cron, plugin config, gateway, or model-routing changes.
+
+## Verifier plan
+
+Dry-run / direct tests:
+
+- `python -m pytest tests/test_self_improvement_surface.py tests/test_goal_primitive.py tests/test_active_line_context.py`
+- `python -m openclaw_mem surface validate --inventory <fixture> --receipt <fixture> --json`
+- `python -m openclaw_mem goal status --file <fixture> --json --out <receipt>`
+
+Counterfactuals:
+
+- invalid inventory state fails validation
+- protected surface with unauthorized `applied[]` fails validation
+- malformed goal receipt fails with bounded error
+
+Live local install smoke:
+
+- `python -m pip install -e .`
+- `openclaw-mem goal status --file <fixture> --json`
+- `openclaw-mem surface validate --inventory <fixture> --receipt <fixture> --json`
+
+Human-readable report:
+
+- `docs/2026-05-12_self-improvement-goal-pilot-receipt.md`
+
+Rollback posture:
+
+- Revert this branch commit or remove the new module/tests/docs and CLI registrations.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
       - Privacy/export rules: privacy-export-rules.md
   - Advanced Labs:
       - Core vs Advanced Labs: core-vs-advanced-labs.md
+      - Self-improvement goal pilot: self-improvement-goal-pilot.md
       - Governed optimize assist: optimize-assist.md
       - Verbatim semantic lane: verbatim-semantic-lane.md
       - Dual-language memory strategy: dual-language-memory-strategy.md

--- a/openclaw_mem/__init__.py
+++ b/openclaw_mem/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "1.9.11"
+__version__ = "1.9.12"

--- a/openclaw_mem/cli.py
+++ b/openclaw_mem/cli.py
@@ -41,9 +41,11 @@ from openclaw_mem import active_line_context
 from openclaw_mem import context_pack_v1
 from openclaw_mem import ingestion_review
 from openclaw_mem import gbrain_sidecar
+from openclaw_mem import goal_primitive
 from openclaw_mem import pack_trace_v1
 from openclaw_mem import self_model_sidecar
 from openclaw_mem import self_curator
+from openclaw_mem import self_improvement_surface
 from openclaw_mem import steward_review
 from openclaw_mem import harness as harness_install
 from openclaw_mem import codex_install
@@ -10696,6 +10698,42 @@ def cmd_active_line_pack(conn: sqlite3.Connection, args: argparse.Namespace) -> 
         print(f"active_line goal_id={active['goal_id']} status={active['status']} writes_performed=false")
 
 
+def cmd_surface_validate(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    inventory = None
+    receipt = None
+    if getattr(args, "inventory", None):
+        inventory = self_improvement_surface.load_json_object(args.inventory)
+    if getattr(args, "receipt", None):
+        receipt = self_improvement_surface.load_json_object(args.receipt)
+    if inventory is None and receipt is None:
+        raise SystemExit("surface validate requires --inventory and/or --receipt")
+    payload = self_improvement_surface.validate_bundle(inventory=inventory, receipt=receipt)
+    if getattr(args, "out", None):
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if bool(getattr(args, "json", False)):
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(f"surface_validate ok={str(payload['ok']).lower()} writes_performed=false")
+
+
+def cmd_goal_status(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    receipt = goal_primitive.load_goal_receipt(args.file)
+    payload = goal_primitive.build_goal_status(
+        receipt,
+        source_ref=getattr(args, "source_ref", None),
+    )
+    if getattr(args, "out", None):
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if bool(getattr(args, "json", False)):
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(goal_primitive.render_goal_status(payload))
+
+
 def cmd_self_curator_plan(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
     mutations = json.loads(Path(args.mutations_file).read_text(encoding="utf-8"))
     if isinstance(mutations, dict) and "mutations" in mutations:
@@ -19806,6 +19844,24 @@ def build_parser() -> argparse.ArgumentParser:
     al.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Structured JSON output")
     al.set_defaults(func=cmd_active_line_pack)
 
+    sp = sub.add_parser("surface", help="Validate self-improvement surface inventory and receipts")
+    surfsub = sp.add_subparsers(dest="surface_cmd", required=True)
+    sv = surfsub.add_parser("validate", help="Validate self-improvement surface inventory and receipts")
+    sv.add_argument("--inventory", help="Surface inventory JSON file")
+    sv.add_argument("--receipt", help="Receipt JSON file to validate against the inventory")
+    sv.add_argument("--out", help="Optional path to write the validation receipt JSON")
+    sv.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Structured JSON output")
+    sv.set_defaults(func=cmd_surface_validate)
+
+    sp = sub.add_parser("goal", help="Read-only goal primitive utilities")
+    goalsub = sp.add_subparsers(dest="goal_cmd", required=True)
+    gs = goalsub.add_parser("status", help="Normalize and validate one goal/controller receipt")
+    gs.add_argument("--file", required=True, help="Goal/controller receipt JSON")
+    gs.add_argument("--source-ref", help="Optional public-safe source reference")
+    gs.add_argument("--out", help="Optional path to write the status receipt JSON")
+    gs.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Structured JSON output")
+    gs.set_defaults(func=cmd_goal_status)
+
     sp = sub.add_parser("self-curator", help="Lifecycle curator engine (review + checkpointed apply)")
     scsub = sp.add_subparsers(dest="self_curator_cmd", required=True)
     sc = scsub.add_parser("skill-review", help="Scan skill files and emit review-only lifecycle artifacts")
@@ -19995,7 +20051,7 @@ def main() -> None:
         or (dream_lite_cmd == "apply" and dream_lite_apply_cmd in {"plan", "verify"})
     )
     file_only_snapshot = cmd in {"continuity", "self"} and self_cmd in {"attachment-map", "threat-feed", "adjudication", "public-summary", "explain", "sensitivity", "triggers", "interventions", "wording-lint"} and bool(getattr(args, "snapshot", None))
-    no_db_path = cmd in {"capsule", "self-curator", "steward", "ingest-review", "active-line", "harness", "codex"} or dream_lite_no_db or (cmd == "optimize" and optimize_cmd in {"canary-advisory"}) or (cmd in {"continuity", "self"} and self_cmd in {"diff", "release", "release-history", "status", "enable", "disable", "patterns"}) or file_only_snapshot
+    no_db_path = cmd in {"capsule", "self-curator", "steward", "ingest-review", "active-line", "surface", "goal", "harness", "codex"} or dream_lite_no_db or (cmd == "optimize" and optimize_cmd in {"canary-advisory"}) or (cmd in {"continuity", "self"} and self_cmd in {"diff", "release", "release-history", "status", "enable", "disable", "patterns"}) or file_only_snapshot
 
     if no_db_path:
         # Some command families own their own file-only semantics.

--- a/openclaw_mem/goal_primitive.py
+++ b/openclaw_mem/goal_primitive.py
@@ -1,0 +1,106 @@
+"""Read-only goal primitive helpers.
+
+The first product slice intentionally exposes status only.  It normalizes a
+controller/goal receipt into a small status object and validates that the result
+is safe to use as a low-blast-radius goal readback.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+SCHEMA_VERSION = "openclaw-mem.goal-status.v0"
+ACTIVE_STATUSES = {"active", "in_progress", "blocked", "paused"}
+CLOSED_STATUSES = {"complete", "completed", "closed", "cancelled"}
+VALID_STATUSES = ACTIVE_STATUSES | CLOSED_STATUSES | {"unknown"}
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_goal_receipt(path: str | Path) -> dict[str, Any]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("goal receipt must be a JSON object")
+    return payload
+
+
+def _pick(mapping: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in mapping and mapping.get(key) not in (None, ""):
+            return mapping.get(key)
+    return None
+
+
+def _goal_obj(receipt: Mapping[str, Any]) -> Mapping[str, Any]:
+    goal = receipt.get("goal")
+    return goal if isinstance(goal, Mapping) else receipt
+
+
+def build_goal_status(receipt: Mapping[str, Any], *, source_ref: str | None = None) -> dict[str, Any]:
+    goal = _goal_obj(receipt)
+    goal_id = str(_pick(goal, "goal_id", "id") or _pick(receipt, "goal_id", "id") or "unknown-goal")
+    objective = str(_pick(goal, "objective", "summary") or _pick(receipt, "objective", "summary") or "")
+    status = str(_pick(goal, "status") or _pick(receipt, "status") or "unknown").strip().lower()
+    updated_at = _pick(goal, "updated_at", "recorded_at") or _pick(receipt, "updated_at", "recorded_at")
+    phase = _pick(goal, "phase", "phase_goal") or _pick(receipt, "phase", "phase_goal")
+    next_gate = _pick(goal, "next_gate", "current_gate") or _pick(receipt, "next_gate", "current_gate")
+    verifier = _pick(goal, "completion_verifier", "verifier_receipt") or _pick(receipt, "completion_verifier", "verifier_receipt")
+    continuation = _pick(goal, "continuation_owner", "owner") or _pick(receipt, "continuation_owner", "owner")
+    stop_loss = _pick(goal, "stop_loss", "stop_loss_state") or _pick(receipt, "stop_loss", "stop_loss_state")
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    if not objective:
+        errors.append("goal objective/summary is required")
+    if status not in VALID_STATUSES:
+        errors.append(f"goal status must be one of {sorted(VALID_STATUSES)}")
+    if status in ACTIVE_STATUSES and not next_gate:
+        warnings.append("active goal has no next_gate/current_gate")
+    if status in ACTIVE_STATUSES and not continuation:
+        warnings.append("active goal has no continuation owner")
+
+    active = status in ACTIVE_STATUSES
+    closed = status in CLOSED_STATUSES
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": not errors,
+        "writes_performed": False,
+        "source_ref": source_ref,
+        "goal": {
+            "goal_id": goal_id,
+            "objective": objective,
+            "status": status,
+            "phase": phase,
+            "updated_at": updated_at,
+            "next_gate": next_gate,
+            "has_verifier": verifier is not None,
+            "continuation_owner": continuation,
+            "stop_loss": stop_loss,
+            "active": active,
+            "closed": closed,
+        },
+        "errors": errors,
+        "warnings": warnings,
+        "checked_at": now_iso(),
+    }
+
+
+def render_goal_status(status: Mapping[str, Any]) -> str:
+    goal = status.get("goal") if isinstance(status.get("goal"), Mapping) else {}
+    lines = [
+        f"goal_status goal_id={goal.get('goal_id')} status={goal.get('status')} writes_performed=false"
+    ]
+    if goal.get("next_gate"):
+        lines.append(f"next_gate={goal.get('next_gate')}")
+    if goal.get("continuation_owner"):
+        lines.append(f"continuation_owner={goal.get('continuation_owner')}")
+    if status.get("errors"):
+        lines.append("errors=" + ",".join(str(x) for x in status.get("errors") or []))
+    if status.get("warnings"):
+        lines.append("warnings=" + ",".join(str(x) for x in status.get("warnings") or []))
+    return " ".join(lines)

--- a/openclaw_mem/self_improvement_surface.py
+++ b/openclaw_mem/self_improvement_surface.py
@@ -1,0 +1,222 @@
+"""Shared governance substrate for self-improvement surfaces.
+
+This module is intentionally deterministic and local-only.  It validates the
+small receipt/inventory contract used by read-only consolidation pilots before
+any curator or goal runtime is allowed to mutate durable state.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+SCHEMA_VERSION = "openclaw-mem.self-improvement-surface.v0"
+RECEIPT_SCHEMA_VERSION = "openclaw-mem.self-improvement-receipt.v0"
+
+VALID_STATES = {"stable", "lab", "shadow", "retired"}
+VALID_WRITE_AUTHORITIES = {"none", "suggest", "stage", "apply-local", "apply-publish"}
+VALID_RISK_CLASSES = {"L0", "L1", "L2", "L3", "L4"}
+
+AUTHORITY_RANK = {
+    "none": 0,
+    "suggest": 1,
+    "stage": 2,
+    "apply-local": 3,
+    "apply-publish": 4,
+}
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_json_object(path: str | Path) -> dict[str, Any]:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return data
+
+
+def _as_list(value: Any, *, field: str) -> list[Any]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(f"{field} must be a list")
+    return value
+
+
+def _surface_items(inventory: Mapping[str, Any]) -> list[dict[str, Any]]:
+    raw = inventory.get("surfaces", [])
+    if not isinstance(raw, list):
+        raise ValueError("surfaces must be a list")
+    out: list[dict[str, Any]] = []
+    for idx, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise ValueError(f"surfaces[{idx}] must be an object")
+        out.append(dict(item))
+    return out
+
+
+def validate_inventory(inventory: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate a self-improvement surface inventory and return a receipt."""
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    seen: set[str] = set()
+    surfaces = []
+
+    try:
+        items = _surface_items(inventory)
+    except ValueError as exc:
+        items = []
+        errors.append(str(exc))
+
+    for idx, item in enumerate(items):
+        sid = str(item.get("surface_id") or "").strip()
+        if not sid:
+            errors.append(f"surfaces[{idx}].surface_id is required")
+        elif sid in seen:
+            errors.append(f"duplicate surface_id: {sid}")
+        else:
+            seen.add(sid)
+
+        state = str(item.get("state") or "").strip()
+        if state not in VALID_STATES:
+            errors.append(f"{sid or f'surfaces[{idx}]'}.state must be one of {sorted(VALID_STATES)}")
+
+        write_authority = str(item.get("write_authority") or "").strip()
+        if write_authority not in VALID_WRITE_AUTHORITIES:
+            errors.append(
+                f"{sid or f'surfaces[{idx}]'}.write_authority must be one of {sorted(VALID_WRITE_AUTHORITIES)}"
+            )
+
+        risk_class = str(item.get("risk_class") or "").strip()
+        if risk_class not in VALID_RISK_CLASSES:
+            errors.append(f"{sid or f'surfaces[{idx}]'}.risk_class must be one of {sorted(VALID_RISK_CLASSES)}")
+
+        if "protected" in item and not isinstance(item.get("protected"), bool):
+            errors.append(f"{sid or f'surfaces[{idx}]'}.protected must be boolean")
+
+        if state == "retired" and not item.get("rollback"):
+            warnings.append(f"{sid or f'surfaces[{idx}]'} is retired without rollback/readback reference")
+
+        surfaces.append(
+            {
+                "surface_id": sid,
+                "state": state,
+                "write_authority": write_authority,
+                "risk_class": risk_class,
+                "protected": bool(item.get("protected", False)),
+            }
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "inventory-validation",
+        "ok": not errors,
+        "writes_performed": False,
+        "surface_count": len(items),
+        "protected_count": sum(1 for s in surfaces if s.get("protected")),
+        "states": {state: sum(1 for s in surfaces if s.get("state") == state) for state in sorted(VALID_STATES)},
+        "errors": errors,
+        "warnings": warnings,
+        "validated_at": now_iso(),
+    }
+
+
+def _inventory_by_id(inventory: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    return {str(item.get("surface_id")): item for item in _surface_items(inventory) if item.get("surface_id")}
+
+
+def _min_required_authority(surface: Mapping[str, Any]) -> str:
+    risk = str(surface.get("risk_class") or "").strip()
+    configured = str(surface.get("write_authority") or "none").strip()
+    if bool(surface.get("protected", False)) or risk in {"L3", "L4"}:
+        floor = "apply-publish" if risk == "L4" else "apply-local"
+        return floor if AUTHORITY_RANK[floor] >= AUTHORITY_RANK.get(configured, 0) else configured
+    return configured if configured in AUTHORITY_RANK else "none"
+
+
+def validate_receipt(receipt: Mapping[str, Any], *, inventory: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    """Validate a self-improvement receipt against optional inventory policy."""
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    mode = str(receipt.get("mode") or "none").strip()
+    if mode not in VALID_WRITE_AUTHORITIES:
+        errors.append(f"mode must be one of {sorted(VALID_WRITE_AUTHORITIES)}")
+
+    risk_class = str(receipt.get("risk_class") or "").strip()
+    if risk_class and risk_class not in VALID_RISK_CLASSES:
+        errors.append(f"risk_class must be one of {sorted(VALID_RISK_CLASSES)}")
+
+    writes_performed = receipt.get("writes_performed", False)
+    if not isinstance(writes_performed, bool):
+        errors.append("writes_performed must be boolean")
+
+    try:
+        applied = _as_list(receipt.get("applied"), field="applied")
+    except ValueError as exc:
+        applied = []
+        errors.append(str(exc))
+
+    if applied and AUTHORITY_RANK.get(mode, 0) < AUTHORITY_RANK["suggest"]:
+        errors.append("non-empty applied[] requires mode >= suggest")
+    if writes_performed and AUTHORITY_RANK.get(mode, 0) < AUTHORITY_RANK["apply-local"]:
+        errors.append("writes_performed=true requires mode >= apply-local")
+
+    inv = _inventory_by_id(inventory) if inventory else {}
+    protected_touched = False
+    for idx, item in enumerate(applied):
+        if not isinstance(item, dict):
+            errors.append(f"applied[{idx}] must be an object")
+            continue
+        sid = str(item.get("surface_id") or receipt.get("surface_id") or "").strip()
+        if not sid:
+            errors.append(f"applied[{idx}].surface_id is required")
+            continue
+        surface = inv.get(sid)
+        if not surface:
+            warnings.append(f"applied[{idx}] references unknown surface_id: {sid}")
+            continue
+        if bool(surface.get("protected", False)):
+            protected_touched = True
+        required = _min_required_authority(surface)
+        if AUTHORITY_RANK.get(mode, 0) < AUTHORITY_RANK.get(required, 0):
+            errors.append(
+                f"applied[{idx}] touches {sid} requiring {required}; receipt mode is {mode}"
+            )
+
+    return {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "kind": "receipt-validation",
+        "ok": not errors,
+        "writes_performed": False,
+        "mode": mode,
+        "applied_count": len(applied),
+        "protected_touched": protected_touched,
+        "errors": errors,
+        "warnings": warnings,
+        "validated_at": now_iso(),
+    }
+
+
+def validate_bundle(*, inventory: Mapping[str, Any] | None = None, receipt: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    inventory_result = validate_inventory(inventory or {"surfaces": []}) if inventory is not None else None
+    receipt_result = validate_receipt(receipt or {}, inventory=inventory) if receipt is not None else None
+    ok = True
+    if inventory_result is not None:
+        ok = ok and bool(inventory_result.get("ok"))
+    if receipt_result is not None:
+        ok = ok and bool(receipt_result.get("ok"))
+    return {
+        "schema_version": "openclaw-mem.self-improvement-validation-bundle.v0",
+        "ok": ok,
+        "writes_performed": False,
+        "inventory": inventory_result,
+        "receipt": receipt_result,
+        "validated_at": now_iso(),
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openclaw-context-pack"
-version = "1.9.11"
+version = "1.9.12"
 description = "Local-first AI agent memory governance: Store / Pack / Observe with citations, receipts, and rollback"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/skills/goal-primitive.ops.md
+++ b/skills/goal-primitive.ops.md
@@ -1,0 +1,37 @@
+# goal-primitive.ops
+
+Use when operating the read-only OpenClaw Mem goal primitive pilot.
+
+## Purpose
+
+The goal primitive is the first low-risk product slice of the OpenClaw self-improvement consolidation plan. It provides status/readback and validation before any continuation runtime or skill-learning loop is allowed to mutate durable state.
+
+## Commands
+
+Validate a surface inventory or receipt:
+
+```bash
+openclaw-mem surface validate --inventory surfaces.json --json
+openclaw-mem surface validate --inventory surfaces.json --receipt receipt.json --out validation.json --json
+```
+
+Read goal status:
+
+```bash
+openclaw-mem goal status --file goal.json --json
+openclaw-mem goal status --file goal.json --out goal-status.json --json
+```
+
+## Rules
+
+- Treat this pilot as read-only. `writes_performed` must remain `false` unless the only write is an explicit `--out` receipt.
+- Protected surfaces require sufficient write authority before any future curator can apply mutations.
+- For compaction-safe injection, prefer a context engine/pack seam. Do not paste all goal guidance into every system prompt.
+- `goal status` is not an auto-continuation loop. It only normalizes and verifies the current goal receipt.
+
+## Closeout checks
+
+- Unit tests pass for surface validation and goal status.
+- CLI smoke passes through the installed `openclaw-mem` command.
+- Public docs are reviewed before push.
+- WAL/receipt names the exact commands and artifacts.

--- a/tests/test_goal_primitive.py
+++ b/tests/test_goal_primitive.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from openclaw_mem.goal_primitive import build_goal_status, load_goal_receipt, render_goal_status
+
+
+class TestGoalPrimitive(unittest.TestCase):
+    def test_builds_read_only_goal_status(self):
+        status = build_goal_status(
+            {
+                "goal": {
+                    "goal_id": "self-improvement-pilot",
+                    "objective": "Ship read-only goal status",
+                    "status": "active",
+                    "phase": "phase-1",
+                    "next_gate": "run tests",
+                    "continuation_owner": "Lyria",
+                    "completion_verifier": "pytest",
+                }
+            },
+            source_ref="fixture://goal",
+        )
+        self.assertTrue(status["ok"])
+        self.assertFalse(status["writes_performed"])
+        self.assertEqual(status["goal"]["goal_id"], "self-improvement-pilot")
+        self.assertTrue(status["goal"]["active"])
+        self.assertTrue(status["goal"]["has_verifier"])
+        self.assertIn("writes_performed=false", render_goal_status(status))
+
+    def test_active_goal_without_continuation_warns(self):
+        status = build_goal_status({"goal_id": "g", "objective": "Do it", "status": "active", "next_gate": "next"})
+        self.assertTrue(status["ok"])
+        self.assertIn("continuation owner", " ".join(status["warnings"]))
+
+    def test_missing_objective_fails(self):
+        status = build_goal_status({"goal_id": "g", "status": "active"})
+        self.assertFalse(status["ok"])
+        self.assertIn("objective", " ".join(status["errors"]))
+
+    def test_invalid_status_fails(self):
+        status = build_goal_status({"goal_id": "g", "objective": "Do it", "status": "running-hot"})
+        self.assertFalse(status["ok"])
+        self.assertIn("status", " ".join(status["errors"]))
+
+    def test_load_goal_receipt_requires_object(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            good = Path(tmp) / "goal.json"
+            good.write_text(json.dumps({"goal_id": "g", "objective": "x", "status": "complete"}), encoding="utf-8")
+            self.assertEqual(load_goal_receipt(good)["goal_id"], "g")
+            bad = Path(tmp) / "bad.json"
+            bad.write_text("[]", encoding="utf-8")
+            with self.assertRaises(ValueError):
+                load_goal_receipt(bad)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_self_improvement_surface.py
+++ b/tests/test_self_improvement_surface.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import unittest
+
+from openclaw_mem.self_improvement_surface import validate_bundle, validate_inventory, validate_receipt
+
+
+class TestSelfImprovementSurface(unittest.TestCase):
+    def test_valid_inventory_counts_states_and_protected_surfaces(self):
+        receipt = validate_inventory(
+            {
+                "surfaces": [
+                    {
+                        "surface_id": "goal.primitive",
+                        "state": "lab",
+                        "owner": "openclaw-mem",
+                        "write_authority": "stage",
+                        "risk_class": "L1",
+                        "protected": False,
+                    },
+                    {
+                        "surface_id": "skills.operator-rule",
+                        "state": "stable",
+                        "owner": "operator",
+                        "write_authority": "none",
+                        "risk_class": "L3",
+                        "protected": True,
+                    },
+                ]
+            }
+        )
+        self.assertTrue(receipt["ok"])
+        self.assertFalse(receipt["writes_performed"])
+        self.assertEqual(receipt["surface_count"], 2)
+        self.assertEqual(receipt["protected_count"], 1)
+        self.assertEqual(receipt["states"]["lab"], 1)
+
+    def test_invalid_inventory_state_fails(self):
+        receipt = validate_inventory(
+            {
+                "surfaces": [
+                    {
+                        "surface_id": "bad",
+                        "state": "enabled",
+                        "write_authority": "stage",
+                        "risk_class": "L1",
+                    }
+                ]
+            }
+        )
+        self.assertFalse(receipt["ok"])
+        self.assertIn("state", " ".join(receipt["errors"]))
+
+    def test_protected_surface_requires_sufficient_authority(self):
+        inventory = {
+            "surfaces": [
+                {
+                    "surface_id": "skills.operator-rule",
+                    "state": "stable",
+                    "write_authority": "none",
+                    "risk_class": "L3",
+                    "protected": True,
+                }
+            ]
+        }
+        receipt = {
+            "mode": "stage",
+            "writes_performed": True,
+            "risk_class": "L3",
+            "applied": [{"surface_id": "skills.operator-rule", "action": "patch"}],
+        }
+        result = validate_receipt(receipt, inventory=inventory)
+        self.assertFalse(result["ok"])
+        self.assertTrue(result["protected_touched"])
+        self.assertIn("requiring apply-local", " ".join(result["errors"]))
+
+    def test_protected_surface_can_be_applied_with_sufficient_authority(self):
+        inventory = {
+            "surfaces": [
+                {
+                    "surface_id": "skills.operator-rule",
+                    "state": "stable",
+                    "write_authority": "none",
+                    "risk_class": "L3",
+                    "protected": True,
+                }
+            ]
+        }
+        receipt = {
+            "mode": "apply-local",
+            "writes_performed": True,
+            "risk_class": "L3",
+            "applied": [{"surface_id": "skills.operator-rule", "action": "patch"}],
+        }
+        result = validate_receipt(receipt, inventory=inventory)
+        self.assertTrue(result["ok"])
+        self.assertTrue(result["protected_touched"])
+
+    def test_l4_surface_requires_apply_publish(self):
+        inventory = {
+            "surfaces": [
+                {
+                    "surface_id": "cron.topology",
+                    "state": "stable",
+                    "write_authority": "apply-local",
+                    "risk_class": "L4",
+                    "protected": False,
+                }
+            ]
+        }
+        receipt = {
+            "mode": "apply-local",
+            "writes_performed": True,
+            "risk_class": "L4",
+            "applied": [{"surface_id": "cron.topology", "action": "patch"}],
+        }
+        result = validate_receipt(receipt, inventory=inventory)
+        self.assertFalse(result["ok"])
+        self.assertIn("requiring apply-publish", " ".join(result["errors"]))
+
+    def test_non_empty_applied_requires_at_least_suggest(self):
+        result = validate_receipt({"mode": "none", "writes_performed": False, "applied": [{"surface_id": "x"}]})
+        self.assertFalse(result["ok"])
+        self.assertIn("mode >= suggest", " ".join(result["errors"]))
+
+    def test_writes_performed_requires_apply_local(self):
+        result = validate_receipt({"mode": "stage", "writes_performed": True, "applied": []})
+        self.assertFalse(result["ok"])
+        self.assertIn("writes_performed=true", " ".join(result["errors"]))
+
+    def test_unknown_surface_id_warns_not_errors_when_mode_is_sufficient(self):
+        result = validate_receipt(
+            {"mode": "stage", "writes_performed": False, "applied": [{"surface_id": "unknown"}]},
+            inventory={"surfaces": []},
+        )
+        self.assertTrue(result["ok"])
+        self.assertIn("unknown surface_id", " ".join(result["warnings"]))
+
+    def test_bundle_combines_inventory_and_receipt(self):
+        inventory = {
+            "surfaces": [
+                {
+                    "surface_id": "goal.primitive",
+                    "state": "lab",
+                    "write_authority": "stage",
+                    "risk_class": "L1",
+                    "protected": False,
+                }
+            ]
+        }
+        receipt = {"mode": "stage", "writes_performed": False, "applied": []}
+        result = validate_bundle(inventory=inventory, receipt=receipt)
+        self.assertTrue(result["ok"])
+        self.assertFalse(result["writes_performed"])
+        self.assertTrue(result["inventory"]["ok"])
+        self.assertTrue(result["receipt"]["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -372,7 +372,7 @@ wheels = [
 
 [[package]]
 name = "openclaw-context-pack"
-version = "1.9.11"
+version = "1.9.12"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Adds the first read-only slice of the OpenClaw self-improvement consolidation plan:

- shared self-improvement surface inventory / receipt validator
- read-only `openclaw-mem goal status`
- public Advanced Labs docs
- ops skill card
- implementation blade map and closure receipt

## Verification

- `uv run python -m pytest tests/test_self_improvement_surface.py tests/test_goal_primitive.py tests/test_active_line_context.py`
  - `17 passed`
- `uv run --with mkdocs --with mkdocs-material mkdocs build --strict`
  - built successfully
- CLI smoke:
  - `surface validate` safe case: `ok=true`, `writes_performed=false`
  - protected-surface blocked case: `ok=false`, `protected_touched=true`
  - `goal status`: `ok=true`, `writes_performed=false`, `goal.active=true`
- Local install smoke:
  - `uv tool install --force --editable .`
  - installed `openclaw-mem goal status` and `openclaw-mem surface validate` passed
- Claude public-facing review ran twice:
  - first pass held for fixes
  - second pass cleared push with no must-fix blockers

## Topology impact

Unchanged.

No cron, gateway, plugin config, model routing, channel routing, or auto-continuation behavior changed.

## Release note

Recommended tag after merge: `v1.9.12`.
