### PR TITLE
Align auto-capture min chars contract

### DIFF
--- a/extensions/openclaw-mem-engine/index.ts
+++ b/extensions/openclaw-mem-engine/index.ts
@@ -737,7 +737,7 @@ function resolveAutoCaptureConfig(input: PluginConfig["autoCapture"]): AutoCaptu
       integer: true,
     }),
     maxCharsPerItem: normalizeNumberInRange(raw.maxCharsPerItem, defaults.maxCharsPerItem, {
-      min: 40,
+      min: 60,
       max: AUTO_CAPTURE_MAX_CHARS_PER_ITEM,
       integer: true,
     }),

--- a/extensions/openclaw-mem-engine/openclaw.plugin.json
+++ b/extensions/openclaw-mem-engine/openclaw.plugin.json
@@ -501,7 +501,7 @@
               },
               "maxCharsPerItem": {
                 "type": "integer",
-                "minimum": 40,
+                "minimum": 60,
                 "maximum": 320,
                 "default": 240
               },


### PR DESCRIPTION
## Summary
- align auto-capture maxCharsPerItem runtime normalization with the tested 60-character lower bound
- update the plugin schema minimum to match runtime behavior

## Critique
- /Users/ryan/.openclaw/workspace/memory/nightly-reviews/2026-05-16-openclaw-mem-critique.md

## Validation
- python3 -m pytest -q tests/test_mem_engine_todo_guardrails.py
- python3 -m pytest -q