### PR TITLE
fix(mem-engine): bound RSS-heavy hook inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.16] - 2026-05-12
+
+### Fixed
+
+- Bounded `openclaw-mem-engine` autoCapture input scanning before candidate extraction to avoid RSS spikes on long transcripts while preserving recent-turn capture behavior.
+- Bounded route-auto child output buffering and stopped returning the full parsed route payload from the prompt hook result.
+- Added a hard cap to prompt-hook dedupe tracking so stale quiet-period entries cannot grow without bound.
+
+### Docs
+
+- Documented RSS/context-safety knobs for route-auto and autoCapture, and corrected public cap descriptions for autoRecall and autoCapture.
+
+### Testing
+
+- Added regression coverage for RSS-bound source/schema invariants and route-auto no-payload retention.
+
 ## [1.9.15] - 2026-05-12
 
 ### Added

--- a/docs/mem-engine.md
+++ b/docs/mem-engine.md
@@ -105,14 +105,16 @@ Related boundary: the shipped **verbatim semantic lane** remains a **sidecar ret
 - Default: **on** (but gated by heuristics)
 - Behavior:
   - optional `autoRecall.routeAuto` hook calls `openclaw-mem route auto --compact` before normal recall and injects a compact synthesis-aware routing hint block
+  - route-auto child output is bounded (`maxBufferBytes`, default 512 KiB, hard cap 2 MiB) and only compact text/receipt are retained by the hook
   - dual registration is deduped by run/session key so sequential `before_prompt_build` then legacy `before_agent_start` does not double-inject
+  - prompt-hook dedupe keeps a hard-capped recent-run map to avoid quiet-period stale growth
   - when route-auto carries `preferredCardRefs` / `coveredRawRefs`, the hook prefers the fresh synthesis card but keeps the covered-raw receipt visible
   - route hook is recommendation-only and fail-open (timeout/runtime failure does not block the turn)
   - skip trivial prompts (greetings/ack/emojis/HEARTBEAT/slash commands)
     - robust to trailing emoji/punctuation (e.g. `ok👍`, `done!!`, `thanks...`)
     - punctuation-only prompts also skip (e.g. `？`, `…`)
   - recall tiers: `must_remember` → `nice_to_have` → (optional) `unknown` fallback
-  - cap: <=6 memories
+  - cap: <=5 memories
   - escapes memory text to reduce prompt-injection risk
   - emits bounded lifecycle receipt (`openclaw-mem-engine.recall.receipt.v1`) with skip reason / tier counts / top IDs
   - in `receipts.verbosity=high`, injects a compact autoRecall wrapper comment (IDs only; no memory text in receipt)
@@ -131,11 +133,12 @@ Boundary rule:
 - Hook: `agent_end`
 - Default: **on** (but strict allowlist)
 - Behavior:
-  - capture only a small number of items (1–4 per turn)
+  - capture only a small number of items (1–3 per turn; default 2)
   - default categories: `preference`, `decision`
+  - scans only a bounded recent user-message tail before candidate extraction (`maxScannedUserMessages`, `maxTextBlocksPerMessage`, `maxTotalInputChars`)
   - skip tool outputs; prefer user text; skip secrets-like strings
   - dedupe near-identical items
-  - emits bounded lifecycle receipt (`openclaw-mem-engine.autoCapture.receipt.v1`) with extracted/filtered/stored counts
+  - emits bounded lifecycle receipt (`openclaw-mem-engine.autoCapture.receipt.v1`) with extracted/filtered/stored counts plus scan-bound counters
 
 ### Rollback
 One line:

--- a/extensions/openclaw-mem-engine/README.md
+++ b/extensions/openclaw-mem-engine/README.md
@@ -111,6 +111,7 @@ Example host config:
             "routeAuto": {
               "enabled": true,
               "timeoutMs": 1800,
+              "maxBufferBytes": 524288,
               "maxChars": 420,
               "maxGraphCandidates": 2,
               "maxTranscriptSessions": 2
@@ -124,11 +125,22 @@ Example host config:
 ```
 
 Behavior:
-- shells out to `openclaw-mem route auto "<prompt>"`
+- shells out to `openclaw-mem route auto "<prompt>"` with bounded output buffering (`maxBufferBytes`, default 512 KiB)
+- returns only compact hook text and a bounded receipt to the gateway hook; the parsed route payload is not retained on the result
 - if graph-semantic is ready and returns candidates, injects a compact graph-routing hint block
 - when route-auto reports `preferredCardRefs` / `coveredRawRefs`, the hint prefers the fresh synthesis card while preserving the covered-raw receipt
 - otherwise fails open to a compact transcript-recall hint block
 - runtime failures/timeouts remain fail-open (the turn continues without the route block)
+
+## autoCapture RSS/context bounds
+
+`autoCapture` is intentionally strict: it stores only a small number of preference/decision/TODO candidates per turn. To avoid large-session RSS spikes, input scanning is bounded before candidate splitting and embedding:
+
+- `maxScannedUserMessages` default `24`, hard cap `64`
+- `maxTextBlocksPerMessage` default `4`, hard cap `8`
+- `maxTotalInputChars` default `48000`, hard cap `120000`
+
+These caps do not reduce normal recent-turn capture quality; they prevent rescanning an entire long transcript when at most a few memory rows can be written.
 
 Rollback:
 - set `plugins.entries.openclaw-mem-engine.config.autoRecall.routeAuto.enabled = false`

--- a/extensions/openclaw-mem-engine/index.ts
+++ b/extensions/openclaw-mem-engine/index.ts
@@ -77,6 +77,7 @@ type RouteAutoConfigInput = {
   commandArgs?: string[];
   dbPath?: string;
   timeoutMs?: number;
+  maxBufferBytes?: number;
   maxChars?: number;
   maxGraphCandidates?: number;
   maxTranscriptSessions?: number;
@@ -98,6 +99,9 @@ type AutoCaptureConfigInput = {
   enabled?: boolean;
   maxItemsPerTurn?: number;
   maxCharsPerItem?: number;
+  maxScannedUserMessages?: number;
+  maxTextBlocksPerMessage?: number;
+  maxTotalInputChars?: number;
   capturePreference?: boolean;
   captureDecision?: boolean;
   captureTodo?: boolean;
@@ -244,6 +248,12 @@ const AUTO_CAPTURE_MAX_CHARS_PER_ITEM = 320;
 const AUTO_CAPTURE_MAX_TODO_PER_TURN = 3;
 const AUTO_CAPTURE_MAX_TODO_DEDUPE_WINDOW_HOURS = 24 * 7;
 const AUTO_CAPTURE_MAX_TODO_STALE_TTL_DAYS = 90;
+const AUTO_CAPTURE_MAX_SCANNED_USER_MESSAGES = 64;
+const AUTO_CAPTURE_MAX_TEXT_BLOCKS_PER_MESSAGE = 8;
+const AUTO_CAPTURE_MAX_TOTAL_INPUT_CHARS = 120_000;
+const ROUTE_AUTO_DEFAULT_MAX_BUFFER_BYTES = 512 * 1024;
+const ROUTE_AUTO_MAX_BUFFER_BYTES = 2 * 1024 * 1024;
+const PROMPT_MUTATION_HOOK_DEDUPE_MAX_ENTRIES = 1024;
 const DOCS_COLD_LANE_MAX_ITEMS = 5;
 const DOCS_COLD_LANE_MAX_SNIPPET_CHARS = 600;
 const DOCS_COLD_LANE_MAX_CHUNK_CHARS = 4000;
@@ -257,6 +267,7 @@ type RouteAutoConfig = {
   commandArgs: string[];
   dbPath?: string;
   timeoutMs: number;
+  maxBufferBytes: number;
   maxChars: number;
   maxGraphCandidates: number;
   maxTranscriptSessions: number;
@@ -282,6 +293,9 @@ type AutoCaptureConfig = {
   enabled: boolean;
   maxItemsPerTurn: number;
   maxCharsPerItem: number;
+  maxScannedUserMessages: number;
+  maxTextBlocksPerMessage: number;
+  maxTotalInputChars: number;
   capturePreference: boolean;
   captureDecision: boolean;
   captureTodo: boolean;
@@ -352,6 +366,7 @@ const DEFAULT_ROUTE_AUTO_CONFIG: RouteAutoConfig = {
   commandArgs: [],
   dbPath: undefined,
   timeoutMs: 1800,
+  maxBufferBytes: ROUTE_AUTO_DEFAULT_MAX_BUFFER_BYTES,
   maxChars: 420,
   maxGraphCandidates: 2,
   maxTranscriptSessions: 2,
@@ -377,6 +392,9 @@ const DEFAULT_AUTO_CAPTURE_CONFIG: AutoCaptureConfig = {
   enabled: true,
   maxItemsPerTurn: 2,
   maxCharsPerItem: 240,
+  maxScannedUserMessages: 24,
+  maxTextBlocksPerMessage: 4,
+  maxTotalInputChars: 48_000,
   capturePreference: true,
   captureDecision: true,
   captureTodo: false,
@@ -709,6 +727,11 @@ function resolveAutoRecallConfig(input: PluginConfig["autoRecall"]): AutoRecallC
       max: 15_000,
       integer: true,
     }),
+    maxBufferBytes: normalizeNumberInRange(rawRouteAuto.maxBufferBytes, defaults.routeAuto.maxBufferBytes, {
+      min: 64 * 1024,
+      max: ROUTE_AUTO_MAX_BUFFER_BYTES,
+      integer: true,
+    }),
     maxChars: normalizeNumberInRange(rawRouteAuto.maxChars, defaults.routeAuto.maxChars, {
       min: 120,
       max: 2400,
@@ -776,6 +799,21 @@ function resolveAutoCaptureConfig(input: PluginConfig["autoCapture"]): AutoCaptu
     maxCharsPerItem: normalizeNumberInRange(raw.maxCharsPerItem, defaults.maxCharsPerItem, {
       min: 60,
       max: AUTO_CAPTURE_MAX_CHARS_PER_ITEM,
+      integer: true,
+    }),
+    maxScannedUserMessages: normalizeNumberInRange(raw.maxScannedUserMessages, defaults.maxScannedUserMessages, {
+      min: 1,
+      max: AUTO_CAPTURE_MAX_SCANNED_USER_MESSAGES,
+      integer: true,
+    }),
+    maxTextBlocksPerMessage: normalizeNumberInRange(raw.maxTextBlocksPerMessage, defaults.maxTextBlocksPerMessage, {
+      min: 1,
+      max: AUTO_CAPTURE_MAX_TEXT_BLOCKS_PER_MESSAGE,
+      integer: true,
+    }),
+    maxTotalInputChars: normalizeNumberInRange(raw.maxTotalInputChars, defaults.maxTotalInputChars, {
+      min: 1_000,
+      max: AUTO_CAPTURE_MAX_TOTAL_INPUT_CHARS,
       integer: true,
     }),
     capturePreference: normalizeBoolean(raw.capturePreference, defaults.capturePreference),
@@ -1736,32 +1774,116 @@ function isNearDuplicateText(a: string, b: string, threshold: number): boolean {
   return tokenJaccardSimilarity(aNorm, bNorm) >= threshold;
 }
 
-function extractUserTextMessages(messages: unknown[]): string[] {
-  const out: string[] = [];
+type AutoCaptureExtractionStats = {
+  scannedUserMessages: number;
+  scannedTextBlocks: number;
+  scannedTextChars: number;
+  skippedOlderUserMessages: number;
+  truncatedInputChars: number;
+};
 
+const EMPTY_AUTO_CAPTURE_EXTRACTION_STATS: AutoCaptureExtractionStats = {
+  scannedUserMessages: 0,
+  scannedTextBlocks: 0,
+  scannedTextChars: 0,
+  skippedOlderUserMessages: 0,
+  truncatedInputChars: 0,
+};
+
+function normalizePositiveInteger(raw: number | undefined, fallback: number): number {
+  if (!Number.isFinite(raw)) return fallback;
+  return Math.max(1, Math.floor(raw as number));
+}
+
+function clampTextForAutoCaptureInput(text: string, remainingChars: number): { text: string; truncatedChars: number } {
+  if (remainingChars <= 0) return { text: "", truncatedChars: text.length };
+  if (text.length <= remainingChars) return { text, truncatedChars: 0 };
+  return { text: text.slice(0, remainingChars), truncatedChars: text.length - remainingChars };
+}
+
+function extractUserTextMessages(
+  messages: unknown[],
+  options: { maxMessages?: number; maxTextBlocksPerMessage?: number; maxTotalInputChars?: number } = {},
+): { texts: string[]; stats: AutoCaptureExtractionStats } {
+  const out: string[] = [];
+  const stats: AutoCaptureExtractionStats = { ...EMPTY_AUTO_CAPTURE_EXTRACTION_STATS };
+  const maxMessages = normalizePositiveInteger(options.maxMessages, AUTO_CAPTURE_MAX_SCANNED_USER_MESSAGES);
+  const maxTextBlocksPerMessage = normalizePositiveInteger(
+    options.maxTextBlocksPerMessage,
+    AUTO_CAPTURE_MAX_TEXT_BLOCKS_PER_MESSAGE,
+  );
+  const maxTotalInputChars = normalizePositiveInteger(options.maxTotalInputChars, AUTO_CAPTURE_MAX_TOTAL_INPUT_CHARS);
+
+  const userMessages: unknown[] = [];
   for (const message of messages) {
     if (!message || typeof message !== "object") continue;
     const msg = message as Record<string, unknown>;
-    if (msg.role !== "user") continue;
+    if (msg.role === "user") userMessages.push(message);
+  }
+
+  stats.skippedOlderUserMessages = Math.max(0, userMessages.length - maxMessages);
+
+  for (const message of userMessages.slice(-maxMessages)) {
+    if (stats.scannedTextChars >= maxTotalInputChars) {
+      if (message && typeof message === "object") {
+        const content = (message as Record<string, unknown>).content;
+        if (typeof content === "string") stats.truncatedInputChars += content.length;
+        else if (Array.isArray(content)) {
+          for (const block of content) {
+            if (block && typeof block === "object" && (block as Record<string, unknown>).type === "text") {
+              const text = (block as Record<string, unknown>).text;
+              if (typeof text === "string") stats.truncatedInputChars += text.length;
+            }
+          }
+        }
+      }
+      continue;
+    }
+    if (!message || typeof message !== "object") continue;
+    const msg = message as Record<string, unknown>;
+    stats.scannedUserMessages += 1;
 
     const content = msg.content;
     if (typeof content === "string") {
-      out.push(content);
+      const remaining = maxTotalInputChars - stats.scannedTextChars;
+      const clamped = clampTextForAutoCaptureInput(content, remaining);
+      if (clamped.text) {
+        out.push(clamped.text);
+        stats.scannedTextBlocks += 1;
+        stats.scannedTextChars += clamped.text.length;
+      }
+      stats.truncatedInputChars += clamped.truncatedChars;
       continue;
     }
 
     if (!Array.isArray(content)) continue;
+    let textBlocks = 0;
     for (const block of content) {
+      if (stats.scannedTextChars >= maxTotalInputChars || textBlocks >= maxTextBlocksPerMessage) {
+        if (block && typeof block === "object" && (block as Record<string, unknown>).type === "text") {
+          const skippedText = (block as Record<string, unknown>).text;
+          if (typeof skippedText === "string") stats.truncatedInputChars += skippedText.length;
+        }
+        continue;
+      }
       if (!block || typeof block !== "object") continue;
       const typed = block as Record<string, unknown>;
       if (typed.type !== "text") continue;
       if (typeof typed.text === "string") {
-        out.push(typed.text);
+        const remaining = maxTotalInputChars - stats.scannedTextChars;
+        const clamped = clampTextForAutoCaptureInput(typed.text, remaining);
+        if (clamped.text) {
+          out.push(clamped.text);
+          stats.scannedTextBlocks += 1;
+          stats.scannedTextChars += clamped.text.length;
+          textBlocks += 1;
+        }
+        stats.truncatedInputChars += clamped.truncatedChars;
       }
     }
   }
 
-  return out;
+  return { texts: out, stats };
 }
 
 function stripAutoInjectedArtifacts(rawText: string): string {
@@ -2063,6 +2185,13 @@ type AutoCaptureLifecycleReceipt = {
     duplicate: number;
     todo_rate_limit: number;
     todo_dedupe_window: number;
+    older_user_messages: number;
+    input_chars_truncated: number;
+  };
+  scanned: {
+    userMessages: number;
+    textBlocks: number;
+    textChars: number;
   };
   storedCount: number;
 };
@@ -2288,6 +2417,13 @@ function buildAutoCaptureLifecycleReceipt(input: {
     duplicate: number;
     todo_rate_limit: number;
     todo_dedupe_window: number;
+    older_user_messages?: number;
+    input_chars_truncated?: number;
+  };
+  scanned?: {
+    userMessages: number;
+    textBlocks: number;
+    textChars: number;
   };
   storedCount: number;
 }): AutoCaptureLifecycleReceipt {
@@ -2301,9 +2437,29 @@ function buildAutoCaptureLifecycleReceipt(input: {
       duplicate: Math.max(0, Math.floor(input.filteredOut.duplicate)),
       todo_rate_limit: Math.max(0, Math.floor(input.filteredOut.todo_rate_limit)),
       todo_dedupe_window: Math.max(0, Math.floor(input.filteredOut.todo_dedupe_window)),
+      older_user_messages: Math.max(0, Math.floor(input.filteredOut.older_user_messages ?? 0)),
+      input_chars_truncated: Math.max(0, Math.floor(input.filteredOut.input_chars_truncated ?? 0)),
+    },
+    scanned: {
+      userMessages: Math.max(0, Math.floor(input.scanned?.userMessages ?? 0)),
+      textBlocks: Math.max(0, Math.floor(input.scanned?.textBlocks ?? 0)),
+      textChars: Math.max(0, Math.floor(input.scanned?.textChars ?? 0)),
     },
     storedCount: Math.max(0, Math.floor(input.storedCount)),
   };
+}
+
+
+function capPromptMutationHookRuns(map: Map<string, number>, maxEntries = PROMPT_MUTATION_HOOK_DEDUPE_MAX_ENTRIES): number {
+  const cappedMax = Math.max(1, Math.floor(maxEntries));
+  let dropped = 0;
+  while (map.size > cappedMax) {
+    const oldestKey = map.keys().next().value as string | undefined;
+    if (oldestKey == null) break;
+    map.delete(oldestKey);
+    dropped += 1;
+  }
+  return dropped;
 }
 
 function renderAutoRecallReceiptComment(receipt: RecallLifecycleReceipt, cfg: ReceiptsConfig): string {
@@ -3498,7 +3654,7 @@ const memoryEngineConfigSchema = {
         const routeAutoObj = obj.routeAuto as Record<string, unknown>;
         assertAllowedKeys(
           routeAutoObj,
-          ["enabled", "command", "commandArgs", "dbPath", "timeoutMs", "maxChars", "maxGraphCandidates", "maxTranscriptSessions"],
+          ["enabled", "command", "commandArgs", "dbPath", "timeoutMs", "maxBufferBytes", "maxChars", "maxGraphCandidates", "maxTranscriptSessions"],
           "autoRecall.routeAuto config",
         );
 
@@ -3510,6 +3666,7 @@ const memoryEngineConfigSchema = {
             : undefined,
           dbPath: typeof routeAutoObj.dbPath === "string" ? routeAutoObj.dbPath : undefined,
           timeoutMs: typeof routeAutoObj.timeoutMs === "number" ? routeAutoObj.timeoutMs : undefined,
+          maxBufferBytes: typeof routeAutoObj.maxBufferBytes === "number" ? routeAutoObj.maxBufferBytes : undefined,
           maxChars: typeof routeAutoObj.maxChars === "number" ? routeAutoObj.maxChars : undefined,
           maxGraphCandidates:
             typeof routeAutoObj.maxGraphCandidates === "number" ? routeAutoObj.maxGraphCandidates : undefined,
@@ -3549,6 +3706,9 @@ const memoryEngineConfigSchema = {
           "enabled",
           "maxItemsPerTurn",
           "maxCharsPerItem",
+          "maxScannedUserMessages",
+          "maxTextBlocksPerMessage",
+          "maxTotalInputChars",
           "capturePreference",
           "captureDecision",
           "captureTodo",
@@ -3564,6 +3724,9 @@ const memoryEngineConfigSchema = {
         enabled: typeof obj.enabled === "boolean" ? obj.enabled : undefined,
         maxItemsPerTurn: typeof obj.maxItemsPerTurn === "number" ? obj.maxItemsPerTurn : undefined,
         maxCharsPerItem: typeof obj.maxCharsPerItem === "number" ? obj.maxCharsPerItem : undefined,
+        maxScannedUserMessages: typeof obj.maxScannedUserMessages === "number" ? obj.maxScannedUserMessages : undefined,
+        maxTextBlocksPerMessage: typeof obj.maxTextBlocksPerMessage === "number" ? obj.maxTextBlocksPerMessage : undefined,
+        maxTotalInputChars: typeof obj.maxTotalInputChars === "number" ? obj.maxTotalInputChars : undefined,
         capturePreference: typeof obj.capturePreference === "boolean" ? obj.capturePreference : undefined,
         captureDecision: typeof obj.captureDecision === "boolean" ? obj.captureDecision : undefined,
         captureTodo: typeof obj.captureTodo === "boolean" ? obj.captureTodo : undefined,
@@ -4192,7 +4355,7 @@ const memoryPlugin = {
     const embeddings = apiKey ? new OpenAIEmbeddings(apiKey, model, embeddingClampCfg) : null;
 
     api.logger.info(
-      `openclaw-mem-engine: registered (db=${resolvedDbPath}, table=${tableName}, model=${model}, embedClamp=${embeddingClampCfg.maxChars}c/head=${embeddingClampCfg.headChars}${embeddingClampCfg.maxBytes ? ` bytes=${embeddingClampCfg.maxBytes}` : ""}, scopePolicy=${scopePolicyCfg.enabled ? `${scopePolicyCfg.defaultScope}|fallback=${scopePolicyCfg.fallbackScopes.join(",") || "none"}|validation=${scopePolicyCfg.validationMode}|skipInvalidFallback=${scopePolicyCfg.skipFallbackOnInvalidScope ? "on" : "off"}` : "off"}, budget=${budgetCfg.enabled ? `${budgetCfg.maxChars}c|minRecent=${budgetCfg.minRecentSlots}|${budgetCfg.overflowAction}` : "off"}, workingSet=${workingSetCfg.enabled ? `on|persist=${workingSetCfg.persist ? "on" : "off"}|max=${workingSetCfg.maxChars}|items=${workingSetCfg.maxItemsPerSection}` : "off"}, receipts=${receiptsCfg.enabled ? `${receiptsCfg.verbosity}/${receiptsCfg.maxItems}` : "off"}, routeAuto=${routeAutoResolved.enabled ? `on|timeout=${routeAutoResolved.timeoutMs}|chars=${routeAutoResolved.maxChars}|graph=${routeAutoResolved.maxGraphCandidates}|episodes=${routeAutoResolved.maxTranscriptSessions}|db=${routeAutoResolved.dbPath}` : "off"}, docsColdLane=${docsColdLaneResolved.enabled ? `on|db=${docsColdLaneResolved.sqlitePath}|roots=${docsColdLaneResolved.sourceRoots.length}|globs=${docsColdLaneResolved.sourceGlobs.length}|scope=${docsColdLaneResolved.scopeMappingStrategy}|minHot=${docsColdLaneResolved.minHotItems}` : "off"}, weijiMemoryPreflight=${weijiMemoryPreflightResolved.enabled ? `${weijiMemoryPreflightResolved.failOnQueued || weijiMemoryPreflightResolved.failOnRejected ? "enforced" : "advisory"}|${weijiMemoryPreflightResolved.failMode}|cmd=${weijiMemoryPreflightResolved.command}` : "off"}, gbrainMirror=${gbrainMirrorResolved.enabled ? `${gbrainMirrorResolved.importOnStore ? "write-through" : "file-only"}|timeout=${gbrainMirrorResolved.timeoutMs}|root=${gbrainMirrorResolved.mirrorRoot}|cmd=${gbrainMirrorResolved.command}` : "off"}, readOnly=${readOnlyEnabled ? `on(${readOnlySource})` : "off"}, lazyInit=true)`,
+      `openclaw-mem-engine: registered (db=${resolvedDbPath}, table=${tableName}, model=${model}, embedClamp=${embeddingClampCfg.maxChars}c/head=${embeddingClampCfg.headChars}${embeddingClampCfg.maxBytes ? ` bytes=${embeddingClampCfg.maxBytes}` : ""}, scopePolicy=${scopePolicyCfg.enabled ? `${scopePolicyCfg.defaultScope}|fallback=${scopePolicyCfg.fallbackScopes.join(",") || "none"}|validation=${scopePolicyCfg.validationMode}|skipInvalidFallback=${scopePolicyCfg.skipFallbackOnInvalidScope ? "on" : "off"}` : "off"}, budget=${budgetCfg.enabled ? `${budgetCfg.maxChars}c|minRecent=${budgetCfg.minRecentSlots}|${budgetCfg.overflowAction}` : "off"}, workingSet=${workingSetCfg.enabled ? `on|persist=${workingSetCfg.persist ? "on" : "off"}|max=${workingSetCfg.maxChars}|items=${workingSetCfg.maxItemsPerSection}` : "off"}, receipts=${receiptsCfg.enabled ? `${receiptsCfg.verbosity}/${receiptsCfg.maxItems}` : "off"}, routeAuto=${routeAutoResolved.enabled ? `on|timeout=${routeAutoResolved.timeoutMs}|buffer=${routeAutoResolved.maxBufferBytes}|chars=${routeAutoResolved.maxChars}|graph=${routeAutoResolved.maxGraphCandidates}|episodes=${routeAutoResolved.maxTranscriptSessions}|db=${routeAutoResolved.dbPath}` : "off"}, docsColdLane=${docsColdLaneResolved.enabled ? `on|db=${docsColdLaneResolved.sqlitePath}|roots=${docsColdLaneResolved.sourceRoots.length}|globs=${docsColdLaneResolved.sourceGlobs.length}|scope=${docsColdLaneResolved.scopeMappingStrategy}|minHot=${docsColdLaneResolved.minHotItems}` : "off"}, weijiMemoryPreflight=${weijiMemoryPreflightResolved.enabled ? `${weijiMemoryPreflightResolved.failOnQueued || weijiMemoryPreflightResolved.failOnRejected ? "enforced" : "advisory"}|${weijiMemoryPreflightResolved.failMode}|cmd=${weijiMemoryPreflightResolved.command}` : "off"}, gbrainMirror=${gbrainMirrorResolved.enabled ? `${gbrainMirrorResolved.importOnStore ? "write-through" : "file-only"}|timeout=${gbrainMirrorResolved.timeoutMs}|root=${gbrainMirrorResolved.mirrorRoot}|cmd=${gbrainMirrorResolved.command}` : "off"}, readOnly=${readOnlyEnabled ? `on(${readOnlySource})` : "off"}, lazyInit=true)`,
     );
 
     const resolveAdminFilters = (input: {
@@ -5953,6 +6116,7 @@ const memoryPlugin = {
         }
 
         promptMutationHookRuns.set(runKey, now);
+        capPromptMutationHookRuns(promptMutationHookRuns, PROMPT_MUTATION_HOOK_DEDUPE_MAX_ENTRIES);
         return false;
       };
 
@@ -6459,7 +6623,12 @@ const memoryPlugin = {
           if (allowedCategories.size === 0) return;
 
           try {
-            const userTexts = extractUserTextMessages(event.messages)
+            const extracted = extractUserTextMessages(event.messages, {
+              maxMessages: autoCaptureCfg.maxScannedUserMessages,
+              maxTextBlocksPerMessage: autoCaptureCfg.maxTextBlocksPerMessage,
+              maxTotalInputChars: autoCaptureCfg.maxTotalInputChars,
+            });
+            const userTexts = extracted.texts
               .map(stripAutoInjectedArtifacts)
               .filter((text) => Boolean(String(text ?? "").trim()));
             if (userTexts.length === 0) return;
@@ -6470,6 +6639,8 @@ const memoryPlugin = {
               duplicate: 0,
               todo_rate_limit: 0,
               todo_dedupe_window: 0,
+              older_user_messages: extracted.stats.skippedOlderUserMessages,
+              input_chars_truncated: extracted.stats.truncatedInputChars,
             };
 
             let candidateExtractionCount = 0;
@@ -6662,6 +6833,11 @@ const memoryPlugin = {
                 cfg: receiptsCfg,
                 candidateExtractionCount,
                 filteredOut,
+                scanned: {
+                  userMessages: extracted.stats.scannedUserMessages,
+                  textBlocks: extracted.stats.scannedTextBlocks,
+                  textChars: extracted.stats.scannedTextChars,
+                },
                 storedCount: toStore.length,
               });
               api.logger.info(`openclaw-mem-engine:autoCapture.receipt ${JSON.stringify(receipt)}`);
@@ -6687,6 +6863,8 @@ export const __debugReceipts = {
   isTodoStale,
   buildRecallLifecycleReceipt,
   buildAutoCaptureLifecycleReceipt,
+  extractUserTextMessages,
+  capPromptMutationHookRuns,
   applyPrependContextBudget,
 };
 

--- a/extensions/openclaw-mem-engine/openclaw.plugin.json
+++ b/extensions/openclaw-mem-engine/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "name": "OpenClaw Mem Engine",
   "description": "Optional memory slot backend with hybrid recall and Proactive Pack runtime recall",
   "kind": "memory",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "uiHints": {
     "embedding.apiKey": {
       "label": "OpenAI API Key",
@@ -322,6 +322,11 @@
       "help": "Maximum subprocess runtime in milliseconds for the route auto hook.",
       "advanced": true
     },
+    "autoRecall.routeAuto.maxBufferBytes": {
+      "label": "Route Auto Max Buffer Bytes",
+      "help": "Maximum child-process output buffered while reading compact route auto JSON.",
+      "advanced": true
+    },
     "autoRecall.routeAuto.maxChars": {
       "label": "Route Auto Max Chars",
       "help": "Maximum characters preserved for the injected route hint block.",
@@ -527,6 +532,12 @@
                     "maximum": 15000,
                     "default": 1800
                   },
+                  "maxBufferBytes": {
+                    "type": "integer",
+                    "minimum": 65536,
+                    "maximum": 2097152,
+                    "default": 524288
+                  },
                   "maxChars": {
                     "type": "integer",
                     "minimum": 120,
@@ -575,6 +586,24 @@
                 "minimum": 60,
                 "maximum": 320,
                 "default": 240
+              },
+              "maxScannedUserMessages": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 64,
+                "default": 24
+              },
+              "maxTextBlocksPerMessage": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 8,
+                "default": 4
+              },
+              "maxTotalInputChars": {
+                "type": "integer",
+                "minimum": 1000,
+                "maximum": 120000,
+                "default": 48000
               },
               "capturePreference": {
                 "type": "boolean",

--- a/extensions/openclaw-mem-engine/package-lock.json
+++ b/extensions/openclaw-mem-engine/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-mem-engine",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-mem-engine",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "@lancedb/lancedb": "^0.27.2",

--- a/extensions/openclaw-mem-engine/package.json
+++ b/extensions/openclaw-mem-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-mem-engine",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "description": "Optional OpenClaw memory-slot backend with hybrid recall, docs cold-lane search, and bounded autoRecall/autoCapture controls.",
   "license": "MIT",

--- a/extensions/openclaw-mem-engine/routeAuto.js
+++ b/extensions/openclaw-mem-engine/routeAuto.js
@@ -7,6 +7,8 @@ const DEFAULT_COMMAND = "openclaw-mem";
 const DEFAULT_TIMEOUT_MS = 1800;
 const MAX_TIMEOUT_MS = 15000;
 const DEFAULT_MAX_CHARS = 420;
+const DEFAULT_MAX_BUFFER_BYTES = 512 * 1024;
+const MAX_BUFFER_BYTES = 2 * 1024 * 1024;
 const DEFAULT_MAX_GRAPH_CANDIDATES = 2;
 const DEFAULT_MAX_TRANSCRIPT_SESSIONS = 2;
 
@@ -71,11 +73,17 @@ function compactSessionId(raw) {
   return text.length > 18 ? `${text.slice(0, 18)}…` : text;
 }
 
-async function defaultRunner({ command, args, timeoutMs }) {
+function clampBufferBytes(raw) {
+  const parsed = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isFinite(parsed)) return DEFAULT_MAX_BUFFER_BYTES;
+  return Math.max(64 * 1024, Math.min(MAX_BUFFER_BYTES, Math.floor(parsed)));
+}
+
+async function defaultRunner({ command, args, timeoutMs, maxBufferBytes }) {
   try {
     const { stdout, stderr } = await execFile(command, args, {
       timeout: timeoutMs,
-      maxBuffer: 2 * 1024 * 1024,
+      maxBuffer: clampBufferBytes(maxBufferBytes),
     });
     return {
       ok: true,
@@ -106,6 +114,7 @@ function receiptBase(config) {
   const timeoutMs = clampTimeout(config?.timeoutMs);
   const dbPath = typeof config?.dbPath === "string" && config.dbPath.trim() ? config.dbPath.trim() : null;
   const maxChars = clampChars(config?.maxChars, DEFAULT_MAX_CHARS);
+  const maxBufferBytes = clampBufferBytes(config?.maxBufferBytes);
   const maxGraphCandidates = clampCount(config?.maxGraphCandidates, DEFAULT_MAX_GRAPH_CANDIDATES, 5);
   const maxTranscriptSessions = clampCount(config?.maxTranscriptSessions, DEFAULT_MAX_TRANSCRIPT_SESSIONS, 5);
 
@@ -115,6 +124,7 @@ function receiptBase(config) {
     timeoutMs,
     dbPath,
     maxChars,
+    maxBufferBytes,
     maxGraphCandidates,
     maxTranscriptSessions,
   };
@@ -209,7 +219,6 @@ export async function runRouteAuto({ query, scope, config, runner = defaultRunne
   if (!enabled) {
     return {
       text: "",
-      payload: null,
       receipt: {
         enabled: false,
         attempted: false,
@@ -225,7 +234,6 @@ export async function runRouteAuto({ query, scope, config, runner = defaultRunne
   if (!trimmedQuery) {
     return {
       text: "",
-      payload: null,
       receipt: {
         enabled: true,
         attempted: false,
@@ -243,6 +251,7 @@ export async function runRouteAuto({ query, scope, config, runner = defaultRunne
     command: base.command,
     args: buildArgs({ query: trimmedQuery, scope, base }),
     timeoutMs: base.timeoutMs,
+    maxBufferBytes: base.maxBufferBytes,
   });
 
   const payload = parseJsonLoose(result.stdout) ?? parseJsonLoose(result.stderr);
@@ -259,7 +268,6 @@ export async function runRouteAuto({ query, scope, config, runner = defaultRunne
 
   return {
     text,
-    payload,
     receipt: {
       enabled: true,
       attempted: true,
@@ -280,6 +288,7 @@ export async function runRouteAuto({ query, scope, config, runner = defaultRunne
       killed: Boolean(result.killed),
       latencyMs: Date.now() - started,
       timeoutMs: base.timeoutMs,
+      maxBufferBytes: base.maxBufferBytes,
       command: base.command,
     },
   };

--- a/extensions/openclaw-mem-engine/routeAuto.test.mjs
+++ b/extensions/openclaw-mem-engine/routeAuto.test.mjs
@@ -163,3 +163,46 @@ test("runRouteAuto marks timeout receipts explicitly", async () => {
   assert.equal(result.receipt.signal, "SIGTERM");
   assert.equal(result.receipt.killed, true);
 });
+
+test("runRouteAuto does not retain full parsed payload on result", async () => {
+  const largeRefs = Array.from({ length: 100 }, (_, idx) => `obs:${idx}`);
+  const payload = {
+    selection: {
+      selected_lane: "graph_match",
+      reason: "graph_ready_with_candidates",
+      graph_consumption: {
+        preferredCardRefs: largeRefs,
+        coveredRawRefs: largeRefs,
+      },
+    },
+    inputs: {
+      graph_match: {
+        result: {
+          candidates: [
+            {
+              title: "openclaw-mem",
+              why_relevant: "matched graph evidence",
+              large_unused_blob: "x".repeat(400_000),
+            },
+          ],
+        },
+      },
+    },
+  };
+
+  const result = await runRouteAuto({
+    query: "graph semantic memory",
+    scope: "global",
+    config: { enabled: true, timeoutMs: 400, maxBufferBytes: 128 * 1024, maxChars: 320 },
+    runner: async ({ maxBufferBytes }) => {
+      assert.equal(maxBufferBytes, 128 * 1024);
+      return { ok: true, exitCode: 0, stdout: JSON.stringify(payload), stderr: "", errorCode: null, errorMessage: null };
+    },
+  });
+
+  assert.equal(Object.hasOwn(result, "payload"), false);
+  assert.equal(result.receipt.preferredCardRefs.length, 64);
+  assert.equal(result.receipt.coveredRawRefs.length, 64);
+  assert.equal(result.receipt.maxBufferBytes, 128 * 1024);
+  assert.ok(result.text.length <= 320);
+});

--- a/extensions/openclaw-mem-engine/rssBoundsSource.test.mjs
+++ b/extensions/openclaw-mem-engine/rssBoundsSource.test.mjs
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const source = fs.readFileSync(new URL("./index.ts", import.meta.url), "utf8");
+const schema = JSON.parse(fs.readFileSync(new URL("./openclaw.plugin.json", import.meta.url), "utf8"));
+
+test("autoCapture has front-loaded RSS input bounds before candidate extraction", () => {
+  assert.match(source, /AUTO_CAPTURE_MAX_SCANNED_USER_MESSAGES = 64/);
+  assert.match(source, /AUTO_CAPTURE_MAX_TEXT_BLOCKS_PER_MESSAGE = 8/);
+  assert.match(source, /AUTO_CAPTURE_MAX_TOTAL_INPUT_CHARS = 120_000/);
+  assert.match(source, /userMessages\.slice\(-maxMessages\)/);
+  assert.match(source, /maxTotalInputChars - stats\.scannedTextChars/);
+  assert.match(source, /maxMessages: autoCaptureCfg\.maxScannedUserMessages/);
+  assert.match(source, /scanned: \{\s*userMessages: extracted\.stats\.scannedUserMessages/s);
+});
+
+test("prompt hook dedupe map has a hard cap", () => {
+  assert.match(source, /PROMPT_MUTATION_HOOK_DEDUPE_MAX_ENTRIES = 1024/);
+  assert.match(source, /function capPromptMutationHookRuns/);
+  assert.match(source, /capPromptMutationHookRuns\(promptMutationHookRuns, PROMPT_MUTATION_HOOK_DEDUPE_MAX_ENTRIES\)/);
+});
+
+test("plugin schema exposes bounded RSS knobs", () => {
+  const routeAuto = schema.configSchema.properties.autoRecall.oneOf[1].properties.routeAuto.properties;
+  assert.equal(routeAuto.maxBufferBytes.default, 524288);
+  assert.equal(routeAuto.maxBufferBytes.maximum, 2097152);
+
+  const autoCapture = schema.configSchema.properties.autoCapture.oneOf[1].properties;
+  assert.equal(autoCapture.maxScannedUserMessages.default, 24);
+  assert.equal(autoCapture.maxScannedUserMessages.maximum, 64);
+  assert.equal(autoCapture.maxTextBlocksPerMessage.default, 4);
+  assert.equal(autoCapture.maxTotalInputChars.default, 48000);
+  assert.equal(autoCapture.maxTotalInputChars.maximum, 120000);
+});

--- a/handoffs/receipts/2026-05-12_rss-bounded-memory-hooks/release-check.json
+++ b/handoffs/receipts/2026-05-12_rss-bounded-memory-hooks/release-check.json
@@ -1,0 +1,27 @@
+{
+  "checked_at": "2026-05-12T08:48:02.735921+00:00",
+  "checks": {
+    "changelog_entry_present": true,
+    "engine_version_consistent": true,
+    "lockfile_mentions_version": true,
+    "public_safety_clean": true,
+    "receipt_present": true,
+    "version_consistent": true
+  },
+  "errors": [],
+  "expected_version": "1.9.16",
+  "ok": true,
+  "public_safety_markers": {},
+  "repo_root": "/root/.openclaw/workspace/.worktrees/openclaw-mem-rss-bounded",
+  "schema_version": "openclaw-mem.governed.release-check.v0",
+  "topology_changed": false,
+  "versions": {
+    "engine_package": "0.0.6",
+    "engine_package_lock": "0.0.6",
+    "engine_plugin": "0.0.6",
+    "init": "1.9.16",
+    "pyproject": "1.9.16"
+  },
+  "warnings": [],
+  "writes_performed": false
+}

--- a/openclaw_mem/__init__.py
+++ b/openclaw_mem/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "1.9.15"
+__version__ = "1.9.16"

--- a/openclaw_mem/governed_release.py
+++ b/openclaw_mem/governed_release.py
@@ -7,6 +7,7 @@ higher-risk automation can be considered.
 
 from __future__ import annotations
 
+import json
 import re
 from datetime import datetime, timezone
 from pathlib import Path
@@ -262,6 +263,15 @@ def _version_from_init(text: str) -> str | None:
     return m.group(1) if m else None
 
 
+def _version_from_json_manifest(text: str) -> str | None:
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    version = parsed.get("version") if isinstance(parsed, dict) else None
+    return version if isinstance(version, str) and version else None
+
+
 def _lockfile_project_version_present(lock_text: str, expected: str) -> bool:
     pattern = (
         r'(?ms)^\[\[package\]\]\s*\n'
@@ -283,6 +293,9 @@ def release_check(
     init = _read(root / "openclaw_mem" / "__init__.py")
     lock = _read(root / "uv.lock")
     changelog = _read(root / "CHANGELOG.md")
+    engine_plugin_version = _version_from_json_manifest(_read(root / "extensions" / "openclaw-mem-engine" / "openclaw.plugin.json"))
+    engine_package_version = _version_from_json_manifest(_read(root / "extensions" / "openclaw-mem-engine" / "package.json"))
+    engine_package_lock_version = _version_from_json_manifest(_read(root / "extensions" / "openclaw-mem-engine" / "package-lock.json"))
     version = _version_from_pyproject(pyproject)
     init_version = _version_from_init(init)
     expected = expected_version or version
@@ -294,6 +307,10 @@ def release_check(
         errors.append("init_version_mismatch")
     if expected and version != expected:
         errors.append("expected_version_mismatch")
+    engine_versions = [v for v in [engine_plugin_version, engine_package_version, engine_package_lock_version] if v]
+    engine_version_consistent = len(set(engine_versions)) <= 1 and len(engine_versions) == 3
+    if not engine_version_consistent:
+        errors.append("engine_version_mismatch")
     lock_has_project_version = bool(expected and _lockfile_project_version_present(lock, expected))
     if expected and not lock_has_project_version:
         errors.append("uv_lock_version_missing")
@@ -318,9 +335,16 @@ def release_check(
         "topology_changed": False,
         "repo_root": str(root),
         "expected_version": expected,
-        "versions": {"pyproject": version, "init": init_version},
+        "versions": {
+            "pyproject": version,
+            "init": init_version,
+            "engine_plugin": engine_plugin_version,
+            "engine_package": engine_package_version,
+            "engine_package_lock": engine_package_lock_version,
+        },
         "checks": {
             "version_consistent": bool(version and init_version == version),
+            "engine_version_consistent": engine_version_consistent,
             "lockfile_mentions_version": lock_has_project_version,
             "changelog_entry_present": bool(expected and f"## [{expected}]" in changelog),
             "receipt_present": bool(receipts),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openclaw-context-pack"
-version = "1.9.15"
+version = "1.9.16"
 description = "Local-first AI agent memory governance: Store / Pack / Observe with citations, receipts, and rollback"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/tests/test_governed_cli.py
+++ b/tests/test_governed_cli.py
@@ -28,6 +28,10 @@ def test_governed_release_check_cli(tmp_path: Path):
     root = tmp_path
     (root / "openclaw_mem").mkdir()
     (root / "docs").mkdir()
+    (root / "extensions" / "openclaw-mem-engine").mkdir(parents=True)
+    (root / "extensions" / "openclaw-mem-engine" / "openclaw.plugin.json").write_text('{"version":"0.0.9"}\n', encoding="utf-8")
+    (root / "extensions" / "openclaw-mem-engine" / "package.json").write_text('{"version":"0.0.9"}\n', encoding="utf-8")
+    (root / "extensions" / "openclaw-mem-engine" / "package-lock.json").write_text('{"version":"0.0.9"}\n', encoding="utf-8")
     (root / "pyproject.toml").write_text('version = "9.9.9"\n', encoding="utf-8")
     (root / "openclaw_mem" / "__init__.py").write_text('__version__ = "9.9.9"\n', encoding="utf-8")
     (root / "uv.lock").write_text('[[package]]\nname = "openclaw-context-pack"\nversion = "9.9.9"\n', encoding="utf-8")

--- a/tests/test_governed_release.py
+++ b/tests/test_governed_release.py
@@ -81,6 +81,10 @@ class TestGovernedRelease(unittest.TestCase):
             root = Path(tmp)
             (root / "openclaw_mem").mkdir()
             (root / "docs").mkdir()
+            (root / "extensions" / "openclaw-mem-engine").mkdir(parents=True)
+            (root / "extensions" / "openclaw-mem-engine" / "openclaw.plugin.json").write_text('{"version":"0.0.9"}\n', encoding="utf-8")
+            (root / "extensions" / "openclaw-mem-engine" / "package.json").write_text('{"version":"0.0.9"}\n', encoding="utf-8")
+            (root / "extensions" / "openclaw-mem-engine" / "package-lock.json").write_text('{"version":"0.0.9"}\n', encoding="utf-8")
             (root / "pyproject.toml").write_text('version = "9.9.9"\n', encoding="utf-8")
             (root / "openclaw_mem" / "__init__.py").write_text('__version__ = "9.9.9"\n', encoding="utf-8")
             (root / "uv.lock").write_text('[[package]]\nname = "openclaw-context-pack"\nversion = "9.9.9"\n', encoding="utf-8")
@@ -90,6 +94,7 @@ class TestGovernedRelease(unittest.TestCase):
             check = release_check(repo_root=root, expected_version="9.9.9")
         self.assertTrue(check["ok"])
         self.assertTrue(check["checks"]["version_consistent"])
+        self.assertTrue(check["checks"]["engine_version_consistent"])
         self.assertTrue(check["checks"]["public_safety_clean"])
 
     def test_release_check_fails_version_and_public_safety(self):
@@ -97,6 +102,10 @@ class TestGovernedRelease(unittest.TestCase):
             root = Path(tmp)
             (root / "openclaw_mem").mkdir()
             (root / "docs").mkdir()
+            (root / "extensions" / "openclaw-mem-engine").mkdir(parents=True)
+            (root / "extensions" / "openclaw-mem-engine" / "openclaw.plugin.json").write_text('{"version":"0.0.9"}\n', encoding="utf-8")
+            (root / "extensions" / "openclaw-mem-engine" / "package.json").write_text('{"version":"0.0.9"}\n', encoding="utf-8")
+            (root / "extensions" / "openclaw-mem-engine" / "package-lock.json").write_text('{"version":"0.0.8"}\n', encoding="utf-8")
             (root / "pyproject.toml").write_text('version = "9.9.9"\n', encoding="utf-8")
             (root / "openclaw_mem" / "__init__.py").write_text('__version__ = "9.9.8"\n', encoding="utf-8")
             (root / "uv.lock").write_text('[[package]]\nname = "some-dependency"\nversion = "9.9.9"\n[[package]]\nname = "openclaw-context-pack"\nversion = "9.9.8"\n', encoding="utf-8")
@@ -105,6 +114,7 @@ class TestGovernedRelease(unittest.TestCase):
             check = release_check(repo_root=root, expected_version="9.9.9")
         self.assertFalse(check["ok"])
         self.assertIn("init_version_mismatch", check["errors"])
+        self.assertIn("engine_version_mismatch", check["errors"])
         self.assertIn("public_safety_markers_found", check["errors"])
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -372,7 +372,7 @@ wheels = [
 
 [[package]]
 name = "openclaw-context-pack"
-version = "1.9.15"
+version = "1.9.16"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Ships RSS-bounded hardening for `openclaw-mem-engine` prompt/memory hooks without reducing normal recent-turn capture quality.

### Changes
- `autoCapture`: bounds recent user-message scan, text blocks per message, and total input chars before candidate extraction / embedding.
- `routeAuto`: adds bounded child output buffering and stops returning the parsed full route payload from hook results.
- prompt-hook dedupe: hard-caps the recent-run map.
- release/docs: bumps package to `1.9.16`, engine package to `0.0.6`, updates public docs/changelog, and extends release-check to verify engine package manifest consistency.

## Verification

- `cd extensions/openclaw-mem-engine && node --test *.test.mjs` → 51 pass
- `uv run python -m pytest tests -q` → 690 passed, 1 skipped, 71 subtests passed
- `uv sync --locked`
- `uv sync --locked --extra docs`
- `uv run mkdocs build --strict`
- `uv run openclaw-mem governed release-check --repo-root . --expected-version 1.9.16 --no-require-receipt --out handoffs/receipts/2026-05-12_rss-bounded-memory-hooks/release-check.json --json` → ok
- Claude second-brain review: no must-fix; should-fix items addressed for NaN guard, truncation receipt truthfulness, and engine-version release-check coverage.

@codex please review for behavior regressions, release/version consistency, and whether the RSS caps preserve normal recent-turn capture semantics.
