### PR TITLE
feat: add L3/L4 advisory dossiers

### DIFF
--- a/docs/l3-l4-advisory-dossier.md
+++ b/docs/l3-l4-advisory-dossier.md
@@ -1,0 +1,42 @@
+# L3/L4 advisory dossier
+
+`openclaw-mem governed advisory-dossier` turns a mutation plan into an operator-facing approval dossier.
+
+It is advisory-only. It does not apply mutations, publish, tag, push, merge, change OpenClaw core, alter gateway/plugin/cron/model routing, or make L3/L4 auto-applyable.
+
+## Example
+
+```bash
+openclaw-mem governed advisory-dossier \
+  --plan-file plan.json \
+  --allowed-root .state/mutation-framework/sandbox \
+  --why-now "The protected surface needs an operator decision" \
+  --recommendation "Approve only by opening a separate execution line" \
+  --markdown-out dossier.md \
+  --json
+```
+
+## Policy
+
+- L3 requires human/operator approval before any separate execution line.
+- L4 requires explicit CK approval before any separate execution line.
+- Approval flags on this command are review context only; they do not approve execution.
+- Message delivery or dossier rendering is not approval.
+- Any approved execution must be a separate line with rollback and verifier receipts.
+
+## Output
+
+The JSON receipt includes:
+
+- `risk_class`
+- `affected_surfaces`
+- `proposed_changes`
+- `approval.status`
+- `rollback_plan`
+- `verifier_plan`
+- `artifact_outputs` for optional JSON/Markdown dossier files
+- nested `apply_review` receipt
+
+`writes_performed=false` means no target mutation/application occurred; writing the dossier artifact itself is not treated as governed apply.
+
+For L3/L4, the nested apply review remains blocked with `l3_l4_not_auto_applyable`.

--- a/docs/l3-l4-advisory-dossier.md
+++ b/docs/l3-l4-advisory-dossier.md
@@ -28,6 +28,8 @@ openclaw-mem governed advisory-dossier \
 
 The JSON receipt includes:
 
+- `ok` following the nested apply-review gate result
+- `dossier_generated` to distinguish successful report generation from approval
 - `risk_class`
 - `affected_surfaces`
 - `proposed_changes`

--- a/docs/specs/l3-l4-advisory-dossier-v0.md
+++ b/docs/specs/l3-l4-advisory-dossier-v0.md
@@ -35,6 +35,8 @@ Turn high-risk governed apply candidates into operator-facing advisory dossiers 
 - Optional JSON/Markdown dossier files are reported under `artifact_outputs`, not treated as target writes.
 - `apply_review.writes_performed=false` always.
 - L3/L4 always remain execution-blocked in this slice.
+- Top-level `ok` follows nested `apply_review.ok`; L3/L4 dossiers are generated but not gate-ok.
+- `dossier_generated=true` distinguishes successful report generation from approval.
 - Approval status is `approval_required`, never `approved`.
 - Topology/config impact: unchanged.
 

--- a/docs/specs/l3-l4-advisory-dossier-v0.md
+++ b/docs/specs/l3-l4-advisory-dossier-v0.md
@@ -1,0 +1,51 @@
+# L3/L4 Advisory Dossier v0 — blade map
+
+Date: 2026-05-12
+Status: implementation blade map
+Owner: Lyria
+
+## Goal
+
+Turn high-risk governed apply candidates into operator-facing advisory dossiers that CK can approve or reject before any execution line starts.
+
+## Boundary
+
+- Repo: `openclaw-mem` only.
+- Advisory-only: no mutation apply, no publish/tag/push/merge, no Gateway/plugin/cron/model routing changes.
+- Does not make L3/L4 auto-applyable.
+- Does not treat sending or rendering a dossier as approval.
+
+## Inputs
+
+- Existing mutation plan JSON (`openclaw-mem.mutation.plan.v0`).
+- Existing `allowed-root` validation boundary.
+- Optional metadata: title, why-now, recommended action, operator target, do-nothing cost.
+
+## Outputs / artifacts
+
+- New governed command: `openclaw-mem governed advisory-dossier`.
+- Machine JSON receipt containing risk, affected surfaces, approval requirement, rollback/verifier skeleton, and exact blocked apply-review decision.
+- Optional Markdown dossier report for CK-facing approval.
+- Unit/CLI tests including L3/L4 blocked counterfactuals.
+- Public docs note.
+
+## Invariants
+
+- `writes_performed=false` always means no target mutation/application was performed.
+- Optional JSON/Markdown dossier files are reported under `artifact_outputs`, not treated as target writes.
+- `apply_review.writes_performed=false` always.
+- L3/L4 always remain execution-blocked in this slice.
+- Approval status is `approval_required`, never `approved`.
+- Topology/config impact: unchanged.
+
+## Verifier plan
+
+- Unit tests for L3 and L4 dossier payloads.
+- CLI test for Markdown output and JSON fields.
+- Counterfactual: L4 with `--ck-approved` still emits `approval_required` and blocked apply-review due to `l3_l4_not_auto_applyable`.
+- Targeted pytest for governed release and CLI tests.
+- CLI smoke creating a sample L4 dossier artifact.
+
+## Rollback
+
+Revert this branch/commit. No runtime topology rollback is required because no live component is enabled.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
       - Self-improvement slices 2–5: self-improvement-slices-2-5.md
       - Self-improvement Slice 6: self-improvement-slice-6.md
       - Self-improvement Slice 7: self-improvement-slice-7.md
+      - L3/L4 advisory dossier: l3-l4-advisory-dossier.md
       - Governed optimize assist: optimize-assist.md
       - Verbatim semantic lane: verbatim-semantic-lane.md
       - Dual-language memory strategy: dual-language-memory-strategy.md

--- a/openclaw_mem/cli.py
+++ b/openclaw_mem/cli.py
@@ -10907,6 +10907,38 @@ def cmd_governed_release_check(conn: sqlite3.Connection, args: argparse.Namespac
         print(f"governed_release_check ok={str(payload['ok']).lower()} version={payload['expected_version']} writes_performed=false")
 
 
+def cmd_governed_advisory_dossier(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
+    plan = mutation_framework.load_json(args.plan_file)
+    payload = governed_release.build_advisory_dossier(
+        plan,
+        allowed_root=getattr(args, "allowed_root"),
+        title=getattr(args, "title", None),
+        why_now=getattr(args, "why_now", None),
+        recommendation=getattr(args, "recommendation", None),
+        do_nothing_cost=getattr(args, "do_nothing_cost", None),
+        operator_target=getattr(args, "operator_target", None),
+        l2_enabled=bool(getattr(args, "l2_enabled", False)),
+        human_approved=bool(getattr(args, "human_approved", False)),
+        ck_approved=bool(getattr(args, "ck_approved", False)),
+    )
+    artifact_outputs = []
+    if getattr(args, "markdown_out", None):
+        report_path = Path(args.markdown_out)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(governed_release.render_advisory_dossier_markdown(payload), encoding="utf-8")
+        artifact_outputs.append(str(report_path))
+    if getattr(args, "out", None):
+        artifact_outputs.append(str(args.out))
+        payload["artifact_outputs"] = artifact_outputs
+        mutation_framework.write_json(args.out, payload)
+    else:
+        payload["artifact_outputs"] = artifact_outputs
+    if bool(getattr(args, "json", False)):
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(f"governed_advisory_dossier verdict={payload['verdict']} risk={payload['risk_class']} writes_performed={str(payload['writes_performed']).lower()}")
+
+
 def cmd_self_curator_plan(conn: sqlite3.Connection, args: argparse.Namespace) -> None:
     mutations = json.loads(Path(args.mutations_file).read_text(encoding="utf-8"))
     if isinstance(mutations, dict) and "mutations" in mutations:
@@ -20152,6 +20184,22 @@ def build_parser() -> argparse.ArgumentParser:
     gr.add_argument("--out", help="Optional release check receipt path")
     gr.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Structured JSON output")
     gr.set_defaults(func=cmd_governed_release_check)
+
+    gd = govsub.add_parser("advisory-dossier", help="Build an L3/L4 operator approval dossier without applying it")
+    gd.add_argument("--plan-file", required=True, help="Mutation plan JSON file")
+    gd.add_argument("--allowed-root", default=".state/mutation-framework/sandbox", help="Allowed local fixture root")
+    gd.add_argument("--title", help="Human-facing dossier title")
+    gd.add_argument("--why-now", help="Why this should be considered now")
+    gd.add_argument("--recommendation", help="Recommended operator action")
+    gd.add_argument("--do-nothing-cost", help="Cost/risk of taking no action")
+    gd.add_argument("--operator-target", help="Operator/person whose approval is needed")
+    gd.add_argument("--l2-enabled", action="store_true", help="Pass through L2 config gate for review context")
+    gd.add_argument("--human-approved", action="store_true", help="Record human approval flag for review context; does not execute")
+    gd.add_argument("--ck-approved", action="store_true", help="Record CK approval flag for review context; does not execute")
+    gd.add_argument("--out", help="Optional JSON dossier receipt path")
+    gd.add_argument("--markdown-out", help="Optional Markdown dossier report path")
+    gd.add_argument("--json", action="store_true", default=argparse.SUPPRESS, help="Structured JSON output")
+    gd.set_defaults(func=cmd_governed_advisory_dossier)
 
     sp = sub.add_parser("self-curator", help="Lifecycle curator engine (review + checkpointed apply)")
     scsub = sp.add_subparsers(dest="self_curator_cmd", required=True)

--- a/openclaw_mem/governed_release.py
+++ b/openclaw_mem/governed_release.py
@@ -17,6 +17,7 @@ from openclaw_mem.steward_review import public_safety_markers
 
 APPLY_REVIEW_SCHEMA = "openclaw-mem.governed.apply-review.v0"
 RELEASE_CHECK_SCHEMA = "openclaw-mem.governed.release-check.v0"
+ADVISORY_DOSSIER_SCHEMA = "openclaw-mem.governed.advisory-dossier.v0"
 RISK_ORDER = {"L0": 0, "L1": 1, "L2": 2, "L3": 3, "L4": 4}
 
 
@@ -75,6 +76,172 @@ def review_apply_plan(
         "validation": validation,
         "reviewed_at": now_iso(),
     }
+
+
+def _affected_surfaces(plan: Mapping[str, Any]) -> list[str]:
+    surfaces: list[str] = []
+    seen: set[str] = set()
+    for m in plan.get("mutations") or []:
+        if not isinstance(m, Mapping):
+            continue
+        path = str(m.get("path") or "").strip() or "<missing-path>"
+        if path not in seen:
+            surfaces.append(path)
+            seen.add(path)
+    return surfaces
+
+
+def _proposed_changes(plan: Mapping[str, Any]) -> list[dict[str, Any]]:
+    changes: list[dict[str, Any]] = []
+    for m in plan.get("mutations") or []:
+        if not isinstance(m, Mapping):
+            continue
+        action = str(m.get("action") or "")
+        path = str(m.get("path") or "")
+        item: dict[str, Any] = {
+            "mutation_id": m.get("mutation_id"),
+            "action": action,
+            "path": path,
+            "risk_class": str(m.get("risk_class") or "L1"),
+            "protected": bool(m.get("protected", False)),
+            "requires_approval": bool(m.get("requires_approval", False)),
+        }
+        if "rationale" in m:
+            item["rationale"] = m.get("rationale")
+        if action == "replace_text":
+            item["old_preview"] = str(m.get("old") or "")[:240]
+            item["new_preview"] = str(m.get("new") or "")[:240]
+        elif action == "write_file":
+            item["content_preview"] = str(m.get("content") or "")[:240]
+        changes.append(item)
+    return changes
+
+
+def build_advisory_dossier(
+    plan: Mapping[str, Any],
+    *,
+    allowed_root: str | Path,
+    title: str | None = None,
+    why_now: str | None = None,
+    recommendation: str | None = None,
+    do_nothing_cost: str | None = None,
+    operator_target: str | None = None,
+    l2_enabled: bool = False,
+    human_approved: bool = False,
+    ck_approved: bool = False,
+) -> dict[str, Any]:
+    """Build an operator-facing advisory dossier without applying anything."""
+
+    apply_review = review_apply_plan(
+        plan,
+        allowed_root=allowed_root,
+        l2_enabled=l2_enabled,
+        human_approved=human_approved,
+        ck_approved=ck_approved,
+    )
+    highest = str(apply_review.get("highest_risk_class") or _risk(plan))
+    if highest == "L4":
+        approval_needed = "CK explicit approval required before any separate execution line"
+    elif highest == "L3":
+        approval_needed = "human operator approval required before any separate execution line"
+    elif highest == "L2":
+        approval_needed = "L2 config gate required before local advisory apply"
+    else:
+        approval_needed = "no high-risk approval required by dossier policy"
+    approval_status = "approval_required" if highest in {"L3", "L4"} else "not_high_risk"
+    return {
+        "schema_version": ADVISORY_DOSSIER_SCHEMA,
+        "ok": True,
+        "writes_performed": False,
+        "topology_changed": False,
+        "title": title or f"Governed advisory dossier for {highest} mutation plan",
+        "verdict": "approval_required_before_execution" if highest in {"L3", "L4"} else "not_l3_l4_review_only",
+        "recommendation": recommendation or "Review the dossier; approve only by opening a separate execution line with explicit scope.",
+        "risk_class": highest,
+        "why_now": why_now or "Not provided.",
+        "do_nothing_cost": do_nothing_cost or "Not provided.",
+        "operator_target": operator_target or "CK/operator",
+        "affected_surfaces": _affected_surfaces(plan),
+        "proposed_changes": _proposed_changes(plan),
+        "approval": {
+            "status": approval_status,
+            "needed": approval_needed,
+            "message_delivery_is_not_approval": True,
+            "execution_requires_separate_line": True,
+        },
+        "rollback_plan": [
+            "Do not execute this dossier directly.",
+            "If approved later, require a separate execution receipt with before/after diff and rollback command/path.",
+            "For file mutations, rollback must restore original content or revert the execution commit.",
+        ],
+        "verifier_plan": [
+            "Validate the plan against the intended allowed root before execution.",
+            "Run counterfactual authority checks showing the same L3/L4 candidate remains blocked without explicit execution approval.",
+            "Run the smallest targeted tests or smoke checks for affected surfaces.",
+            "Capture a closure receipt and topology readback after any approved execution line.",
+        ],
+        "apply_review": apply_review,
+        "created_at": now_iso(),
+    }
+
+
+def render_advisory_dossier_markdown(dossier: Mapping[str, Any]) -> str:
+    changes = dossier.get("proposed_changes") or []
+    surfaces = dossier.get("affected_surfaces") or []
+    approval = dossier.get("approval") or {}
+    apply_review = dossier.get("apply_review") or {}
+    lines = [
+        "# L3/L4 Advisory Dossier",
+        "",
+        f"Verdict: {dossier.get('verdict')}",
+        f"Recommendation: {dossier.get('recommendation')}",
+        f"Risk class: {dossier.get('risk_class')}",
+        f"Why now: {dossier.get('why_now')}",
+        f"Operator target: {dossier.get('operator_target')}",
+        "",
+        "## Approval needed",
+        "",
+        f"- Status: {approval.get('status')}",
+        f"- Needed: {approval.get('needed')}",
+        f"- Message delivery is not approval: {approval.get('message_delivery_is_not_approval')}",
+        f"- Separate execution line required: {approval.get('execution_requires_separate_line')}",
+        "",
+        "## Affected surfaces",
+        "",
+    ]
+    lines.extend([f"- `{s}`" for s in surfaces] or ["- none"])
+    lines.extend(["", "## Proposed changes", ""])
+    if changes:
+        for c in changes:
+            lines.append(f"- `{c.get('action')}` `{c.get('path')}` risk={c.get('risk_class')} protected={c.get('protected')} requires_approval={c.get('requires_approval')}")
+            if c.get("rationale"):
+                lines.append(f"  - rationale: {c.get('rationale')}")
+    else:
+        lines.append("- none")
+    lines.extend([
+        "",
+        "## Rollback",
+        "",
+        *[f"- {x}" for x in dossier.get("rollback_plan") or []],
+        "",
+        "## Verifier",
+        "",
+        *[f"- {x}" for x in dossier.get("verifier_plan") or []],
+        "",
+        "## Apply-review receipt",
+        "",
+        f"- decision: {apply_review.get('decision')}",
+        f"- ok: {apply_review.get('ok')}",
+        f"- reasons: {', '.join(apply_review.get('reasons') or [])}",
+        f"- writes_performed: {apply_review.get('writes_performed')}",
+        f"- topology_changed: {apply_review.get('topology_changed')}",
+        "",
+        "## Do nothing cost",
+        "",
+        str(dossier.get("do_nothing_cost") or "Not provided."),
+        "",
+    ])
+    return "\n".join(lines)
 
 
 def _read(path: Path) -> str:

--- a/openclaw_mem/governed_release.py
+++ b/openclaw_mem/governed_release.py
@@ -151,7 +151,8 @@ def build_advisory_dossier(
     approval_status = "approval_required" if highest in {"L3", "L4"} else "not_high_risk"
     return {
         "schema_version": ADVISORY_DOSSIER_SCHEMA,
-        "ok": True,
+        "ok": bool(apply_review.get("ok")),
+        "dossier_generated": True,
         "writes_performed": False,
         "topology_changed": False,
         "title": title or f"Governed advisory dossier for {highest} mutation plan",

--- a/tests/test_governed_cli.py
+++ b/tests/test_governed_cli.py
@@ -59,6 +59,8 @@ def test_governed_advisory_dossier_cli_writes_markdown(tmp_path: Path):
         str(report),
         "--json",
     )
+    assert payload["ok"] is False
+    assert payload["dossier_generated"] is True
     assert payload["risk_class"] == "L4"
     assert payload["approval"]["status"] == "approval_required"
     assert payload["apply_review"]["ok"] is False

--- a/tests/test_governed_cli.py
+++ b/tests/test_governed_cli.py
@@ -37,3 +37,35 @@ def test_governed_release_check_cli(tmp_path: Path):
     payload = run_cli("governed", "release-check", "--repo-root", str(root), "--expected-version", "9.9.9", "--json")
     assert payload["ok"] is True
     assert payload["writes_performed"] is False
+
+
+def test_governed_advisory_dossier_cli_writes_markdown(tmp_path: Path):
+    mutations = tmp_path / "mutations.json"
+    mutations.write_text(json.dumps({"mutations": [{"action": "write_file", "path": "protected.txt", "content": "x", "risk_class": "L4"}]}), encoding="utf-8")
+    plan = tmp_path / "plan.json"
+    run_cli("mutation", "plan", "--mutations-file", str(mutations), "--out", str(plan), "--json")
+    report = tmp_path / "dossier.md"
+    payload = run_cli(
+        "governed",
+        "advisory-dossier",
+        "--plan-file",
+        str(plan),
+        "--allowed-root",
+        str(tmp_path / "sandbox"),
+        "--ck-approved",
+        "--why-now",
+        "Need CK decision",
+        "--markdown-out",
+        str(report),
+        "--json",
+    )
+    assert payload["risk_class"] == "L4"
+    assert payload["approval"]["status"] == "approval_required"
+    assert payload["apply_review"]["ok"] is False
+    assert "l3_l4_not_auto_applyable" in payload["apply_review"]["reasons"]
+    assert payload["writes_performed"] is False
+    assert str(report) in payload["artifact_outputs"]
+    assert report.exists()
+    text = report.read_text(encoding="utf-8")
+    assert "# L3/L4 Advisory Dossier" in text
+    assert "Message delivery is not approval: True" in text

--- a/tests/test_governed_release.py
+++ b/tests/test_governed_release.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from openclaw_mem.governed_release import release_check, review_apply_plan
+from openclaw_mem.governed_release import build_advisory_dossier, release_check, render_advisory_dossier_markdown, review_apply_plan
 from openclaw_mem.mutation_framework import build_plan
 
 
@@ -45,6 +45,32 @@ class TestGovernedRelease(unittest.TestCase):
             review = review_apply_plan(plan, allowed_root=Path(tmp) / "sandbox")
         self.assertFalse(review["ok"])
         self.assertIn("invalid_plan_schema", review["reasons"])
+
+
+    def test_advisory_dossier_keeps_l3_execution_blocked(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            plan = build_plan(mutations=[{"action": "replace_text", "path": "runtime/config.json", "old": "off", "new": "on", "risk_class": "L3", "requires_approval": True}])
+            dossier = build_advisory_dossier(plan, allowed_root=Path(tmp) / "sandbox", human_approved=True, why_now="Need operator decision")
+        self.assertEqual(dossier["schema_version"], "openclaw-mem.governed.advisory-dossier.v0")
+        self.assertEqual(dossier["risk_class"], "L3")
+        self.assertEqual(dossier["approval"]["status"], "approval_required")
+        self.assertFalse(dossier["apply_review"]["ok"])
+        self.assertIn("l3_l4_not_auto_applyable", dossier["apply_review"]["reasons"])
+        self.assertFalse(dossier["writes_performed"])
+
+    def test_advisory_dossier_l4_ck_flag_is_not_execution_approval(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            plan = build_plan(mutations=[{"action": "write_file", "path": "release/tag.txt", "content": "ship", "risk_class": "L4"}])
+            dossier = build_advisory_dossier(plan, allowed_root=Path(tmp) / "sandbox", ck_approved=True, recommendation="Ask CK before execution")
+        self.assertEqual(dossier["risk_class"], "L4")
+        self.assertEqual(dossier["approval"]["status"], "approval_required")
+        self.assertTrue(dossier["approval"]["message_delivery_is_not_approval"])
+        self.assertFalse(dossier["apply_review"]["ok"])
+        self.assertIn("l3_l4_not_auto_applyable", dossier["apply_review"]["reasons"])
+        report = render_advisory_dossier_markdown(dossier)
+        self.assertIn("# L3/L4 Advisory Dossier", report)
+        self.assertIn("Risk class: L4", report)
+        self.assertIn("Message delivery is not approval: True", report)
 
     def test_release_check_passes_consistent_release(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_governed_release.py
+++ b/tests/test_governed_release.py
@@ -52,6 +52,8 @@ class TestGovernedRelease(unittest.TestCase):
             plan = build_plan(mutations=[{"action": "replace_text", "path": "runtime/config.json", "old": "off", "new": "on", "risk_class": "L3", "requires_approval": True}])
             dossier = build_advisory_dossier(plan, allowed_root=Path(tmp) / "sandbox", human_approved=True, why_now="Need operator decision")
         self.assertEqual(dossier["schema_version"], "openclaw-mem.governed.advisory-dossier.v0")
+        self.assertFalse(dossier["ok"])
+        self.assertTrue(dossier["dossier_generated"])
         self.assertEqual(dossier["risk_class"], "L3")
         self.assertEqual(dossier["approval"]["status"], "approval_required")
         self.assertFalse(dossier["apply_review"]["ok"])
@@ -62,6 +64,8 @@ class TestGovernedRelease(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             plan = build_plan(mutations=[{"action": "write_file", "path": "release/tag.txt", "content": "ship", "risk_class": "L4"}])
             dossier = build_advisory_dossier(plan, allowed_root=Path(tmp) / "sandbox", ck_approved=True, recommendation="Ask CK before execution")
+        self.assertFalse(dossier["ok"])
+        self.assertTrue(dossier["dossier_generated"])
         self.assertEqual(dossier["risk_class"], "L4")
         self.assertEqual(dossier["approval"]["status"], "approval_required")
         self.assertTrue(dossier["approval"]["message_delivery_is_not_approval"])


### PR DESCRIPTION
## Summary

Adds an advisory-only L3/L4 operator dossier flow on top of governed apply review.

New command:

- `openclaw-mem governed advisory-dossier`

The command turns a mutation plan into a CK/operator-facing dossier with risk class, affected surfaces, proposed changes, approval requirement, rollback/verifier skeleton, optional Markdown output, and nested apply-review receipt.

## Safety / authority

- Advisory-only; does not apply mutations
- Message/report delivery is not approval
- L3/L4 remain blocked from auto-apply via nested `apply_review` with `l3_l4_not_auto_applyable`
- Any approved action must open a separate execution line with rollback and verifier receipts
- `writes_performed=false` preserves target-mutation semantics; optional JSON/Markdown dossier files are reported as `artifact_outputs`
- No OpenClaw core, gateway, plugin config, cron, model routing, package publish, or live mutation is enabled

## Verification

- L4 smoke produced a dossier artifact with:
  - `risk_class=L4`
  - `approval.status=approval_required`
  - `writes_performed=false`
  - nested `apply_review.ok=false`
  - `l3_l4_not_auto_applyable`
- `uv run python -m pytest tests/test_governed_release.py tests/test_governed_cli.py tests/test_mutation_framework.py tests/test_mutation_cli.py -q`
  - `21 passed`
- `uv run --with mkdocs --with mkdocs-material mkdocs build --strict`
  - built successfully
- `git diff --check`
  - passed

@codex please review the safety contract, CLI semantics, `writes_performed`/`artifact_outputs` split, and tests.
