### PR TITLE
feat: add self-improvement slices 2-5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.13] - 2026-05-12
+
+### Added
+
+- Added `openclaw-mem goal pack` as the goal-survival pack seam for building ContextPack-compatible fragments from goal/controller receipts.
+- Added `openclaw-mem skill-capture propose` for L1 staged skill-learning proposal artifacts without live skill mutation.
+- Added `openclaw-mem skill-curator review` as a product-facing non-mutating report-only alias for skill lifecycle review.
+- Added `openclaw-mem mem-system status` for read-only Store / Pack / Observe / Review / Curate surface inventory.
+- Added public documentation and operator skill guidance for self-improvement slices 2-5.
+
+### Testing
+
+- Added regression coverage for goal pack survival, skill-capture proposals, mem-system status, and CLI smoke for the new command surfaces.
+- Verified targeted tests, CLI smoke, MkDocs strict build, public-facing second-brain review, and local editable install smoke for this batch.
+
 ## [1.9.12] - 2026-05-12
 
 ### Added

--- a/docs/2026-05-12_self-improvement-slices-2-5-receipt.md
+++ b/docs/2026-05-12_self-improvement-slices-2-5-receipt.md
@@ -1,0 +1,35 @@
+# Self-improvement slices 2–5 receipt — 2026-05-12
+
+## Summary
+
+Implemented the next read-only / report-only / staged-only batch of the OpenClaw Mem self-improvement consolidation plan:
+
+- Slice 2: `openclaw-mem goal pack`
+- Slice 3: `openclaw-mem skill-capture propose`
+- Slice 4: `openclaw-mem skill-curator review`
+- Slice 5: `openclaw-mem mem-system status`
+
+## Authority posture
+
+- `goal pack` is read-only and emits a ContextPack-compatible fragment.
+- `skill-capture propose` can write only explicit L1 staged proposal artifacts.
+- `skill-curator review` is non-mutating report-only; by default it writes review JSON/Markdown artifacts, and `--no-write` makes it payload-only.
+- `mem-system status` is read-only and reports `topology_changed=false`.
+
+No auto-continuation, live skill mutation, governed apply, cron, gateway, plugin config, or model-routing change was enabled.
+
+## Verification plan
+
+- targeted unit and CLI integration tests
+- CLI smoke for all new commands
+- MkDocs strict build
+- public-facing second-brain review
+- local editable install smoke
+
+## Topology impact
+
+Unchanged.
+
+## Rollback
+
+Revert the implementation commit or remove the new modules/CLI registrations/docs before release. No runtime topology rollback is needed.

--- a/docs/self-improvement-slices-2-5.md
+++ b/docs/self-improvement-slices-2-5.md
@@ -1,0 +1,86 @@
+# Self-improvement consolidation: slices 2–5
+
+This page documents the second product batch in the OpenClaw Mem self-improvement consolidation line. The batch expands the read-only/staged-only skeleton after the initial surface validator and `goal status` pilot.
+
+## What this batch adds
+
+### Slice 2 — Goal survival pack seam
+
+`openclaw-mem goal pack` builds a ContextPack-compatible fragment from a goal/controller receipt.
+
+```bash
+openclaw-mem goal pack --file goal.json --json
+```
+
+This is the goal-primitive alias for the existing active-line context pack shape. It is read-only and returns `writes_performed=false`.
+
+Use it when an unfinished goal needs to survive compaction or handoff as a bounded pack fragment containing:
+
+- goal id
+- status
+- objective
+- current/next gate
+- stop-loss state, when present
+- verifier presence
+
+### Slice 3 — `skill_capture` staged proposal
+
+`openclaw-mem skill-capture propose` lets an agent mark a learning candidate during a turn without editing live skills.
+
+```bash
+openclaw-mem skill-capture propose \
+  --text "When version changes, refresh uv.lock before CI." \
+  --target-skill ck-software-engineering-ops \
+  --rationale "Prevents lockfile freshness failures" \
+  --out .state/skill-capture/proposals/version-lock.json \
+  --json
+```
+
+Rules:
+
+- writes only an explicit L1 staged proposal artifact
+- never patches live skills mid-turn
+- caps text size
+- rejects path-like target skill names
+- leaves curator judgment for a later review surface
+
+### Slice 4 — Skill Curator report-only review
+
+`openclaw-mem skill-curator review` is a product-facing report-only alias for the existing self-curator skill review lane.
+
+```bash
+openclaw-mem skill-curator review --skill-root skills --json
+```
+
+It emits review-only lifecycle candidates and remains blocked until human review. By default it writes review JSON/Markdown artifacts under `--out-root` (default `.state/skill-curator/runs/<timestamp>/`); use `--no-write` for payload-only review. It does not apply patches.
+
+### Slice 5 — OpenClaw Mem System status
+
+`openclaw-mem mem-system status` reports the current Store / Pack / Observe / Review / Curate surfaces in one read-only inventory.
+
+```bash
+openclaw-mem mem-system status --json
+```
+
+The status output includes:
+
+- planes: Store, Pack, Observe, Review, Curate
+- surface count
+- state counts such as `stable`, `lab`, and `shadow`
+- `writes_performed=false`
+- `topology_changed=false`
+
+## Non-goals
+
+This batch does not enable:
+
+- auto-continuation
+- automatic skill mutation
+- governed apply
+- cron changes
+- gateway/plugin configuration changes
+- L3/L4 live mutation
+
+## Recommended next step
+
+After these surfaces are merged and released, the next engineering line can prepare Slice 6: the staged mutation framework. That line should remain separate because it introduces proposal → apply → rollback semantics and touches higher-risk authority boundaries.

--- a/docs/specs/self-improvement-slices-2-5-blade-map-v0.md
+++ b/docs/specs/self-improvement-slices-2-5-blade-map-v0.md
@@ -1,0 +1,50 @@
+# Self-improvement consolidation slices 2–5 — blade map v0
+
+Date: 2026-05-12
+Status: implementation blade map
+
+## Goal
+
+Complete the next read-only/staged-only product skeleton for OpenClaw Mem self-improvement consolidation:
+
+2. Goal survival pack seam.
+3. `skill_capture` staged proposal path.
+4. Skill Curator report-only review surface.
+5. OpenClaw Mem System status surface.
+
+## Non-goals
+
+- No auto-continuation runtime.
+- No automatic skill mutation.
+- No governed apply enablement.
+- No cron, gateway, plugin config, or model-routing changes.
+- No L3/L4 live mutation.
+
+## Outputs / artifacts
+
+- New/updated CLI surfaces for goal pack, skill capture, skill-curator review alias, and mem-system status.
+- Unit tests for each slice.
+- Public docs and ops skill updates.
+- Claude second-brain public review before push.
+- Local install smoke.
+- WAL update and public PR/tag if the slice is merged.
+
+## Invariants
+
+- Goal pack and mem-system status are read-only.
+- Skill capture writes only explicit L1 staged proposal artifacts under `--out` / `--out-dir`; it never patches live skills.
+- Skill curator review remains non-mutating and proposal/report-only; it may write explicit review artifacts under `--out-root` but never applies patches.
+- Topology remains unchanged.
+
+## Verifier plan
+
+- targeted pytest for new modules, CLI integration, and affected existing goal/active-line tests
+- CLI smoke for each new command
+- mkdocs strict build
+- Claude public-facing review
+- local editable install smoke
+- PR CI readback before merge
+
+## Rollback
+
+Revert the implementation commit or delete the feature branch before merge. No runtime topology rollback is needed because no cron/gateway/config changes are allowed in this batch.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
   - Advanced Labs:
       - Core vs Advanced Labs: core-vs-advanced-labs.md
       - Self-improvement goal pilot: self-improvement-goal-pilot.md
+      - Self-improvement slices 2–5: self-improvement-slices-2-5.md
       - Governed optimize assist: optimize-assist.md
       - Verbatim semantic lane: verbatim-semantic-lane.md
       - Dual-language memory strategy: dual-language-memory-strategy.md

--- a/openclaw_mem/__init__.py
+++ b/openclaw_mem/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "1.9.12"
+__version__ = "1.9.13"

--- a/openclaw_mem/cli.py
+++ b/openclaw_mem/cli.py
@@ -42,10 +42,12 @@ from openclaw_mem import context_pack_v1
 from openclaw_mem import ingestion_review
 from openclaw_mem import gbrain_sidecar
 from openclaw_mem import goal_primitive
+from openclaw_mem import mem_system_status
 from openclaw_mem import pack_trace_v1
 from openclaw_mem import self_model_sidecar
 from openclaw_mem import self_curator
 from openclaw_mem import self_improvement_surface
+from openclaw_mem import skill_capture
 from openclaw_mem import steward_review
 from openclaw_mem import harness as harness_install
 from openclaw_mem import codex_install
@@ -10734,6 +10736,79 @@ def cmd_goal_status(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
         print(goal_primitive.render_goal_status(payload))
 
 
+def cmd_goal_pack(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    receipt = active_line_context.load_receipt(args.file)
+    payload = {
+        "ok": True,
+        "input": str(args.file),
+        "context": active_line_context.build_active_line_context(
+            receipt,
+            source_ref=getattr(args, "source_ref", None),
+        ),
+        "relationship": "goal pack is the goal-primitive alias for active-line pack",
+    }
+    if getattr(args, "out", None):
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if bool(getattr(args, "json", False)):
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        active = payload["context"]["active_line"]
+        print(f"goal_pack goal_id={active['goal_id']} status={active['status']} writes_performed=false")
+
+
+def cmd_skill_capture_propose(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    text = getattr(args, "text", None)
+    if getattr(args, "text_file", None):
+        text_path = Path(args.text_file)
+        if text_path.stat().st_size > skill_capture.MAX_TEXT_CHARS * 10:
+            raise SystemExit(f"text file exceeds pre-read cap: {skill_capture.MAX_TEXT_CHARS * 10} bytes")
+        text = text_path.read_text(encoding="utf-8")
+    proposal = skill_capture.build_proposal(
+        text=text or "",
+        source_ref=getattr(args, "source_ref", None),
+        target_skill=getattr(args, "target_skill", None),
+        rationale=getattr(args, "rationale", None),
+        run_id=getattr(args, "run_id", None),
+    )
+    stored_path = None
+    if getattr(args, "out", None) or getattr(args, "out_dir", None):
+        if not proposal.get("ok"):
+            raise SystemExit("refusing to write invalid skill capture proposal")
+        stored_path = skill_capture.write_proposal(proposal, out=getattr(args, "out", None), out_dir=getattr(args, "out_dir", None))
+        proposal = dict(proposal)
+        proposal["artifact_path"] = str(stored_path)
+        proposal["writes_performed"] = True
+        proposal["write_scope"] = "staged_proposal_artifact"
+    if bool(getattr(args, "json", False)):
+        print(json.dumps(proposal, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(
+            f"skill_capture candidate_id={proposal.get('candidate_id')} ok={str(proposal.get('ok')).lower()} "
+            f"writes_performed={str(proposal.get('writes_performed')).lower()}"
+        )
+
+
+def cmd_skill_curator_review(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    return cmd_self_curator_skill_review(conn, args)
+
+
+def cmd_mem_system_status(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    payload = mem_system_status.build_status(
+        workspace_root=getattr(args, "workspace_root", "."),
+        state_root=getattr(args, "state_root", None),
+    )
+    if getattr(args, "out", None):
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if bool(getattr(args, "json", False)):
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(mem_system_status.render_status(payload))
+
+
 def cmd_self_curator_plan(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
     mutations = json.loads(Path(args.mutations_file).read_text(encoding="utf-8"))
     if isinstance(mutations, dict) and "mutations" in mutations:
@@ -19861,6 +19936,53 @@ def build_parser() -> argparse.ArgumentParser:
     gs.add_argument("--out", help="Optional path to write the status receipt JSON")
     gs.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Structured JSON output")
     gs.set_defaults(func=cmd_goal_status)
+    gp = goalsub.add_parser("pack", help="Build a ContextPack fragment from one goal/controller receipt")
+    gp.add_argument("--file", required=True, help="Goal/controller receipt JSON")
+    gp.add_argument("--source-ref", help="Optional public-safe source reference")
+    gp.add_argument("--out", help="Optional path to write the pack fragment JSON")
+    gp.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Structured JSON output")
+    gp.set_defaults(func=cmd_goal_pack)
+
+    sp = sub.add_parser("skill-capture", help="Stage skill-learning proposals without mutating live skills")
+    sksub = sp.add_subparsers(dest="skill_capture_cmd", required=True)
+    sk = sksub.add_parser("propose", help="Create one L1 staged skill-learning proposal")
+    sk_text = sk.add_mutually_exclusive_group(required=True)
+    sk_text.add_argument("--text", help="Learning candidate text")
+    sk_text.add_argument("--text-file", help="Read learning candidate text from a file")
+    sk.add_argument("--source-ref", help="Optional public-safe source reference")
+    sk.add_argument("--target-skill", help="Optional target skill name (not a path)")
+    sk.add_argument("--rationale", help="Why this candidate may deserve curator review")
+    sk.add_argument("--run-id", help="Optional caller run/session id")
+    sk.add_argument("--out", help="Write the staged proposal artifact to this JSON path")
+    sk.add_argument("--out-dir", help="Write the staged proposal artifact into this directory")
+    sk.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Structured JSON output")
+    sk.set_defaults(func=cmd_skill_capture_propose)
+
+    sp = sub.add_parser("skill-curator", help="Read-only skill lifecycle curator review surface")
+    ksub = sp.add_subparsers(dest="skill_curator_cmd", required=True)
+    kr = ksub.add_parser("review", help="Alias for self-curator skill-review; emits review-only artifacts")
+    kr.add_argument(
+        "--skill-root",
+        action="append",
+        dest="skill_roots",
+        default=[],
+        help="Skill root containing */SKILL.md (repeatable)",
+    )
+    kr.add_argument("--out-root", default=".state/skill-curator/runs", help="Output root for timestamped run artifacts")
+    kr.add_argument("--run-id", help="Optional safe run id")
+    kr.add_argument("--limit", type=int, help="Optional candidate limit")
+    kr.add_argument("--no-write", action="store_true", help="Print review payload without writing review artifacts")
+    kr.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Print review JSON")
+    kr.set_defaults(func=cmd_skill_curator_review)
+
+    sp = sub.add_parser("mem-system", help="Read-only Store/Pack/Observe/Review/Curate status")
+    msub = sp.add_subparsers(dest="mem_system_cmd", required=True)
+    ms = msub.add_parser("status", help="Show OpenClaw Mem system surface inventory")
+    ms.add_argument("--workspace-root", default=".", help="Repository/workspace root to inspect")
+    ms.add_argument("--state-root", help="OpenClaw state root to inspect (default: ~/.openclaw)")
+    ms.add_argument("--out", help="Optional path to write the status JSON")
+    ms.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Structured JSON output")
+    ms.set_defaults(func=cmd_mem_system_status)
 
     sp = sub.add_parser("self-curator", help="Lifecycle curator engine (review + checkpointed apply)")
     scsub = sp.add_subparsers(dest="self_curator_cmd", required=True)
@@ -20051,7 +20173,7 @@ def main() -> None:
         or (dream_lite_cmd == "apply" and dream_lite_apply_cmd in {"plan", "verify"})
     )
     file_only_snapshot = cmd in {"continuity", "self"} and self_cmd in {"attachment-map", "threat-feed", "adjudication", "public-summary", "explain", "sensitivity", "triggers", "interventions", "wording-lint"} and bool(getattr(args, "snapshot", None))
-    no_db_path = cmd in {"capsule", "self-curator", "steward", "ingest-review", "active-line", "surface", "goal", "harness", "codex"} or dream_lite_no_db or (cmd == "optimize" and optimize_cmd in {"canary-advisory"}) or (cmd in {"continuity", "self"} and self_cmd in {"diff", "release", "release-history", "status", "enable", "disable", "patterns"}) or file_only_snapshot
+    no_db_path = cmd in {"capsule", "self-curator", "skill-curator", "steward", "ingest-review", "active-line", "surface", "goal", "skill-capture", "mem-system", "harness", "codex"} or dream_lite_no_db or (cmd == "optimize" and optimize_cmd in {"canary-advisory"}) or (cmd in {"continuity", "self"} and self_cmd in {"diff", "release", "release-history", "status", "enable", "disable", "patterns"}) or file_only_snapshot
 
     if no_db_path:
         # Some command families own their own file-only semantics.

--- a/openclaw_mem/mem_system_status.py
+++ b/openclaw_mem/mem_system_status.py
@@ -1,0 +1,104 @@
+"""Read-only OpenClaw Mem system status surface."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+SCHEMA_VERSION = "openclaw-mem.system-status.v0"
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _exists(path: str | Path) -> bool:
+    return Path(path).expanduser().exists()
+
+
+def build_status(*, workspace_root: str | Path = ".", state_root: str | Path | None = None) -> dict[str, Any]:
+    root = Path(workspace_root).expanduser().resolve()
+    state = Path(state_root).expanduser().resolve() if state_root else Path.home() / ".openclaw"
+    mem = state / "memory"
+    surfaces = [
+        {
+            "plane": "Store",
+            "surface_id": "store.sqlite",
+            "state": "stable" if _exists(mem / "openclaw-mem.sqlite") else "shadow",
+            "path_hint": "memory/openclaw-mem.sqlite",
+        },
+        {
+            "plane": "Store",
+            "surface_id": "store.lancedb",
+            "state": "stable" if _exists(mem / "lancedb") else "shadow",
+            "path_hint": "memory/lancedb",
+        },
+        {
+            "plane": "Pack",
+            "surface_id": "pack.context-pack",
+            "state": "stable" if _exists(root / "openclaw_mem" / "context_pack_v1.py") else "shadow",
+            "path_hint": "openclaw_mem/context_pack_v1.py",
+        },
+        {
+            "plane": "Pack",
+            "surface_id": "pack.goal",
+            "state": "lab" if _exists(root / "openclaw_mem" / "goal_primitive.py") else "shadow",
+            "path_hint": "openclaw_mem/goal_primitive.py",
+        },
+        {
+            "plane": "Observe",
+            "surface_id": "observe.episodes",
+            "state": "stable" if _exists(mem / "openclaw-mem-episodes.jsonl") else "shadow",
+            "path_hint": "memory/openclaw-mem-episodes.jsonl",
+        },
+        {
+            "plane": "Review",
+            "surface_id": "review.steward",
+            "state": "stable" if _exists(root / "openclaw_mem" / "steward_review.py") else "shadow",
+            "path_hint": "openclaw_mem/steward_review.py",
+        },
+        {
+            "plane": "Review",
+            "surface_id": "review.skill-curator",
+            "state": "lab" if _exists(root / "openclaw_mem" / "self_curator.py") else "shadow",
+            "path_hint": "openclaw_mem/self_curator.py",
+        },
+        {
+            "plane": "Curate",
+            "surface_id": "curate.dream-lite",
+            "state": "lab",
+            "path_hint": "openclaw-mem dream-lite",
+        },
+        {
+            "plane": "Curate",
+            "surface_id": "curate.skill-capture",
+            "state": "lab" if _exists(root / "openclaw_mem" / "skill_capture.py") else "shadow",
+            "path_hint": "openclaw_mem/skill_capture.py",
+        },
+    ]
+    counts: dict[str, int] = {}
+    for item in surfaces:
+        key = str(item["state"])
+        counts[key] = counts.get(key, 0) + 1
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": True,
+        "writes_performed": False,
+        "workspace_root": str(root),
+        "state_root": str(state),
+        "planes": ["Store", "Pack", "Observe", "Review", "Curate"],
+        "surface_count": len(surfaces),
+        "counts_by_state": counts,
+        "surfaces": surfaces,
+        "topology_changed": False,
+        "checked_at": now_iso(),
+    }
+
+
+def render_status(status: Mapping[str, Any]) -> str:
+    counts = status.get("counts_by_state") if isinstance(status.get("counts_by_state"), Mapping) else {}
+    return (
+        f"mem_system_status surfaces={status.get('surface_count')} "
+        f"states={dict(counts)} writes_performed=false topology_changed=false"
+    )

--- a/openclaw_mem/skill_capture.py
+++ b/openclaw_mem/skill_capture.py
@@ -1,0 +1,88 @@
+"""Staged skill-capture proposal helpers.
+
+This is intentionally not a live skill mutation system.  It lets an agent mark a
+bounded learning candidate during a turn and write an L1 proposal artifact for a
+later curator/reviewer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "openclaw-mem.skill-capture.proposal.v0"
+MAX_TEXT_CHARS = 4000
+MAX_CANDIDATES_PER_TURN = 3
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def stable_candidate_id(text: str, *, target_skill: str | None = None, source_ref: str | None = None) -> str:
+    seed = "\0".join([target_skill or "", source_ref or "", text])
+    return "skill-capture-" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def build_proposal(
+    *,
+    text: str,
+    source_ref: str | None = None,
+    target_skill: str | None = None,
+    rationale: str | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    body = str(text or "").strip()
+    errors: list[str] = []
+    warnings: list[str] = []
+    if not body:
+        errors.append("text is required")
+    if len(body) > MAX_TEXT_CHARS:
+        errors.append(f"text exceeds {MAX_TEXT_CHARS} chars")
+    if target_skill and any(part in target_skill for part in ("..", "/", "\\")):
+        errors.append("target_skill must be a skill name, not a path")
+    if not rationale:
+        warnings.append("rationale is recommended for curator review")
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": not errors,
+        "mode": "stage",
+        "risk_class": "L1",
+        "writes_performed": False,
+        "candidate_id": stable_candidate_id(body, target_skill=target_skill, source_ref=source_ref),
+        "run_id": run_id,
+        "source_ref": source_ref,
+        "target_skill": target_skill,
+        "proposal": {
+            "text": body,
+            "rationale": rationale,
+            "action": "propose_skill_update",
+        },
+        "limits": {
+            "max_text_chars": MAX_TEXT_CHARS,
+            "max_candidates_per_turn": MAX_CANDIDATES_PER_TURN,
+        },
+        "errors": errors,
+        "warnings": warnings,
+        "created_at": now_iso(),
+    }
+
+
+def write_proposal(proposal: dict[str, Any], *, out: str | Path | None = None, out_dir: str | Path | None = None) -> Path:
+    if out and out_dir:
+        raise ValueError("provide only one of out or out_dir")
+    if out:
+        path = Path(out)
+    else:
+        root = Path(out_dir or ".state/skill-capture/proposals")
+        path = root / f"{proposal.get('candidate_id')}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    stored = dict(proposal)
+    stored["writes_performed"] = True
+    stored["write_scope"] = "staged_proposal_artifact"
+    path.write_text(json.dumps(stored, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openclaw-context-pack"
-version = "1.9.12"
+version = "1.9.13"
 description = "Local-first AI agent memory governance: Store / Pack / Observe with citations, receipts, and rollback"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/skills/self-improvement-consolidation.ops.md
+++ b/skills/self-improvement-consolidation.ops.md
@@ -1,0 +1,35 @@
+# self-improvement-consolidation.ops
+
+Use for operating the OpenClaw Mem self-improvement consolidation surfaces.
+
+## Surfaces
+
+Read-only / report-only / staged-only commands:
+
+```bash
+openclaw-mem surface validate --inventory surfaces.json --receipt receipt.json --json
+openclaw-mem goal status --file goal.json --json
+openclaw-mem goal pack --file goal.json --json
+openclaw-mem skill-capture propose --text "..." --out proposal.json --json
+openclaw-mem skill-curator review --skill-root skills --json
+openclaw-mem mem-system status --json
+```
+
+## Authority rules
+
+- `goal status`, `goal pack`, and `mem-system status` are read-only.
+- `skill-curator review` is non-mutating report-only: it may write review JSON/Markdown artifacts under `--out-root`, or payload-only with `--no-write`.
+- `skill-capture propose` may write only an explicit L1 staged proposal artifact.
+- No command in slices 2–5 patches live skills, schedules cron, changes gateway/plugin config, or enables auto-continuation.
+- L3/L4 surfaces remain manual/CK approval territory.
+
+## Verifier posture
+
+Before claiming a slice is installed:
+
+1. Run targeted pytest.
+2. Run CLI smoke for every new command.
+3. Run MkDocs strict build for public docs.
+4. Run public-facing second-brain review before public push.
+5. Run local editable install smoke.
+6. Write WAL with topology impact and rollback.

--- a/tests/test_goal_primitive.py
+++ b/tests/test_goal_primitive.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from openclaw_mem.active_line_context import build_active_line_context
 from openclaw_mem.goal_primitive import build_goal_status, load_goal_receipt, render_goal_status
 
 
@@ -55,6 +56,23 @@ class TestGoalPrimitive(unittest.TestCase):
             bad.write_text("[]", encoding="utf-8")
             with self.assertRaises(ValueError):
                 load_goal_receipt(bad)
+
+    def test_goal_receipt_can_feed_context_pack_fragment(self):
+        receipt = {
+            "goal": {
+                "goal_id": "survival-pack",
+                "objective": "Survive compaction",
+                "status": "active",
+                "next_gate": "pack current gate",
+                "continuation_owner": "operator",
+                "completion_verifier": "context fragment readback",
+            }
+        }
+        fragment = build_active_line_context(receipt, source_ref="test://goal")
+        self.assertFalse(fragment["writes_performed"])
+        self.assertEqual(fragment["active_line"]["goal_id"], "survival-pack")
+        self.assertTrue(fragment["active_line"]["has_verifier"])
+        self.assertIn("active-line:survival-pack", fragment["context_pack_fragment"]["bundle_text"])
 
 
 if __name__ == "__main__":

--- a/tests/test_mem_system_status.py
+++ b/tests/test_mem_system_status.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from openclaw_mem.mem_system_status import build_status, render_status
+
+
+class TestMemSystemStatus(unittest.TestCase):
+    def test_builds_read_only_plane_status(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            state = Path(tmp) / "state"
+            (root / "openclaw_mem").mkdir(parents=True)
+            (root / "openclaw_mem" / "context_pack_v1.py").write_text("", encoding="utf-8")
+            (root / "openclaw_mem" / "goal_primitive.py").write_text("", encoding="utf-8")
+            (root / "openclaw_mem" / "self_curator.py").write_text("", encoding="utf-8")
+            (root / "openclaw_mem" / "skill_capture.py").write_text("", encoding="utf-8")
+            (root / "openclaw_mem" / "steward_review.py").write_text("", encoding="utf-8")
+            (state / "memory" / "lancedb").mkdir(parents=True)
+            (state / "memory" / "openclaw-mem.sqlite").write_text("", encoding="utf-8")
+            status = build_status(workspace_root=root, state_root=state)
+        self.assertTrue(status["ok"])
+        self.assertFalse(status["writes_performed"])
+        self.assertFalse(status["topology_changed"])
+        self.assertIn("Store", status["planes"])
+        self.assertGreaterEqual(status["counts_by_state"].get("stable", 0), 3)
+        self.assertIn("writes_performed=false", render_status(status))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_self_improvement_cli.py
+++ b/tests/test_self_improvement_cli.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_cli(*args: str, cwd: Path | None = None) -> dict:
+    proc = subprocess.run(
+        [sys.executable, "-m", "openclaw_mem", *args],
+        cwd=cwd,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return json.loads(proc.stdout)
+
+
+def test_goal_pack_cli(tmp_path: Path):
+    goal = tmp_path / "goal.json"
+    goal.write_text(
+        json.dumps(
+            {
+                "goal": {
+                    "goal_id": "cli-goal",
+                    "objective": "Survive compaction",
+                    "status": "active",
+                    "next_gate": "pack",
+                    "continuation_owner": "operator",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    out = tmp_path / "goal-pack.json"
+    payload = run_cli("goal", "pack", "--file", str(goal), "--out", str(out), "--json")
+    assert payload["context"]["writes_performed"] is False
+    assert "active-line:cli-goal" in payload["context"]["context_pack_fragment"]["bundle_text"]
+    assert out.exists()
+
+
+def test_skill_capture_cli_writes_staged_artifact(tmp_path: Path):
+    out = tmp_path / "proposal.json"
+    payload = run_cli(
+        "skill-capture",
+        "propose",
+        "--text",
+        "Refresh uv.lock after version bumps.",
+        "--target-skill",
+        "ck-software-engineering-ops",
+        "--rationale",
+        "CI freshness",
+        "--out",
+        str(out),
+        "--json",
+    )
+    assert payload["ok"] is True
+    assert payload["writes_performed"] is True
+    assert payload["write_scope"] == "staged_proposal_artifact"
+    stored = json.loads(out.read_text(encoding="utf-8"))
+    assert stored["schema_version"] == "openclaw-mem.skill-capture.proposal.v0"
+
+
+def test_skill_curator_cli_no_write_payload_only(tmp_path: Path):
+    skill_root = tmp_path / "skills"
+    skill_dir = skill_root / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: Demo skill\n---\n\n" + "Body " * 80,
+        encoding="utf-8",
+    )
+    out_root = tmp_path / "runs"
+    payload = run_cli(
+        "skill-curator",
+        "review",
+        "--skill-root",
+        str(skill_root),
+        "--out-root",
+        str(out_root),
+        "--no-write",
+        "--json",
+    )
+    assert payload["mode"] == "review_only"
+    assert payload["writes_performed"] == 0
+    assert payload["artifacts"] == {}
+    assert not out_root.exists()
+
+
+def test_mem_system_status_cli(tmp_path: Path):
+    payload = run_cli("mem-system", "status", "--workspace-root", ".", "--state-root", str(tmp_path), "--json")
+    assert payload["ok"] is True
+    assert payload["writes_performed"] is False
+    assert payload["topology_changed"] is False
+    assert "Store" in payload["planes"]

--- a/tests/test_skill_capture.py
+++ b/tests/test_skill_capture.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from openclaw_mem.skill_capture import MAX_TEXT_CHARS, build_proposal, write_proposal
+
+
+class TestSkillCapture(unittest.TestCase):
+    def test_builds_l1_staged_proposal_without_live_write(self):
+        proposal = build_proposal(
+            text="When a command changes package version, refresh uv.lock before PR checks.",
+            source_ref="test://turn",
+            target_skill="ck-software-engineering-ops",
+            rationale="prevents CI lockfile failure",
+            run_id="demo-run",
+        )
+        self.assertTrue(proposal["ok"])
+        self.assertEqual(proposal["mode"], "stage")
+        self.assertEqual(proposal["risk_class"], "L1")
+        self.assertFalse(proposal["writes_performed"])
+        self.assertEqual(proposal["target_skill"], "ck-software-engineering-ops")
+
+    def test_rejects_path_like_target_skill(self):
+        proposal = build_proposal(text="x", target_skill="../SKILL.md")
+        self.assertFalse(proposal["ok"])
+        self.assertIn("target_skill", " ".join(proposal["errors"]))
+
+    def test_rejects_oversized_text(self):
+        proposal = build_proposal(text="x" * (MAX_TEXT_CHARS + 1))
+        self.assertFalse(proposal["ok"])
+        self.assertIn("exceeds", " ".join(proposal["errors"]))
+
+    def test_write_proposal_marks_only_staged_artifact_write(self):
+        proposal = build_proposal(text="Capture this learning", rationale="demo")
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_proposal(proposal, out_dir=tmp)
+            stored = json.loads(Path(path).read_text(encoding="utf-8"))
+            self.assertTrue(stored["writes_performed"])
+            self.assertEqual(stored["write_scope"], "staged_proposal_artifact")
+            self.assertTrue(Path(path).name.startswith("skill-capture-"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -372,7 +372,7 @@ wheels = [
 
 [[package]]
 name = "openclaw-context-pack"
-version = "1.9.12"
+version = "1.9.13"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Completes self-improvement consolidation slices 2–5 as read-only / report-only / staged-only product surfaces:

- Slice 2: `openclaw-mem goal pack` goal-survival pack seam
- Slice 3: `openclaw-mem skill-capture propose` L1 staged proposal path
- Slice 4: `openclaw-mem skill-curator review` non-mutating report-only curator alias
- Slice 5: `openclaw-mem mem-system status` Store / Pack / Observe / Review / Curate inventory

Also prepares `v1.9.13` release metadata and docs.

## Verification

- `uv run python -m pytest tests/test_goal_primitive.py tests/test_skill_capture.py tests/test_mem_system_status.py tests/test_self_improvement_surface.py tests/test_active_line_context.py tests/test_self_improvement_cli.py`
  - `27 passed`
- CLI smoke passed for:
  - `goal pack`
  - `skill-capture propose`
  - `skill-curator review` artifact-writing and `--no-write` payload-only paths
  - `mem-system status`
- `uv run --with mkdocs --with mkdocs-material mkdocs build --strict`
  - built successfully
- Claude public-facing review ran twice:
  - first pass held for wording/release metadata fixes
  - second pass approved public push
- Local editable install smoke:
  - `openclaw-context-pack==1.9.13`
  - installed CLI readbacks passed for the four new command groups

## Topology impact

Unchanged.

No cron, gateway, plugin config, model routing, auto-continuation, governed apply, or live skill mutation was enabled.

## Release note

Recommended tag after merge: `v1.9.13`.
