### PR TITLE
feat: add staged mutation framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.14] - 2026-05-12
+
+### Added
+
+- Added `openclaw-mem mutation plan|validate|stage|apply|rollback`, a local staged mutation framework for synthetic L0-L2 fixture apply with rollback receipts.
+- Added public Slice 6 documentation and receipt for the staged mutation framework.
+
+### Safety
+
+- Slice 6 apply is confined to `--allowed-root`, blocks absolute/traversal paths, and rejects protected/L3/L4/manual-approval mutations.
+- Failed multi-step applies restore already-applied changes and return `failed_closed`.
+
+### Testing
+
+- Added unit and CLI integration coverage for plan/stage/apply/rollback, L3/L4/protected blocking, path escape blocking, and rollback-on-failure.
+
 ## [1.9.13] - 2026-05-12
 
 ### Added

--- a/docs/2026-05-12_self-improvement-slice-6-receipt.md
+++ b/docs/2026-05-12_self-improvement-slice-6-receipt.md
@@ -1,0 +1,38 @@
+# Self-improvement Slice 6 receipt — 2026-05-12
+
+## Summary
+
+Implemented the local staged mutation framework for OpenClaw Mem self-improvement work.
+
+New command group:
+
+```bash
+openclaw-mem mutation plan
+openclaw-mem mutation validate
+openclaw-mem mutation stage
+openclaw-mem mutation apply
+openclaw-mem mutation rollback
+```
+
+## Authority posture
+
+- Synthetic/local fixture apply only.
+- `--allowed-root` confines writes to a bounded local directory.
+- L3/L4/protected/manual-approval mutations are blocked.
+- No OpenClaw core, gateway, plugin config, cron, model routing, or live skill mutation is enabled.
+
+## Verification plan
+
+- targeted unit tests and CLI integration tests
+- CLI smoke for plan/stage/apply/rollback
+- MkDocs strict build
+- Claude public-facing review
+- local editable install smoke
+
+## Topology impact
+
+Unchanged.
+
+## Rollback
+
+Revert the implementation commit or release from the previous tag. No runtime topology rollback is needed.

--- a/docs/self-improvement-slice-6.md
+++ b/docs/self-improvement-slice-6.md
@@ -1,0 +1,73 @@
+# Self-improvement Slice 6: staged mutation framework
+
+Slice 6 introduces a narrow local mutation framework for OpenClaw Mem self-improvement work.
+
+It is intentionally not a general-purpose self-modification runtime. It provides a reviewable `plan → stage → apply → rollback` loop for local fixture files so future governed-apply work can reuse a tested receipt shape.
+
+## Commands
+
+Build a plan:
+
+```bash
+openclaw-mem mutation plan --mutations-file mutations.json --out plan.json --json
+```
+
+Validate a plan:
+
+```bash
+openclaw-mem mutation validate --plan-file plan.json --allowed-root .state/mutation-framework/sandbox --allow-apply --json
+```
+
+Stage review artifacts:
+
+```bash
+openclaw-mem mutation stage --plan-file plan.json --allowed-root .state/mutation-framework/sandbox --json
+```
+
+Apply synthetic/local fixture mutations:
+
+```bash
+openclaw-mem mutation apply --plan-file plan.json --allowed-root .state/mutation-framework/sandbox --json
+```
+
+Rollback an apply receipt:
+
+```bash
+openclaw-mem mutation rollback --receipt .state/mutation-framework/apply-runs/<run>/apply-receipt.json --json
+```
+
+## Supported actions
+
+- `write_file`
+- `replace_text`
+
+## Safety boundaries
+
+Slice 6 apply is limited to local fixture paths under `--allowed-root`. The default `--allowed-root` is relative to the current working directory; use an absolute path for repeatable operator runs.
+
+Validation blocks L3/L4/protected/manual-approval mutations unconditionally, even when you are only validating and not applying.
+
+It blocks:
+
+- absolute paths
+- `..` path traversal
+- protected mutations
+- L3/L4 mutations
+- mutations requiring manual approval
+- apply attempts outside the configured allowed root
+- missing or empty `mutations` lists in CLI input
+
+If any mutation in a plan fails during apply, the framework restores already-applied changes and returns `failed_closed`. Staging can still write review artifacts for an invalid plan; the stage receipt will have `ok=false` and must not be treated as apply approval.
+
+## What this does not enable
+
+- no OpenClaw core changes
+- no Gateway or plugin config changes
+- no cron changes
+- no live skill mutation
+- no governed real apply to production surfaces
+- no L3/L4 automatic mutation
+
+## Relationship to Slice 7
+
+Slice 7 can build on this receipt shape to add governed allowlists, approval boundaries, release gates, and stale-rule retirement checks. Slice 6 deliberately stops before those higher-risk live boundaries.

--- a/docs/specs/self-improvement-slice-6-blade-map-v0.md
+++ b/docs/specs/self-improvement-slice-6-blade-map-v0.md
@@ -1,0 +1,36 @@
+# Self-improvement Slice 6 — blade map v0
+
+Date: 2026-05-12
+Status: implementation blade map
+
+## Goal
+
+Implement a local staged mutation framework with reviewable `plan → stage → apply → rollback` receipts.
+
+## Boundary
+
+- Repo: `openclaw-mem` only.
+- No OpenClaw core/runtime changes.
+- Apply is limited to synthetic/local fixture files under `--allowed-root`.
+- L3/L4/protected/manual-approval mutations are blocked.
+
+## Outputs
+
+- `openclaw_mem/mutation_framework.py`
+- `openclaw-mem mutation plan|validate|stage|apply|rollback`
+- Unit and CLI integration tests
+- Public docs and receipt
+- Version/changelog for release
+
+## Verifier plan
+
+- targeted pytest for mutation framework and CLI
+- counterfactual tests for L3/L4/protected/path escape/failure rollback
+- CLI smoke for plan/stage/apply/rollback
+- MkDocs strict build
+- Claude public-facing review before push
+- local editable install smoke
+
+## Rollback
+
+Revert the Slice 6 commit or release from prior tag `v1.9.13`. No runtime topology rollback is required.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
       - Core vs Advanced Labs: core-vs-advanced-labs.md
       - Self-improvement goal pilot: self-improvement-goal-pilot.md
       - Self-improvement slices 2–5: self-improvement-slices-2-5.md
+      - Self-improvement Slice 6: self-improvement-slice-6.md
       - Governed optimize assist: optimize-assist.md
       - Verbatim semantic lane: verbatim-semantic-lane.md
       - Dual-language memory strategy: dual-language-memory-strategy.md

--- a/openclaw_mem/__init__.py
+++ b/openclaw_mem/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "1.9.13"
+__version__ = "1.9.14"

--- a/openclaw_mem/cli.py
+++ b/openclaw_mem/cli.py
@@ -43,6 +43,7 @@ from openclaw_mem import ingestion_review
 from openclaw_mem import gbrain_sidecar
 from openclaw_mem import goal_primitive
 from openclaw_mem import mem_system_status
+from openclaw_mem import mutation_framework
 from openclaw_mem import pack_trace_v1
 from openclaw_mem import self_model_sidecar
 from openclaw_mem import self_curator
@@ -10809,6 +10810,70 @@ def cmd_mem_system_status(conn: sqlite3.Connection, args: argparse.Namespace) ->
         print(mem_system_status.render_status(payload))
 
 
+def _load_mutation_input(args: argparse.Namespace) -> dict[str, Any]:
+    if getattr(args, "plan_file", None):
+        return mutation_framework.load_json(args.plan_file)
+    if getattr(args, "mutations_file", None):
+        data = mutation_framework.load_json(args.mutations_file)
+        if not isinstance(data.get("mutations"), list) or not data.get("mutations"):
+            raise SystemExit("mutations file must contain a non-empty {'mutations': [...]} list")
+        mutations = data.get("mutations")
+        return mutation_framework.build_plan(mutations=mutations, plan_id=getattr(args, "plan_id", None), source_ref=getattr(args, "source_ref", None))
+    raise SystemExit("provide --plan-file or --mutations-file")
+
+
+def cmd_mutation_plan(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    data = mutation_framework.load_json(args.mutations_file)
+    if not isinstance(data.get("mutations"), list) or not data.get("mutations"):
+        raise SystemExit("mutations file must contain a non-empty {'mutations': [...]} list")
+    mutations = data.get("mutations")
+    payload = mutation_framework.build_plan(mutations=mutations, plan_id=getattr(args, "plan_id", None), source_ref=getattr(args, "source_ref", None))
+    if getattr(args, "out", None):
+        mutation_framework.write_json(args.out, payload)
+    if bool(getattr(args, "json", False)):
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(f"mutation_plan plan_id={payload['plan_id']} mutations={len(payload['mutations'])} writes_performed=false")
+
+
+def cmd_mutation_validate(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    plan = _load_mutation_input(args)
+    payload = mutation_framework.validate_plan(plan, allowed_root=getattr(args, "allowed_root"), allow_apply=getattr(args, "allow_apply", False))
+    if getattr(args, "out", None):
+        mutation_framework.write_json(args.out, payload)
+    if bool(getattr(args, "json", False)):
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(f"mutation_validate ok={str(payload['ok']).lower()} mutations={payload['mutation_count']} writes_performed=false")
+
+
+def cmd_mutation_stage(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    plan = _load_mutation_input(args)
+    payload = mutation_framework.stage_plan(plan, stage_root=getattr(args, "stage_root"), allowed_root=getattr(args, "allowed_root"))
+    if bool(getattr(args, "json", False)):
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(f"mutation_stage ok={str(payload['ok']).lower()} stage_id={payload['stage_id']} writes_performed=true")
+
+
+def cmd_mutation_apply(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    plan = _load_mutation_input(args)
+    payload = mutation_framework.apply_plan(plan, allowed_root=getattr(args, "allowed_root"), receipt_root=getattr(args, "receipt_root"))
+    if bool(getattr(args, "json", False)):
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(f"mutation_apply ok={str(payload['ok']).lower()} mode={payload['mode']} writes_performed={str(payload['writes_performed']).lower()}")
+
+
+def cmd_mutation_rollback(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    receipt = mutation_framework.load_json(args.receipt)
+    payload = mutation_framework.rollback_apply_receipt(receipt, out_root=getattr(args, "out_root", None))
+    if bool(getattr(args, "json", False)):
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(f"mutation_rollback ok={str(payload['ok']).lower()} restored={len(payload['restored'])} writes_performed={str(payload['writes_performed']).lower()}")
+
+
 def cmd_self_curator_plan(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
     mutations = json.loads(Path(args.mutations_file).read_text(encoding="utf-8"))
     if isinstance(mutations, dict) and "mutations" in mutations:
@@ -19984,6 +20049,56 @@ def build_parser() -> argparse.ArgumentParser:
     ms.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Structured JSON output")
     ms.set_defaults(func=cmd_mem_system_status)
 
+    sp = sub.add_parser("mutation", help="Local staged mutation framework (synthetic L0-L2 only)")
+    musub = sp.add_subparsers(dest="mutation_cmd", required=True)
+    mp = musub.add_parser("plan", help="Build a mutation plan from a JSON mutations list")
+    mp.add_argument("--mutations-file", required=True, help="JSON object containing {'mutations': [...]} list")
+    mp.add_argument("--plan-id", help="Optional plan id")
+    mp.add_argument("--source-ref", help="Optional public-safe source reference")
+    mp.add_argument("--out", help="Optional output plan JSON path")
+    mp.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Structured JSON output")
+    mp.set_defaults(func=cmd_mutation_plan)
+
+    mv = musub.add_parser("validate", help="Validate a mutation plan against a local allowed root")
+    mv_src = mv.add_mutually_exclusive_group(required=True)
+    mv_src.add_argument("--plan-file", help="Plan JSON file")
+    mv_src.add_argument("--mutations-file", help="JSON object containing {'mutations': [...]} list")
+    mv.add_argument("--allowed-root", default=".state/mutation-framework/sandbox", help="Allowed local fixture root")
+    mv.add_argument("--allow-apply", action="store_true", help="Also enforce Slice 6 synthetic apply risk floor")
+    mv.add_argument("--plan-id", help="Optional plan id when using --mutations-file")
+    mv.add_argument("--source-ref", help="Optional public-safe source reference")
+    mv.add_argument("--out", help="Optional validation receipt path")
+    mv.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Structured JSON output")
+    mv.set_defaults(func=cmd_mutation_validate)
+
+    mst = musub.add_parser("stage", help="Stage a validated mutation plan as reviewable artifacts")
+    mst_src = mst.add_mutually_exclusive_group(required=True)
+    mst_src.add_argument("--plan-file", help="Plan JSON file")
+    mst_src.add_argument("--mutations-file", help="JSON object containing {'mutations': [...]} list")
+    mst.add_argument("--allowed-root", default=".state/mutation-framework/sandbox", help="Allowed local fixture root")
+    mst.add_argument("--stage-root", default=".state/mutation-framework/staged", help="Stage artifact root")
+    mst.add_argument("--plan-id", help="Optional plan id when using --mutations-file")
+    mst.add_argument("--source-ref", help="Optional public-safe source reference")
+    mst.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Structured JSON output")
+    mst.set_defaults(func=cmd_mutation_stage)
+
+    ma = musub.add_parser("apply", help="Apply L0-L2 synthetic/local fixture mutations with rollback receipt")
+    ma_src = ma.add_mutually_exclusive_group(required=True)
+    ma_src.add_argument("--plan-file", help="Plan JSON file")
+    ma_src.add_argument("--mutations-file", help="JSON object containing {'mutations': [...]} list")
+    ma.add_argument("--allowed-root", default=".state/mutation-framework/sandbox", help="Allowed local fixture root")
+    ma.add_argument("--receipt-root", default=".state/mutation-framework/apply-runs", help="Apply receipt root")
+    ma.add_argument("--plan-id", help="Optional plan id when using --mutations-file")
+    ma.add_argument("--source-ref", help="Optional public-safe source reference")
+    ma.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Structured JSON output")
+    ma.set_defaults(func=cmd_mutation_apply)
+
+    mr = musub.add_parser("rollback", help="Rollback a synthetic apply receipt")
+    mr.add_argument("--receipt", required=True, help="Apply receipt JSON")
+    mr.add_argument("--out-root", help="Optional directory to write rollback-receipt.json")
+    mr.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Structured JSON output")
+    mr.set_defaults(func=cmd_mutation_rollback)
+
     sp = sub.add_parser("self-curator", help="Lifecycle curator engine (review + checkpointed apply)")
     scsub = sp.add_subparsers(dest="self_curator_cmd", required=True)
     sc = scsub.add_parser("skill-review", help="Scan skill files and emit review-only lifecycle artifacts")
@@ -20173,7 +20288,7 @@ def main() -> None:
         or (dream_lite_cmd == "apply" and dream_lite_apply_cmd in {"plan", "verify"})
     )
     file_only_snapshot = cmd in {"continuity", "self"} and self_cmd in {"attachment-map", "threat-feed", "adjudication", "public-summary", "explain", "sensitivity", "triggers", "interventions", "wording-lint"} and bool(getattr(args, "snapshot", None))
-    no_db_path = cmd in {"capsule", "self-curator", "skill-curator", "steward", "ingest-review", "active-line", "surface", "goal", "skill-capture", "mem-system", "harness", "codex"} or dream_lite_no_db or (cmd == "optimize" and optimize_cmd in {"canary-advisory"}) or (cmd in {"continuity", "self"} and self_cmd in {"diff", "release", "release-history", "status", "enable", "disable", "patterns"}) or file_only_snapshot
+    no_db_path = cmd in {"capsule", "self-curator", "skill-curator", "steward", "ingest-review", "active-line", "surface", "goal", "skill-capture", "mem-system", "mutation", "harness", "codex"} or dream_lite_no_db or (cmd == "optimize" and optimize_cmd in {"canary-advisory"}) or (cmd in {"continuity", "self"} and self_cmd in {"diff", "release", "release-history", "status", "enable", "disable", "patterns"}) or file_only_snapshot
 
     if no_db_path:
         # Some command families own their own file-only semantics.

--- a/openclaw_mem/mutation_framework.py
+++ b/openclaw_mem/mutation_framework.py
@@ -1,0 +1,297 @@
+"""Local staged mutation framework for self-improvement Slice 6.
+
+This framework is deliberately narrow.  It supports plan -> stage -> synthetic
+apply -> rollback for local fixture files only, so higher-risk governed apply
+work can be built later without changing OpenClaw core/runtime topology.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+PLAN_SCHEMA = "openclaw-mem.mutation.plan.v0"
+STAGE_SCHEMA = "openclaw-mem.mutation.stage.v0"
+APPLY_SCHEMA = "openclaw-mem.mutation.apply.v0"
+ROLLBACK_SCHEMA = "openclaw-mem.mutation.rollback.v0"
+VALID_RISK = {"L0", "L1", "L2", "L3", "L4"}
+APPLY_ALLOWED_RISK = {"L0", "L1", "L2"}
+VALID_ACTIONS = {"write_file", "replace_text"}
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_json(path: str | Path) -> dict[str, Any]:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("expected JSON object")
+    return data
+
+
+def write_json(path: str | Path, payload: Mapping[str, Any]) -> Path:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return p
+
+
+def stable_id(seed: str) -> str:
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def _mutation_id(m: Mapping[str, Any]) -> str:
+    raw = "\0".join([str(m.get("action") or ""), str(m.get("path") or ""), str(m.get("content") or ""), str(m.get("old") or ""), str(m.get("new") or "")])
+    return "mut-" + stable_id(raw)
+
+
+def _normalize_mutation(raw: Mapping[str, Any]) -> dict[str, Any]:
+    action = str(raw.get("action") or "").strip()
+    path = str(raw.get("path") or "").strip()
+    risk = str(raw.get("risk_class") or "L1").strip()
+    mutation = {
+        "mutation_id": str(raw.get("mutation_id") or _mutation_id(raw)),
+        "action": action,
+        "path": path,
+        "risk_class": risk,
+        "protected": bool(raw.get("protected", False)),
+        "requires_approval": bool(raw.get("requires_approval", False)),
+    }
+    for key in ("content", "old", "new", "rationale"):
+        if key in raw:
+            mutation[key] = raw.get(key)
+    return mutation
+
+
+def build_plan(*, mutations: list[Mapping[str, Any]], plan_id: str | None = None, source_ref: str | None = None) -> dict[str, Any]:
+    normalized = [_normalize_mutation(m) for m in mutations]
+    seed = json.dumps(normalized, ensure_ascii=False, sort_keys=True)
+    return {
+        "schema_version": PLAN_SCHEMA,
+        "plan_id": plan_id or "mutation-plan-" + stable_id(seed),
+        "mode": "plan",
+        "source_ref": source_ref,
+        "writes_performed": False,
+        "mutations": normalized,
+        "created_at": now_iso(),
+    }
+
+
+def _safe_target(path: str, *, allowed_root: Path) -> Path:
+    if not path:
+        raise ValueError("path_required")
+    p = Path(path)
+    if p.is_absolute():
+        raise ValueError("absolute_paths_forbidden")
+    if any(part in {"..", ""} for part in p.parts):
+        raise ValueError("path_traversal_forbidden")
+    root = allowed_root.expanduser().resolve()
+    target = (root / p).resolve()
+    try:
+        target.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("target_outside_allowed_root") from exc
+    return target
+
+
+def validate_plan(plan: Mapping[str, Any], *, allowed_root: str | Path, allow_apply: bool = False) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    mutations = plan.get("mutations")
+    if plan.get("schema_version") != PLAN_SCHEMA:
+        errors.append("invalid_plan_schema")
+    if not isinstance(mutations, list):
+        errors.append("mutations must be a list")
+        mutations = []
+    root = Path(allowed_root)
+    for idx, item in enumerate(mutations):
+        if not isinstance(item, Mapping):
+            errors.append(f"mutations[{idx}] must be an object")
+            continue
+        action = str(item.get("action") or "")
+        risk = str(item.get("risk_class") or "")
+        if action not in VALID_ACTIONS:
+            errors.append(f"mutations[{idx}].action unsupported: {action}")
+        if risk not in VALID_RISK:
+            errors.append(f"mutations[{idx}].risk_class invalid: {risk}")
+        if bool(item.get("protected")):
+            errors.append(f"mutations[{idx}] touches protected surface")
+        if risk in {"L3", "L4"} or bool(item.get("requires_approval")):
+            errors.append(f"mutations[{idx}] requires manual approval; slice6 apply is L0-L2 synthetic only")
+        if allow_apply and risk not in APPLY_ALLOWED_RISK:
+            errors.append(f"mutations[{idx}].risk_class not apply-allowed: {risk}")
+        try:
+            _safe_target(str(item.get("path") or ""), allowed_root=root)
+        except ValueError as exc:
+            errors.append(f"mutations[{idx}].path {exc}")
+        if action == "write_file" and "content" not in item:
+            errors.append(f"mutations[{idx}].content required for write_file")
+        if action == "replace_text":
+            if "old" not in item or "new" not in item:
+                errors.append(f"mutations[{idx}].old/new required for replace_text")
+    return {
+        "schema_version": "openclaw-mem.mutation.validation.v0",
+        "ok": not errors,
+        "writes_performed": False,
+        "allowed_root": str(Path(allowed_root).expanduser()),
+        "mutation_count": len(mutations),
+        "errors": errors,
+        "warnings": warnings,
+        "validated_at": now_iso(),
+    }
+
+
+def stage_plan(plan: Mapping[str, Any], *, stage_root: str | Path, allowed_root: str | Path) -> dict[str, Any]:
+    validation = validate_plan(plan, allowed_root=allowed_root, allow_apply=False)
+    stage_id = "stage-" + stable_id(json.dumps(plan, ensure_ascii=False, sort_keys=True) + str(allowed_root))
+    stage_dir = Path(stage_root) / stage_id
+    payload = {
+        "schema_version": STAGE_SCHEMA,
+        "ok": bool(validation["ok"]),
+        "stage_id": stage_id,
+        "plan_id": plan.get("plan_id"),
+        "writes_performed": True,
+        "write_scope": "staged_mutation_artifact",
+        "allowed_root": str(Path(allowed_root).expanduser()),
+        "validation": validation,
+        "created_at": now_iso(),
+    }
+    stage_dir.mkdir(parents=True, exist_ok=True)
+    write_json(stage_dir / "plan.json", plan)
+    write_json(stage_dir / "stage-receipt.json", payload)
+    payload["stage_dir"] = str(stage_dir)
+    return payload
+
+
+def _snapshot_target(target: Path, backup_dir: Path, rel: str) -> dict[str, Any]:
+    backup_path = backup_dir / rel
+    if target.exists():
+        backup_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(target, backup_path)
+        before = target.read_text(encoding="utf-8")
+        existed = True
+    else:
+        before = None
+        existed = False
+    return {"path": rel, "existed": existed, "backup_path": str(backup_path) if existed else None, "before_sha256": hashlib.sha256((before or "").encode("utf-8")).hexdigest() if existed else None}
+
+
+def apply_plan(plan: Mapping[str, Any], *, allowed_root: str | Path, receipt_root: str | Path) -> dict[str, Any]:
+    validation = validate_plan(plan, allowed_root=allowed_root, allow_apply=True)
+    run_id = "apply-" + stable_id(json.dumps(plan, ensure_ascii=False, sort_keys=True) + now_iso())
+    run_dir = Path(receipt_root) / run_id
+    backup_dir = run_dir / "backups"
+    applied: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    root = Path(allowed_root).expanduser().resolve()
+    if not validation["ok"]:
+        payload = {
+            "schema_version": APPLY_SCHEMA,
+            "ok": False,
+            "mode": "failed_closed",
+            "run_id": run_id,
+            "writes_performed": False,
+            "validation": validation,
+            "mutations_applied": applied,
+            "mutations_skipped": [],
+            "rollback_available": False,
+            "created_at": now_iso(),
+        }
+        write_json(run_dir / "apply-receipt.json", payload)
+        return payload
+    run_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        for item in plan.get("mutations") or []:
+            m = dict(item)
+            rel = str(m["path"])
+            target = _safe_target(rel, allowed_root=root)
+            snapshot = _snapshot_target(target, backup_dir, rel)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if m["action"] == "write_file":
+                target.write_text(str(m.get("content") or ""), encoding="utf-8")
+            elif m["action"] == "replace_text":
+                if not target.exists():
+                    skipped.append({"mutation_id": m.get("mutation_id"), "path": rel, "reason": "target_missing"})
+                    break
+                text = target.read_text(encoding="utf-8")
+                old = str(m.get("old"))
+                if text.count(old) != 1:
+                    skipped.append({"mutation_id": m.get("mutation_id"), "path": rel, "reason": "old_text_not_unique"})
+                    break
+                target.write_text(text.replace(old, str(m.get("new")), 1), encoding="utf-8")
+            after = target.read_text(encoding="utf-8")
+            applied.append({"mutation_id": m.get("mutation_id"), "action": m.get("action"), "path": rel, "snapshot": snapshot, "after_sha256": hashlib.sha256(after.encode("utf-8")).hexdigest()})
+    except Exception as exc:  # fail closed and let rollback receipt explain what happened
+        skipped.append({"reason": "exception", "exception": repr(exc)})
+
+    if skipped:
+        rollback = rollback_apply_receipt({"schema_version": APPLY_SCHEMA, "run_id": run_id, "allowed_root": str(root), "mutations_applied": applied}, out_root=run_dir)
+        applied = []
+        mode = "failed_closed"
+    else:
+        rollback = None
+        mode = "applied" if applied else "noop"
+    payload = {
+        "schema_version": APPLY_SCHEMA,
+        "ok": not skipped,
+        "mode": mode,
+        "run_id": run_id,
+        "plan_id": plan.get("plan_id"),
+        "allowed_root": str(root),
+        "writes_performed": bool(applied),
+        "mutations_applied": applied,
+        "mutations_skipped": skipped,
+        "rollback_available": bool(applied),
+        "rollback_receipt": rollback,
+        "created_at": now_iso(),
+    }
+    write_json(run_dir / "apply-receipt.json", payload)
+    payload["receipt_path"] = str(run_dir / "apply-receipt.json")
+    return payload
+
+
+def rollback_apply_receipt(receipt: Mapping[str, Any], *, out_root: str | Path | None = None) -> dict[str, Any]:
+    root = Path(str(receipt.get("allowed_root") or ".")).expanduser().resolve()
+    restored: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for item in reversed(receipt.get("mutations_applied") or []):
+        if not isinstance(item, Mapping):
+            continue
+        snap = item.get("snapshot") if isinstance(item.get("snapshot"), Mapping) else {}
+        rel = str(item.get("path") or snap.get("path") or "")
+        try:
+            target = _safe_target(rel, allowed_root=root)
+        except ValueError as exc:
+            errors.append(f"{rel}:{exc}")
+            continue
+        if snap.get("existed"):
+            backup = Path(str(snap.get("backup_path") or ""))
+            if not backup.exists():
+                errors.append(f"missing_backup:{rel}")
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(backup, target)
+            action = "restored"
+        else:
+            if target.exists():
+                target.unlink()
+            action = "deleted_created_file"
+        restored.append({"path": rel, "action": action})
+    payload = {
+        "schema_version": ROLLBACK_SCHEMA,
+        "ok": not errors,
+        "run_id": "rollback-" + stable_id(str(receipt.get("run_id")) + now_iso()),
+        "source_apply_run_id": receipt.get("run_id"),
+        "writes_performed": bool(restored),
+        "restored": restored,
+        "errors": errors,
+        "created_at": now_iso(),
+    }
+    if out_root:
+        write_json(Path(out_root) / "rollback-receipt.json", payload)
+    return payload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openclaw-context-pack"
-version = "1.9.13"
+version = "1.9.14"
 description = "Local-first AI agent memory governance: Store / Pack / Observe with citations, receipts, and rollback"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/tests/test_mutation_cli.py
+++ b/tests/test_mutation_cli.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_cli(*args: str) -> dict:
+    proc = subprocess.run([sys.executable, "-m", "openclaw_mem", *args], check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return json.loads(proc.stdout)
+
+
+def test_mutation_cli_plan_stage_apply_rollback(tmp_path: Path):
+    mutations = tmp_path / "mutations.json"
+    mutations.write_text(json.dumps({"mutations": [{"action": "write_file", "path": "demo.txt", "content": "hello", "risk_class": "L1"}]}), encoding="utf-8")
+    plan = tmp_path / "plan.json"
+    payload = run_cli("mutation", "plan", "--mutations-file", str(mutations), "--out", str(plan), "--json")
+    assert payload["schema_version"] == "openclaw-mem.mutation.plan.v0"
+    sandbox = tmp_path / "sandbox"
+    validation = run_cli("mutation", "validate", "--plan-file", str(plan), "--allowed-root", str(sandbox), "--allow-apply", "--json")
+    assert validation["ok"] is True
+    stage = run_cli("mutation", "stage", "--plan-file", str(plan), "--allowed-root", str(sandbox), "--stage-root", str(tmp_path / "staged"), "--json")
+    assert stage["ok"] is True
+    assert stage["writes_performed"] is True
+    applied = run_cli("mutation", "apply", "--plan-file", str(plan), "--allowed-root", str(sandbox), "--receipt-root", str(tmp_path / "runs"), "--json")
+    assert applied["ok"] is True
+    assert (sandbox / "demo.txt").read_text(encoding="utf-8") == "hello"
+    receipt = Path(applied["receipt_path"])
+    rollback = run_cli("mutation", "rollback", "--receipt", str(receipt), "--out-root", str(tmp_path / "rollback"), "--json")
+    assert rollback["ok"] is True
+    assert not (sandbox / "demo.txt").exists()
+
+
+def test_mutation_cli_blocks_l4(tmp_path: Path):
+    mutations = tmp_path / "mutations.json"
+    mutations.write_text(json.dumps({"mutations": [{"action": "write_file", "path": "demo.txt", "content": "x", "risk_class": "L4"}]}), encoding="utf-8")
+    validation = run_cli("mutation", "validate", "--mutations-file", str(mutations), "--allowed-root", str(tmp_path / "sandbox"), "--allow-apply", "--json")
+    assert validation["ok"] is False
+    assert "manual approval" in " ".join(validation["errors"])

--- a/tests/test_mutation_framework.py
+++ b/tests/test_mutation_framework.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from openclaw_mem.mutation_framework import apply_plan, build_plan, rollback_apply_receipt, stage_plan, validate_plan
+
+
+class TestMutationFramework(unittest.TestCase):
+    def test_plan_validate_stage_apply_and_rollback_write_file(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sandbox"
+            plan = build_plan(mutations=[{"action": "write_file", "path": "demo.txt", "content": "hello", "risk_class": "L1"}])
+            validation = validate_plan(plan, allowed_root=root, allow_apply=True)
+            self.assertTrue(validation["ok"])
+            staged = stage_plan(plan, stage_root=Path(tmp) / "staged", allowed_root=root)
+            self.assertTrue(staged["ok"])
+            self.assertTrue(staged["writes_performed"])
+            applied = apply_plan(plan, allowed_root=root, receipt_root=Path(tmp) / "runs")
+            self.assertTrue(applied["ok"])
+            self.assertTrue(applied["writes_performed"])
+            self.assertEqual((root / "demo.txt").read_text(encoding="utf-8"), "hello")
+            rollback = rollback_apply_receipt(applied)
+            self.assertTrue(rollback["ok"])
+            self.assertTrue(rollback["writes_performed"])
+            self.assertFalse((root / "demo.txt").exists())
+
+    def test_replace_text_roundtrip(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sandbox"
+            root.mkdir()
+            (root / "demo.txt").write_text("before", encoding="utf-8")
+            plan = build_plan(mutations=[{"action": "replace_text", "path": "demo.txt", "old": "before", "new": "after", "risk_class": "L1"}])
+            applied = apply_plan(plan, allowed_root=root, receipt_root=Path(tmp) / "runs")
+            self.assertTrue(applied["ok"])
+            self.assertEqual((root / "demo.txt").read_text(encoding="utf-8"), "after")
+            rollback_apply_receipt(applied)
+            self.assertEqual((root / "demo.txt").read_text(encoding="utf-8"), "before")
+
+    def test_blocks_protected_and_l3_l4(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sandbox"
+            plan = build_plan(mutations=[{"action": "write_file", "path": "demo.txt", "content": "x", "risk_class": "L3", "protected": True}])
+            validation = validate_plan(plan, allowed_root=root, allow_apply=True)
+            self.assertFalse(validation["ok"])
+            joined = " ".join(validation["errors"])
+            self.assertIn("protected", joined)
+            self.assertIn("manual approval", joined)
+
+    def test_blocks_path_escape(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sandbox"
+            plan = build_plan(mutations=[{"action": "write_file", "path": "../escape.txt", "content": "x", "risk_class": "L1"}])
+            validation = validate_plan(plan, allowed_root=root, allow_apply=True)
+            self.assertFalse(validation["ok"])
+            self.assertIn("path", " ".join(validation["errors"]))
+
+    def test_blocks_absolute_path(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sandbox"
+            plan = build_plan(mutations=[{"action": "write_file", "path": "/tmp/escape.txt", "content": "x", "risk_class": "L1"}])
+            validation = validate_plan(plan, allowed_root=root, allow_apply=True)
+            self.assertFalse(validation["ok"])
+            self.assertIn("absolute_paths_forbidden", " ".join(validation["errors"]))
+
+    def test_rollback_missing_backup_fails_closed(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sandbox"
+            receipt = {
+                "schema_version": "openclaw-mem.mutation.apply.v0",
+                "run_id": "apply-demo",
+                "allowed_root": str(root),
+                "mutations_applied": [
+                    {"path": "demo.txt", "snapshot": {"path": "demo.txt", "existed": True, "backup_path": str(Path(tmp) / "missing")}}
+                ],
+            }
+            rollback = rollback_apply_receipt(receipt)
+            self.assertFalse(rollback["ok"])
+            self.assertIn("missing_backup:demo.txt", rollback["errors"])
+
+    def test_failed_apply_rolls_back_partial_changes(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sandbox"
+            root.mkdir()
+            (root / "first.txt").write_text("old", encoding="utf-8")
+            (root / "second.txt").write_text("unchanged", encoding="utf-8")
+            plan = build_plan(
+                mutations=[
+                    {"action": "replace_text", "path": "first.txt", "old": "old", "new": "new", "risk_class": "L1"},
+                    {"action": "replace_text", "path": "second.txt", "old": "missing", "new": "bad", "risk_class": "L1"},
+                ]
+            )
+            applied = apply_plan(plan, allowed_root=root, receipt_root=Path(tmp) / "runs")
+            self.assertFalse(applied["ok"])
+            self.assertEqual((root / "first.txt").read_text(encoding="utf-8"), "old")
+            self.assertEqual((root / "second.txt").read_text(encoding="utf-8"), "unchanged")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -372,7 +372,7 @@ wheels = [
 
 [[package]]
 name = "openclaw-context-pack"
-version = "1.9.13"
+version = "1.9.14"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Adds Slice 6 of the self-improvement consolidation line: a local staged mutation framework for synthetic L0-L2 fixture apply with rollback receipts.

New commands:

- `openclaw-mem mutation plan`
- `openclaw-mem mutation validate`
- `openclaw-mem mutation stage`
- `openclaw-mem mutation apply`
- `openclaw-mem mutation rollback`

## Safety / authority

- Confined to `--allowed-root`
- Blocks absolute paths and `..` traversal
- Blocks protected / L3 / L4 / manual-approval mutations
- Fails closed and restores already-applied changes on multi-step apply failure
- No OpenClaw core, gateway, plugin config, cron, model routing, governed real apply, or live skill mutation is enabled

## Verification

- `uv run python -m pytest tests/test_mutation_framework.py tests/test_mutation_cli.py tests/test_self_improvement_cli.py tests/test_goal_primitive.py`
  - `19 passed`
- CLI smoke passed for plan / validate / stage / apply / rollback
- `uv run --with mkdocs --with mkdocs-material mkdocs build --strict`
  - built successfully
- Claude public-facing review ran twice:
  - first pass approved with minor should-fix items
  - second pass cleared push
- Local editable install smoke:
  - `openclaw-context-pack==1.9.14`
  - installed `openclaw-mem mutation validate` safe and blocked readbacks passed

## Release note

Recommended tag after merge: `v1.9.14`.
