### PR TITLE
fix: verify artifact blob digests

### DIFF
--- a/openclaw_mem/artifact_sidecar.py
+++ b/openclaw_mem/artifact_sidecar.py
@@ -199,6 +199,13 @@ def _read_artifact_bytes(*, handle: str, root: Optional[Path] = None) -> Tuple[b
     if is_gzip:
         data = gzip.decompress(data)
 
+    actual_sha256 = hashlib.sha256(data).hexdigest()
+    if actual_sha256 != sha256_hex:
+        raise ValueError(
+            f"artifact blob sha256 mismatch for handle {handle}: "
+            f"expected {sha256_hex}, got {actual_sha256}"
+        )
+
     return data, meta, blob_path
 
 

--- a/tests/test_artifact_sidecar.py
+++ b/tests/test_artifact_sidecar.py
@@ -1,3 +1,4 @@
+import gzip
 import os
 import stat
 import json
@@ -103,6 +104,28 @@ class TestArtifactSidecar(unittest.TestCase):
 
             fetched = fetch_artifact(stash["handle"], root=root, mode="head", max_chars=1000)
             self.assertEqual(fetched["text"], good)
+
+    def test_fetch_rejects_blob_hash_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "artifacts"
+
+            stash = stash_artifact(b"original payload", root=root)
+            blob, _meta = _artifact_paths(root, stash["sha256"], gzip_blob=False)
+            blob.write_text("tampered payload", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "sha256 mismatch"):
+                fetch_artifact(stash["handle"], root=root)
+
+    def test_fetch_rejects_gzip_blob_hash_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "artifacts"
+
+            stash = stash_artifact(b"original gzip payload", root=root, compress=True)
+            blob, _meta = _artifact_paths(root, stash["sha256"], gzip_blob=True)
+            blob.write_bytes(gzip.compress(b"tampered gzip payload", mtime=0))
+
+            with self.assertRaisesRegex(ValueError, "sha256 mismatch"):
+                fetch_artifact(stash["handle"], root=root)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Recompute SHA-256 after reading/decompressing artifact sidecar blobs
- Reject corrupted or tampered blobs before returning fetch/peek text
- Add plain-text and gzip regression tests

Critique: /Users/ryan/.openclaw/workspace/memory/nightly-reviews/2026-07-16-openclaw-mem-critique.md

## Validation
- .venv/bin/python -m pytest -q tests/test_artifact_sidecar.py