### PR TITLE
feat: add governed release hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.15] - 2026-05-12
+
+### Added
+
+- Added `openclaw-mem governed apply-review`, a review-only approval-boundary receipt for mutation plans.
+- Added `openclaw-mem governed release-check`, a release hardening receipt for version, lockfile, changelog, receipt, and public-doc safety gates.
+- Added public Slice 7 documentation and receipt for governed apply/release hardening.
+
+### Safety
+
+- L2 local apply review requires an explicit config gate; L3/L4 remain blocked from auto-apply even when approval flags are recorded.
+- Release-check does not publish, tag, push, merge, or mutate runtime topology.
+
+### Testing
+
+- Added unit and CLI coverage for L2 gating, L3/L4 blocks, version mismatch, public safety markers, and release-check success.
+
 ## [1.9.14] - 2026-05-12
 
 ### Added

--- a/docs/2026-05-12_self-improvement-slice-7-receipt.md
+++ b/docs/2026-05-12_self-improvement-slice-7-receipt.md
@@ -1,0 +1,36 @@
+# Self-improvement Slice 7 receipt — 2026-05-12
+
+## Summary
+
+Implemented governed apply / release-hardening checks for OpenClaw Mem self-improvement work.
+
+New command group:
+
+```bash
+openclaw-mem governed apply-review
+openclaw-mem governed release-check
+```
+
+## Authority posture
+
+- Review-only receipts.
+- L0/L1 can be allowed for local fixture apply when the underlying Slice 6 plan validates.
+- L2 requires explicit config gate.
+- L3/L4 remain blocked from auto-apply even with approval flags.
+- Release-check does not publish, tag, push, or merge anything.
+
+## Verification plan
+
+- targeted unit tests and CLI tests
+- CLI smoke for apply-review and release-check
+- MkDocs strict build
+- Claude public-facing review
+- local editable install smoke
+
+## Topology impact
+
+Unchanged.
+
+## Rollback
+
+Revert the implementation commit or release from the previous tag. No runtime topology rollback is needed.

--- a/docs/self-improvement-slice-7.md
+++ b/docs/self-improvement-slice-7.md
@@ -1,0 +1,56 @@
+# Self-improvement Slice 7: governed apply and release hardening
+
+Slice 7 adds review-only governance checks around the Slice 6 mutation framework and release process.
+
+It does not enable automatic mutation of production surfaces. It makes approval boundaries and release-readiness gates visible as receipts.
+
+## Commands
+
+Review a mutation plan against approval boundaries:
+
+```bash
+openclaw-mem governed apply-review \
+  --plan-file plan.json \
+  --allowed-root .state/mutation-framework/sandbox \
+  --json
+```
+
+Run a release gate check:
+
+```bash
+openclaw-mem governed release-check \
+  --repo-root . \
+  --expected-version 1.9.15 \
+  --json
+```
+
+## Apply-review policy
+
+- L0/L1: may receive an advisory allow decision for local fixture apply when the Slice 6 plan validates.
+- L2: requires explicit `--l2-enabled` config gate for an advisory allow decision.
+- L3: requires human approval and is still not auto-applyable in this slice.
+- L4: requires CK approval and is still not auto-applyable in this slice.
+
+Slice 7 records approval flags; it does not turn L3/L4 into automatic apply.
+
+## Release-check policy
+
+The release check verifies:
+
+- `pyproject.toml` version matches `openclaw_mem/__init__.py`
+- `uv.lock` mentions the expected version
+- `CHANGELOG.md` has the expected version entry
+- a self-improvement receipt document exists
+- public self-improvement docs do not contain known local/private marker strings, including date-prefixed self-improvement receipts
+
+## What this does not enable
+
+- no OpenClaw core changes
+- no Gateway or plugin config changes
+- no cron changes
+- no live skill mutation
+- no L3/L4 automatic mutation
+- no package publishing
+- no tag push by itself
+
+The command emits receipts only. PR merge, tag push, package publishing, and L3/L4 changes remain separate explicit operator actions.

--- a/docs/specs/self-improvement-slice-7-blade-map-v0.md
+++ b/docs/specs/self-improvement-slice-7-blade-map-v0.md
@@ -1,0 +1,36 @@
+# Self-improvement Slice 7 — blade map v0
+
+Date: 2026-05-12
+Status: implementation blade map
+
+## Goal
+
+Add governed apply review and release-hardening gates as receipt-producing checks.
+
+## Boundary
+
+- Repo: `openclaw-mem` only.
+- Review-only: no mutation apply, publish, tag, cron, gateway, plugin, or OpenClaw core changes.
+- L3/L4 remain blocked from auto-apply even if approval flags are recorded.
+
+## Outputs
+
+- `openclaw_mem/governed_release.py`
+- `openclaw-mem governed apply-review`
+- `openclaw-mem governed release-check`
+- Unit and CLI tests
+- Public docs and receipt
+- Version/changelog update
+
+## Verifier plan
+
+- targeted pytest for governed review and CLI
+- counterfactuals: L2 blocked without config gate, L2 allowed with gate, L3/L4 still blocked, version mismatch fails, public marker fails
+- CLI smoke for apply-review and release-check
+- MkDocs strict build
+- Claude public-facing review before push
+- local editable install smoke
+
+## Rollback
+
+Revert the Slice 7 commit or release from prior tag `v1.9.14`. No runtime topology rollback is required.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
       - Self-improvement goal pilot: self-improvement-goal-pilot.md
       - Self-improvement slices 2–5: self-improvement-slices-2-5.md
       - Self-improvement Slice 6: self-improvement-slice-6.md
+      - Self-improvement Slice 7: self-improvement-slice-7.md
       - Governed optimize assist: optimize-assist.md
       - Verbatim semantic lane: verbatim-semantic-lane.md
       - Dual-language memory strategy: dual-language-memory-strategy.md

--- a/openclaw_mem/__init__.py
+++ b/openclaw_mem/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "1.9.14"
+__version__ = "1.9.15"

--- a/openclaw_mem/cli.py
+++ b/openclaw_mem/cli.py
@@ -41,6 +41,7 @@ from openclaw_mem import active_line_context
 from openclaw_mem import context_pack_v1
 from openclaw_mem import ingestion_review
 from openclaw_mem import gbrain_sidecar
+from openclaw_mem import governed_release
 from openclaw_mem import goal_primitive
 from openclaw_mem import mem_system_status
 from openclaw_mem import mutation_framework
@@ -10874,6 +10875,38 @@ def cmd_mutation_rollback(conn: sqlite3.Connection, args: argparse.Namespace) ->
         print(f"mutation_rollback ok={str(payload['ok']).lower()} restored={len(payload['restored'])} writes_performed={str(payload['writes_performed']).lower()}")
 
 
+def cmd_governed_apply_review(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    plan = mutation_framework.load_json(args.plan_file)
+    payload = governed_release.review_apply_plan(
+        plan,
+        allowed_root=getattr(args, "allowed_root"),
+        l2_enabled=bool(getattr(args, "l2_enabled", False)),
+        human_approved=bool(getattr(args, "human_approved", False)),
+        ck_approved=bool(getattr(args, "ck_approved", False)),
+    )
+    if getattr(args, "out", None):
+        mutation_framework.write_json(args.out, payload)
+    if bool(getattr(args, "json", False)):
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(f"governed_apply_review decision={payload['decision']} ok={str(payload['ok']).lower()} writes_performed=false")
+
+
+def cmd_governed_release_check(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    payload = governed_release.release_check(
+        repo_root=getattr(args, "repo_root"),
+        expected_version=getattr(args, "expected_version", None),
+        require_receipt=not bool(getattr(args, "no_require_receipt", False)),
+        docs_glob=getattr(args, "docs_glob", "docs/self-improvement*.md"),
+    )
+    if getattr(args, "out", None):
+        mutation_framework.write_json(args.out, payload)
+    if bool(getattr(args, "json", False)):
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(f"governed_release_check ok={str(payload['ok']).lower()} version={payload['expected_version']} writes_performed=false")
+
+
 def cmd_self_curator_plan(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
     mutations = json.loads(Path(args.mutations_file).read_text(encoding="utf-8"))
     if isinstance(mutations, dict) and "mutations" in mutations:
@@ -20099,6 +20132,27 @@ def build_parser() -> argparse.ArgumentParser:
     mr.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Structured JSON output")
     mr.set_defaults(func=cmd_mutation_rollback)
 
+    sp = sub.add_parser("governed", help="Governed apply/release hardening checks (review-only)")
+    govsub = sp.add_subparsers(dest="governed_cmd", required=True)
+    ga = govsub.add_parser("apply-review", help="Review a mutation plan against approval boundaries without applying it")
+    ga.add_argument("--plan-file", required=True, help="Mutation plan JSON file")
+    ga.add_argument("--allowed-root", default=".state/mutation-framework/sandbox", help="Allowed local fixture root")
+    ga.add_argument("--l2-enabled", action="store_true", help="Allow L2 local apply in this review")
+    ga.add_argument("--human-approved", action="store_true", help="Record human approval for L3 review (still not auto-applyable)")
+    ga.add_argument("--ck-approved", action="store_true", help="Record CK approval for L4 review (still not auto-applyable)")
+    ga.add_argument("--out", help="Optional apply review receipt path")
+    ga.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Structured JSON output")
+    ga.set_defaults(func=cmd_governed_apply_review)
+
+    gr = govsub.add_parser("release-check", help="Check version/changelog/lockfile/docs safety before release")
+    gr.add_argument("--repo-root", default=".", help="Repository root")
+    gr.add_argument("--expected-version", help="Expected release version")
+    gr.add_argument("--docs-glob", default="docs/self-improvement*.md", help="Glob of public docs to safety-scan")
+    gr.add_argument("--no-require-receipt", action="store_true", help="Do not require a self-improvement receipt document")
+    gr.add_argument("--out", help="Optional release check receipt path")
+    gr.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Structured JSON output")
+    gr.set_defaults(func=cmd_governed_release_check)
+
     sp = sub.add_parser("self-curator", help="Lifecycle curator engine (review + checkpointed apply)")
     scsub = sp.add_subparsers(dest="self_curator_cmd", required=True)
     sc = scsub.add_parser("skill-review", help="Scan skill files and emit review-only lifecycle artifacts")
@@ -20288,7 +20342,7 @@ def main() -> None:
         or (dream_lite_cmd == "apply" and dream_lite_apply_cmd in {"plan", "verify"})
     )
     file_only_snapshot = cmd in {"continuity", "self"} and self_cmd in {"attachment-map", "threat-feed", "adjudication", "public-summary", "explain", "sensitivity", "triggers", "interventions", "wording-lint"} and bool(getattr(args, "snapshot", None))
-    no_db_path = cmd in {"capsule", "self-curator", "skill-curator", "steward", "ingest-review", "active-line", "surface", "goal", "skill-capture", "mem-system", "mutation", "harness", "codex"} or dream_lite_no_db or (cmd == "optimize" and optimize_cmd in {"canary-advisory"}) or (cmd in {"continuity", "self"} and self_cmd in {"diff", "release", "release-history", "status", "enable", "disable", "patterns"}) or file_only_snapshot
+    no_db_path = cmd in {"capsule", "self-curator", "skill-curator", "steward", "ingest-review", "active-line", "surface", "goal", "skill-capture", "mem-system", "mutation", "governed", "harness", "codex"} or dream_lite_no_db or (cmd == "optimize" and optimize_cmd in {"canary-advisory"}) or (cmd in {"continuity", "self"} and self_cmd in {"diff", "release", "release-history", "status", "enable", "disable", "patterns"}) or file_only_snapshot
 
     if no_db_path:
         # Some command families own their own file-only semantics.

--- a/openclaw_mem/governed_release.py
+++ b/openclaw_mem/governed_release.py
@@ -1,0 +1,165 @@
+"""Governed apply and release-hardening checks for Slice 7.
+
+This module deliberately does not apply mutations or publish releases. It emits
+review/gate receipts that make approval boundaries explicit before any future
+higher-risk automation can be considered.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from openclaw_mem.mutation_framework import PLAN_SCHEMA, validate_plan
+from openclaw_mem.steward_review import public_safety_markers
+
+APPLY_REVIEW_SCHEMA = "openclaw-mem.governed.apply-review.v0"
+RELEASE_CHECK_SCHEMA = "openclaw-mem.governed.release-check.v0"
+RISK_ORDER = {"L0": 0, "L1": 1, "L2": 2, "L3": 3, "L4": 4}
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _risk(plan: Mapping[str, Any]) -> str:
+    max_rank = 0
+    for m in plan.get("mutations") or []:
+        if isinstance(m, Mapping):
+            max_rank = max(max_rank, RISK_ORDER.get(str(m.get("risk_class") or "L1"), 99))
+    for label, rank in RISK_ORDER.items():
+        if rank == max_rank:
+            return label
+    return "unknown"
+
+
+def review_apply_plan(
+    plan: Mapping[str, Any],
+    *,
+    allowed_root: str | Path,
+    l2_enabled: bool = False,
+    human_approved: bool = False,
+    ck_approved: bool = False,
+) -> dict[str, Any]:
+    validation = validate_plan(plan, allowed_root=allowed_root, allow_apply=True)
+    highest = _risk(plan)
+    reasons: list[str] = []
+    if plan.get("schema_version") != PLAN_SCHEMA:
+        reasons.append("invalid_plan_schema")
+    if not validation.get("ok"):
+        reasons.append("plan_validation_failed")
+    if highest == "L2" and not l2_enabled:
+        reasons.append("l2_requires_config_gate")
+    if highest == "L3" and not human_approved:
+        reasons.append("l3_requires_human_approval")
+    if highest == "L4" and not ck_approved:
+        reasons.append("l4_requires_ck_approval")
+    # Slice 7 still does not approve L3/L4 auto apply. Approval only records who
+    # must be present for a future separate lane.
+    if highest in {"L3", "L4"}:
+        reasons.append("l3_l4_not_auto_applyable")
+    decision = "advisory_allow_local_apply" if not reasons and highest in {"L0", "L1"} else "advisory_allow_l2_local_apply" if not reasons and highest == "L2" else "blocked"
+    return {
+        "schema_version": APPLY_REVIEW_SCHEMA,
+        "ok": decision != "blocked",
+        "decision": decision,
+        "highest_risk_class": highest,
+        "writes_performed": False,
+        "topology_changed": False,
+        "l2_enabled": bool(l2_enabled),
+        "human_approved": bool(human_approved),
+        "ck_approved": bool(ck_approved),
+        "reasons": reasons,
+        "validation": validation,
+        "reviewed_at": now_iso(),
+    }
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return ""
+
+
+def _version_from_pyproject(text: str) -> str | None:
+    m = re.search(r'^version\s*=\s*["\']([^"\']+)["\']', text, re.MULTILINE)
+    return m.group(1) if m else None
+
+
+def _version_from_init(text: str) -> str | None:
+    m = re.search(r'__version__\s*=\s*["\']([^"\']+)["\']', text)
+    return m.group(1) if m else None
+
+
+def _lockfile_project_version_present(lock_text: str, expected: str) -> bool:
+    pattern = (
+        r'(?ms)^\[\[package\]\]\s*\n'
+        r'name\s*=\s*"openclaw-context-pack"\s*\n'
+        rf'version\s*=\s*"{re.escape(expected)}"\s*\n'
+    )
+    return bool(re.search(pattern, lock_text))
+
+
+def release_check(
+    *,
+    repo_root: str | Path,
+    expected_version: str | None = None,
+    require_receipt: bool = True,
+    docs_glob: str = "docs/self-improvement*.md",
+) -> dict[str, Any]:
+    root = Path(repo_root).expanduser().resolve()
+    pyproject = _read(root / "pyproject.toml")
+    init = _read(root / "openclaw_mem" / "__init__.py")
+    lock = _read(root / "uv.lock")
+    changelog = _read(root / "CHANGELOG.md")
+    version = _version_from_pyproject(pyproject)
+    init_version = _version_from_init(init)
+    expected = expected_version or version
+    errors: list[str] = []
+    warnings: list[str] = []
+    if not version:
+        errors.append("missing_pyproject_version")
+    if init_version != version:
+        errors.append("init_version_mismatch")
+    if expected and version != expected:
+        errors.append("expected_version_mismatch")
+    lock_has_project_version = bool(expected and _lockfile_project_version_present(lock, expected))
+    if expected and not lock_has_project_version:
+        errors.append("uv_lock_version_missing")
+    if expected and f"## [{expected}]" not in changelog:
+        errors.append("changelog_entry_missing")
+    receipts = sorted((root / "docs").glob("2026-*_self-improvement*receipt.md"))
+    if require_receipt and not receipts:
+        if not receipts:
+            errors.append("release_receipt_missing")
+    public_markers: dict[str, list[str]] = {}
+    docs_paths = set(root.glob(docs_glob)) | set(root.glob("docs/2026-*_self-improvement*.md"))
+    for path in sorted(docs_paths):
+        markers = public_safety_markers(_read(path))
+        if markers:
+            public_markers[str(path.relative_to(root))] = markers
+    if public_markers:
+        errors.append("public_safety_markers_found")
+    return {
+        "schema_version": RELEASE_CHECK_SCHEMA,
+        "ok": not errors,
+        "writes_performed": False,
+        "topology_changed": False,
+        "repo_root": str(root),
+        "expected_version": expected,
+        "versions": {"pyproject": version, "init": init_version},
+        "checks": {
+            "version_consistent": bool(version and init_version == version),
+            "lockfile_mentions_version": lock_has_project_version,
+            "changelog_entry_present": bool(expected and f"## [{expected}]" in changelog),
+            "receipt_present": bool(receipts),
+            "public_safety_clean": not public_markers,
+        },
+        "public_safety_markers": public_markers,
+        "errors": errors,
+        "warnings": warnings,
+        "checked_at": now_iso(),
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openclaw-context-pack"
-version = "1.9.14"
+version = "1.9.15"
 description = "Local-first AI agent memory governance: Store / Pack / Observe with citations, receipts, and rollback"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/tests/test_governed_cli.py
+++ b/tests/test_governed_cli.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_cli(*args: str) -> dict:
+    proc = subprocess.run([sys.executable, "-m", "openclaw_mem", *args], check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return json.loads(proc.stdout)
+
+
+def test_governed_apply_review_cli(tmp_path: Path):
+    mutations = tmp_path / "mutations.json"
+    mutations.write_text(json.dumps({"mutations": [{"action": "write_file", "path": "x.txt", "content": "x", "risk_class": "L2"}]}), encoding="utf-8")
+    plan = tmp_path / "plan.json"
+    run_cli("mutation", "plan", "--mutations-file", str(mutations), "--out", str(plan), "--json")
+    blocked = run_cli("governed", "apply-review", "--plan-file", str(plan), "--allowed-root", str(tmp_path / "sandbox"), "--json")
+    assert blocked["ok"] is False
+    assert "l2_requires_config_gate" in blocked["reasons"]
+    allowed = run_cli("governed", "apply-review", "--plan-file", str(plan), "--allowed-root", str(tmp_path / "sandbox"), "--l2-enabled", "--json")
+    assert allowed["ok"] is True
+    assert allowed["decision"] == "advisory_allow_l2_local_apply"
+
+
+def test_governed_release_check_cli(tmp_path: Path):
+    root = tmp_path
+    (root / "openclaw_mem").mkdir()
+    (root / "docs").mkdir()
+    (root / "pyproject.toml").write_text('version = "9.9.9"\n', encoding="utf-8")
+    (root / "openclaw_mem" / "__init__.py").write_text('__version__ = "9.9.9"\n', encoding="utf-8")
+    (root / "uv.lock").write_text('[[package]]\nname = "openclaw-context-pack"\nversion = "9.9.9"\n', encoding="utf-8")
+    (root / "CHANGELOG.md").write_text('## [9.9.9] - 2026-05-12\n', encoding="utf-8")
+    (root / "docs" / "2026-05-12_self-improvement-slice-7-receipt.md").write_text("receipt\n", encoding="utf-8")
+    (root / "docs" / "self-improvement-slice-7.md").write_text("public safe\n", encoding="utf-8")
+    payload = run_cli("governed", "release-check", "--repo-root", str(root), "--expected-version", "9.9.9", "--json")
+    assert payload["ok"] is True
+    assert payload["writes_performed"] is False

--- a/tests/test_governed_release.py
+++ b/tests/test_governed_release.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from openclaw_mem.governed_release import release_check, review_apply_plan
+from openclaw_mem.mutation_framework import build_plan
+
+
+class TestGovernedRelease(unittest.TestCase):
+    def test_apply_review_allows_l1(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            plan = build_plan(mutations=[{"action": "write_file", "path": "x.txt", "content": "x", "risk_class": "L1"}])
+            review = review_apply_plan(plan, allowed_root=Path(tmp) / "sandbox")
+        self.assertTrue(review["ok"])
+        self.assertEqual(review["decision"], "advisory_allow_local_apply")
+        self.assertFalse(review["writes_performed"])
+
+    def test_apply_review_blocks_l2_without_config_gate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            plan = build_plan(mutations=[{"action": "write_file", "path": "x.txt", "content": "x", "risk_class": "L2"}])
+            review = review_apply_plan(plan, allowed_root=Path(tmp) / "sandbox")
+        self.assertFalse(review["ok"])
+        self.assertIn("l2_requires_config_gate", review["reasons"])
+
+    def test_apply_review_allows_l2_when_enabled(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            plan = build_plan(mutations=[{"action": "write_file", "path": "x.txt", "content": "x", "risk_class": "L2"}])
+            review = review_apply_plan(plan, allowed_root=Path(tmp) / "sandbox", l2_enabled=True)
+        self.assertTrue(review["ok"])
+        self.assertEqual(review["decision"], "advisory_allow_l2_local_apply")
+
+    def test_apply_review_blocks_l3_l4_even_with_approval(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            plan = build_plan(mutations=[{"action": "write_file", "path": "x.txt", "content": "x", "risk_class": "L4"}])
+            review = review_apply_plan(plan, allowed_root=Path(tmp) / "sandbox", ck_approved=True, human_approved=True, l2_enabled=True)
+        self.assertFalse(review["ok"])
+        self.assertIn("l3_l4_not_auto_applyable", review["reasons"])
+
+    def test_apply_review_reports_invalid_plan_schema(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            plan = {"schema_version": "wrong", "mutations": []}
+            review = review_apply_plan(plan, allowed_root=Path(tmp) / "sandbox")
+        self.assertFalse(review["ok"])
+        self.assertIn("invalid_plan_schema", review["reasons"])
+
+    def test_release_check_passes_consistent_release(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "openclaw_mem").mkdir()
+            (root / "docs").mkdir()
+            (root / "pyproject.toml").write_text('version = "9.9.9"\n', encoding="utf-8")
+            (root / "openclaw_mem" / "__init__.py").write_text('__version__ = "9.9.9"\n', encoding="utf-8")
+            (root / "uv.lock").write_text('[[package]]\nname = "openclaw-context-pack"\nversion = "9.9.9"\n', encoding="utf-8")
+            (root / "CHANGELOG.md").write_text('## [9.9.9] - 2026-05-12\n', encoding="utf-8")
+            (root / "docs" / "2026-05-12_self-improvement-slice-7-receipt.md").write_text("receipt\n", encoding="utf-8")
+            (root / "docs" / "self-improvement-slice-7.md").write_text("public safe\n", encoding="utf-8")
+            check = release_check(repo_root=root, expected_version="9.9.9")
+        self.assertTrue(check["ok"])
+        self.assertTrue(check["checks"]["version_consistent"])
+        self.assertTrue(check["checks"]["public_safety_clean"])
+
+    def test_release_check_fails_version_and_public_safety(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "openclaw_mem").mkdir()
+            (root / "docs").mkdir()
+            (root / "pyproject.toml").write_text('version = "9.9.9"\n', encoding="utf-8")
+            (root / "openclaw_mem" / "__init__.py").write_text('__version__ = "9.9.8"\n', encoding="utf-8")
+            (root / "uv.lock").write_text('[[package]]\nname = "some-dependency"\nversion = "9.9.9"\n[[package]]\nname = "openclaw-context-pack"\nversion = "9.9.8"\n', encoding="utf-8")
+            (root / "CHANGELOG.md").write_text('## [9.9.8] - 2026-05-12\n', encoding="utf-8")
+            (root / "docs" / "self-improvement-slice-7.md").write_text("/home/ck secret\n", encoding="utf-8")
+            check = release_check(repo_root=root, expected_version="9.9.9")
+        self.assertFalse(check["ok"])
+        self.assertIn("init_version_mismatch", check["errors"])
+        self.assertIn("public_safety_markers_found", check["errors"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -372,7 +372,7 @@ wheels = [
 
 [[package]]
 name = "openclaw-context-pack"
-version = "1.9.14"
+version = "1.9.15"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Adds Slice 7 of the self-improvement consolidation line: governed apply/release hardening checks.

New commands:

- `openclaw-mem governed apply-review`
- `openclaw-mem governed release-check`

## Safety / authority

- Review-only receipts; no apply/publish/tag/push/merge side effects
- L0/L1 may receive advisory local-apply allow when the Slice 6 plan validates
- L2 requires explicit `--l2-enabled`
- L3/L4 remain blocked from auto-apply even with approval flags
- Release-check verifies version, lockfile project block, changelog, receipt presence, and public-doc safety markers
- No OpenClaw core, gateway, plugin config, cron, model routing, package publish, or live skill mutation is enabled

## Verification

- `uv run python -m pytest tests/test_governed_release.py tests/test_governed_cli.py tests/test_mutation_framework.py tests/test_mutation_cli.py`
  - `18 passed`
- CLI smoke passed for:
  - L2 blocked without config gate
  - L2 advisory-allowed with `--l2-enabled`
  - L4 blocked even with approval flag
  - release-check success for `1.9.15`
- `uv run --with mkdocs --with mkdocs-material mkdocs build --strict`
  - built successfully
- Claude public-facing review ran twice and approved public push
- Local editable install smoke:
  - `openclaw-context-pack==1.9.15`
  - installed `governed release-check` and `governed apply-review` readbacks passed

## Release note

Recommended tag after merge: `v1.9.15`.
