### PR TITLE
Fix snapshot receipt test temp-path collision

### DIFF
--- a/tests/test_engine_snapshots.py
+++ b/tests/test_engine_snapshots.py
@@ -28,11 +28,14 @@ class TestEngineSnapshotsCli(unittest.TestCase):
         return json.loads(out) if out else None
 
     def test_snapshot_create_list_checkout_delete_roundtrip(self):
-        with tempfile.TemporaryDirectory() as td:
+        source_payload = "snapshot-source-payload::v1::must-not-enter-receipt"
+        # Keep ``v1`` in the temp path deliberately: receipt paths may contain
+        # that harmless substring and must not be confused with source payload.
+        with tempfile.TemporaryDirectory(prefix="v1-snapshot-") as td:
             root = Path(td)
             db = root / "lancedb"
             db.mkdir()
-            (db / "table.lance").write_text("v1", encoding="utf-8")
+            (db / "table.lance").write_text(source_payload, encoding="utf-8")
             snaps = root / "snapshots"
 
             created = self._run(
@@ -58,7 +61,7 @@ class TestEngineSnapshotsCli(unittest.TestCase):
             self.assertRegex(created["stats"]["files"][0]["sha256"], r"^[0-9a-f]{64}$")
             self.assertRegex(created["stats"]["sha256"], r"^[0-9a-f]{64}$")
             self.assertNotIn("reason", created)
-            self.assertNotIn("v1", json.dumps(created))
+            self.assertNotIn(source_payload, json.dumps(created))
             self.assertNotIn("before risky test", json.dumps(created))
             self.assertTrue((snaps / "pre-change_1" / "manifest.json").exists())
             manifest = json.loads((snaps / "pre-change_1" / "manifest.json").read_text(encoding="utf-8"))
@@ -96,7 +99,7 @@ class TestEngineSnapshotsCli(unittest.TestCase):
             )
             self.assertTrue(checked["ok"])
             self.assertTrue(checked["restartRequired"])
-            self.assertEqual((db / "table.lance").read_text(encoding="utf-8"), "v1")
+            self.assertEqual((db / "table.lance").read_text(encoding="utf-8"), source_payload)
             self.assertTrue(Path(checked["previousDbPath"]).exists())
 
             delete_blocked = self._run(


### PR DESCRIPTION
## Root cause
The main CI temp directory randomly contained the substring \1\, while the snapshot privacy test searched the entire receipt JSON for that two-character payload. This falsely treated an ordinary path as leaked source content.

## Fix
- use a distinctive full source payload for the no-leak assertion
- deliberately prefix the temp directory with \1\ so the former collision is a regression case

## Verification
- \python -m unittest tests.test_engine_snapshots -v\: 4 tests passed/expected skip
- CI-equivalent unittest discovery: 685 tests OK, 2 skipped